### PR TITLE
Initial psolve GPU implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ endef
 
 make_target_in_viz_dir = $(if $(ENABLE_VIZ),$(call run_make_in_dir,$(VIS_DIR),${1}))
 
-.PHONY: all clean cleanall etree octor cvm forward
+.PHONY: all clean cleanall etree octor cvm forward forward_gpu
 
 #	$(MAKE) -C $(VIS_DIR)     SYSTEM=$(SYSTEM) WORKDIR=$(WORKDIR)
 
-all:	etree octor cvm forward
+all:	etree octor cvm forward forward_gpu
 	$(call make_target_in_viz_dir,all)
 
 
@@ -42,6 +42,9 @@ cvm:
 forward:
 	$(MAKE) -C $(FORWARD_DIR) SYSTEM=$(SYSTEM) WORKDIR=$(WORKDIR)
 
+forward_gpu:
+	$(MAKE) -C $(FORWARD_GPU_DIR) SYSTEM=$(SYSTEM) WORKDIR=$(WORKDIR)
+
 
 clean:
 	$(call make_target_in_viz_dir,clean)
@@ -49,9 +52,10 @@ clean:
 	$(MAKE) -C $(OCTOR_DIR)   WORKDIR=$(WORKDIR) clean
 	$(MAKE) -C $(CVM_DIR)     WORKDIR=$(WORKDIR) clean
 	$(MAKE) -C $(FORWARD_DIR) WORKDIR=$(WORKDIR) clean
+	$(MAKE) -C $(FORWARD_GPU_DIR) WORKDIR=$(WORKDIR) clean
 
 
-MY_DIRS := $(ETREE_DIR) $(OCTOR_DIR) $(CVM_DIR) $(FORWARD_DIR)
+MY_DIRS := $(ETREE_DIR) $(OCTOR_DIR) $(CVM_DIR) $(FORWARD_DIR) $(FORWARD_GPU_DIR)
 
 
 # Call run_make_in_dir for each directory in a directory list.

--- a/common.mk
+++ b/common.mk
@@ -15,5 +15,6 @@ JPEG_LIB = $(JPEG_DIR)/libjpeg.a
 CVM_DIR = $(WORKDIR)/quake/cvm
 
 FORWARD_DIR = $(WORKDIR)/quake/forward
+FORWARD_GPU_DIR = $(WORKDIR)/quake/forward_gpu
 
 -include $(WORKDIR)/user.mk

--- a/etree/etree.h
+++ b/etree/etree.h
@@ -225,6 +225,11 @@ typedef struct etree_t {
 } etree_t;
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+
 /*
  * Error reporting functions
  */
@@ -782,6 +787,11 @@ int etree_getkeysize(etree_t *ep);
  *
  */
 uint64_t etree_gettotalcount(etree_t *ep);
+
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif /* __cplusplus */
 
 
 #endif /* ETREE_H */

--- a/octor/Makefile
+++ b/octor/Makefile
@@ -5,6 +5,8 @@
 include $(WORKDIR)/systemdef.mk
 include $(WORKDIR)/common.mk
 
+CPPFLAGS += -I. -I$(MPI_DIR)/include
+
 OBJECTS = octor.o
 
 TARGET = liboctor.a

--- a/octor/octor.h
+++ b/octor/octor.h
@@ -234,6 +234,10 @@ do { \
     ((octree)->ticksize * OCTOR_GETOCTTICKS(octant))
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 
 /**
  * octor_getchild: Return the specified child octant. If parentoctant is a 
@@ -299,6 +303,7 @@ octor_getmaxleavescount(const octree_t* octree, int where);
 /* Tree-level operations */
 /*************************/
 
+
 extern octree_t *
 octor_newtree(double x, double y, double z, int32_t recsize,
               int32_t myid, int32_t groupsize, MPI_Comm solver_comm,
@@ -341,6 +346,10 @@ octor_showstat(octree_t *octree, mesh_t *mesh);
 /*************************/
 extern int32_t octor_zcompare(const void *p1, const void *p2);
 extern const point_t * octor_getintervaltable(octree_t *octree);
-    
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif /* __cplusplus */
+
 
 #endif /* OCTOR_H */

--- a/quake/cvm/Makefile
+++ b/quake/cvm/Makefile
@@ -5,7 +5,7 @@
 include $(WORKDIR)/systemdef.mk
 include $(WORKDIR)/common.mk
 
-CFLAGS += -I$(ETREE_DIR) 
+CFLAGS += -I$(ETREE_DIR)
 LOADLIBES += $(ETREE_DIR)/libetree.a
 
 #

--- a/quake/cvm/cvm.h
+++ b/quake/cvm/cvm.h
@@ -63,6 +63,10 @@ typedef struct dbctl_t {
 
 } dbctl_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 dbctl_t *cvm_newdbctl();
 void cvm_freedbctl(dbctl_t *dbctlPtr);
 
@@ -71,5 +75,9 @@ dbctl_t *cvm_getdbctl(etree_t *cvmEp);
 
 int cvm_query(etree_t *cvmEp, double east_m, double north_m, double depth_m, 
               cvmpayload_t* payload);
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif /* __cplusplus */
 
 #endif /* CVM_H */

--- a/quake/forward_gpu/Makefile
+++ b/quake/forward_gpu/Makefile
@@ -49,43 +49,22 @@ endif
 # Object modules 
 #
 PSOLVE_OBJECTS = psolve.o nrutila.o quakesource.o geometrics.o nonlinear.o \
-	commutil.o util.o output.o io_planes.o io_checkpoint.o stiffness.o damping.o quake_util.o timers.o buildings.o meshformatlab.o drm.o 
+	commutil.o util.o output.o io_planes.o io_checkpoint.o stiffness.o damping.o quake_util.o kernel.o timers.o buildings.o meshformatlab.o drm.o 
 
-OBJECTS = qmesh.o q4.o single_query.o ${PSOLVE_OBJECTS}
+OBJECTS = ${PSOLVE_OBJECTS}
 
 .PHONY: all tags clean cleanall move_cxx_repository
 
 all: move_cxx_repository $(TARGET)
 
-TARGET = qmesh psolve single_query q4showmeta
+TARGET = psolve
 
-
-qmesh: qmesh.o
-	$(LD) $^ \
-	$(LOADLIBES) \
-	$(LDFLAGS) \
-	-o $@
 
 psolve: ${PSOLVE_OBJECTS} ${OCTOR_LIB}
 	$(LD) $^ \
 	$(LOADLIBES) \
 	$(LDFLAGS) \
 	-o $@
-
-q4showmeta: q4showmeta.o util.o
-	$(LD) $^ \
-	$(LOADLIBES) \
-	$(LDFLAGS) \
-	-o $@
-
-psolve_output: psolve_output.o
-	$(LD) $^ \
-	$(LOADLIBES) \
-	$(LDFLAGS) \
-	-o $@
-
-psolve_output.o: psolve.o
-	cp -f psolve.o psolve_output.o
 
 psolve_debug: psolve_debug.o 
 	$(LD) $^ \
@@ -96,31 +75,13 @@ psolve_debug: psolve_debug.o
 psolve_debug.o: psolve.o nrutila.o quakesource.o geometrics.o io_planes.o io_checkpoint.o
 	cp -f psolve.o psolve_debug.o
 
-psolve_novis: psolve_novis.o
-	$(LD) $^ \
-	$(LOADLIBES) \
-	$(LDFLAGS) \
-	-o $@
-
-psolve_novis.o: psolve.o
-	cp -f psolve.o psolve_novis.o
-
-single_query: single_query.o q4.o
-	$(LD) $^ \
-	$(LOADLIBES) \
-	$(LDFLAGS) \
-	-o $@
-
-output.o: output.c output.h psolve.h
-psolve.o: psolve.c psolve.h output.h quakesource.h nonlinear.h io_planes.h \
-          io_checkpoint.h stiffness.h damping.h quake_util.h timers.h buildings.h meshformatlab.h drm.h        
-quakesource.o: quakesource.c quakesource.h psolve.h
-
+%.o: %.cu
+	$(NVCC) $(CPPFLAGS) $(NVFLAGS) -c $^ -o $@
 
 all: $(TARGET)
 
 clean:
-	rm -f $(OBJECTS)  core *.o *~ 
+	rm -f $(OBJECTS)  core *~ 
 
 cleanall:
 	rm -f $(OBJECTS)  $(TARGET) core *~

--- a/quake/forward_gpu/README
+++ b/quake/forward_gpu/README
@@ -1,0 +1,50 @@
+psolve - FEM solver (_Navier Equation_)
+=======================================
+
+Implemented by Tiankai Tu and Leonardo Ramirez-Guzman
+Address questions related to 
+- Algorithms and implementation( Tiankai Tu tutk@cs.cmu.edu )
+- Numerical Method and Physics ( Leonardo Ramirez-Gzuman
+				 lramirez@andrew.cmu.edu )
+
+CAPABILITIES
+------------
+
+*Damping*:: The following damping types are supported:
+	- MASS proportional
+        - RAYLEIGH type
+        - NONE
+
+*Source*:: Hercules supports the following source types.
+	- point source
+	- plane source
+	- strike slip sources defined in term of planes
+
+
+
+Contents
+--------
+
+This directory should contain the following files:
+
+Makefile
+geometrics.c
+geometrics.h
+nrutila.c
+nrutila.h
+psolve.c
+psolve.h
+q4.c
+q4.h
+qmesh.c
+quakesource.c
+quakesource.h
+run_example
+single_query.c
+
+
+Building
+--------
+
+For installation instructions please refer to `$HERCULES_ROOT/doc/install.txt`,
+that is, `../../doc/install.txt`.

--- a/quake/forward_gpu/buildings.cu
+++ b/quake/forward_gpu/buildings.cu
@@ -1,0 +1,1312 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "cvm.h"
+#include "psolve.h"
+#include "octor.h"
+#include "buildings.h"
+#include "util.h"
+#include "quake_util.h"
+#include "commutil.h"
+
+#define  FENCELIMIT  0.9999
+
+/* -------------------------------------------------------------------------- */
+/*                                Structures                                  */
+/* -------------------------------------------------------------------------- */
+
+typedef struct bounds_t {
+
+    double xmin, xmax;
+    double ymin, ymax;
+    double zmin, zmax;
+
+} bounds_t;
+
+typedef struct bldg_t {
+
+    double       height;
+    double       depth;
+    bounds_t     bounds;
+    cvmpayload_t bldgprops;
+    cvmpayload_t fdtnprops;
+
+} bldg_t;
+
+typedef struct basenode_t {
+    lnid_t nindex;
+    int    bldg;
+} basenode_t;
+
+/* -------------------------------------------------------------------------- */
+/*                             Global Variables                               */
+/* -------------------------------------------------------------------------- */
+
+static noyesflag_t  areBaseFixed = (noyesflag_t)0;
+static char         theBaseFixedDir[256];
+static char         theBaseFixedSufix[64];
+static double       theBaseFixedDT;
+static int          theBaseFixedStartIndex;
+static int32_t      theBaseNodesCount;
+static basenode_t  *theBaseNodes;
+static fvector_t  **theBaseSignals;
+
+/* Permanent */
+
+static int      theNumberOfBuildings;
+static int      theBuildingsNFactor;
+static double   theMinOctSizeMeters;
+static double   theSurfaceShift = 0;
+static bldg_t  *theBuilding;
+
+/* Transient */
+
+static double  *theBuildingsVs;
+static double  *theBuildingsVp;
+static double  *theBuildingsRho;
+static double  *theFoundationsVs;
+static double  *theFoundationsVp;
+static double  *theFoundationsRho;
+static double  *theBuildingsXMin,  *theBuildingsXMax;
+static double  *theBuildingsYMin,  *theBuildingsYMax;
+static double  *theBuildingsZMin,  *theBuildingsZMax;
+static double  *theBuildingsDepth, *theBuildingsHeight;
+
+/* -------------------------------------------------------------------------- */
+/*                         Private Method Prototypes                          */
+/* -------------------------------------------------------------------------- */
+
+int crossing_rule ( tick_t   tickcoord,
+                    double   ticksize,
+                    edata_t *edata,
+                    double   bound );
+
+bounds_t get_bldgbounds( int i );
+
+void get_airprops( octant_t *leaf, double ticksize,
+                   edata_t *edata, etree_t *cvm,
+                   double xoriginm,double yoriginm,
+                   double zoriginm);
+
+int inclusivesearch  ( double x, double y, double z, bounds_t bounds );
+int exclusivesearch  ( double x, double y, double z, bounds_t bounds );
+int onboundarysearch ( double x, double y, double z, bounds_t bounds );
+int ininteriorsearch ( double x, double y, double z, bounds_t bounds );
+
+int basenode_search  ( tick_t x, tick_t y, tick_t z, double ticksize );
+
+int bldg_exclusivesearch ( tick_t   x,
+                           tick_t   y,
+                           tick_t   z,
+                           double   ticksize,
+                           edata_t *edata,
+                           int      bldg );
+
+int bldg_meshingsearch ( octant_t *leaf,
+                         double    ticksize,
+                         edata_t  *edata,
+                         int       bldg );
+
+int bldgs_search ( octant_t *leaf, double ticksize, edata_t *edata );
+
+int bldgs_refine ( octant_t *leaf,
+                   double    ticksize,
+                   edata_t  *edata,
+                   int       bldg,
+                   double    theFactor );
+
+int32_t buildings_initparameters ( const char *parametersin );
+
+void fixedbase_read ( FILE* fp );
+
+double adjust (double input);
+
+void adjust_dimensions ();
+
+/* -------------------------------------------------------------------------- */
+/*                             General Utilities                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Checks if a an octant with left-upper-front origin coordinate and size
+ * equal edgesize is being crossed by a defining boundary.
+ *
+ * Returns
+ * 1: True
+ * 0: False
+ */
+int crossing_rule ( tick_t   tickcoord,
+                    double   ticksize,
+                    edata_t *edata,
+                    double   bound ) {
+
+    double LUF, RDB, edgesize;
+
+    edgesize = edata->edgesize;
+    LUF = tickcoord * ticksize;
+    RDB = LUF + edgesize;
+
+    if ( ( LUF < bound) && ( RDB > bound ) ) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                               Get Utilities                                */
+/* -------------------------------------------------------------------------- */
+
+double get_surface_shift() {
+    return theSurfaceShift;
+}
+
+noyesflag_t get_fixedbase_flag() {
+    return areBaseFixed;
+}
+
+bounds_t get_bldgbounds( int i ) {
+
+    return theBuilding[i].bounds;
+}
+
+cvmpayload_t get_props( int i, double z ) {
+
+    /* the i-th building is in the i-1 index */
+    i--;
+
+    if ( z >= theSurfaceShift ) {
+        /* Element is in the foundation */
+        return theBuilding[i].fdtnprops;
+    } else {
+        /* Element is in the foundation */
+        return theBuilding[i].bldgprops;
+    }
+}
+
+void get_airprops( octant_t *leaf, double ticksize, edata_t *edata,
+				   etree_t *cvm ,double xoriginm, double yoriginm,
+                   double zoriginm)
+{
+	int    res;
+	double x, y, z;
+	double edgesize;
+	double halfedge;
+
+	cvmpayload_t props;
+
+	edgesize = edata->edgesize;
+	halfedge = edgesize * 0.5;
+
+	x = ( leaf->lx * ticksize ) + halfedge + xoriginm;
+	y = ( leaf->ly * ticksize ) + halfedge + yoriginm;
+	z = ( leaf->lz * ticksize ) + halfedge + zoriginm;
+
+
+	/* Get the Vs at that location on the surface (z = 0) */
+	res = cvm_query( cvm, y, x, 0, &props );
+
+	if ( res != 0 ) {
+		solver_abort ( __FUNCTION_NAME, "Error from cvm_query: ",
+				"No properties at east = %f, north = %f", y, x);
+		return;
+	}
+
+    /* Increase Vs as it gets far from the surface */
+    edata->Vs  = 2.0 * props.Vs * ( theSurfaceShift - z ) / ticksize;
+
+    /* Assign a negative Vp to identify the octants to carve */
+    edata->Vp  = -1;
+
+    /* Assign a zero to the density */
+    edata->rho = 0;
+
+    return;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                          Single Search Utilities                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Returns 1 if a point is on or within min,max boundaries.
+ * Returns 0 otherwise.
+ */
+int inclusivesearch ( double x, double y, double z, bounds_t bounds )
+{
+    if ( ( x >= bounds.xmin ) &&
+         ( x <= bounds.xmax ) &&
+         ( y >= bounds.ymin ) &&
+         ( y <= bounds.ymax ) &&
+         ( z >= bounds.zmin ) &&
+         ( z <= bounds.zmax ) )
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * Returns 1 if a point is within min,max boundaries, (including min boundaries
+ *           for compliance with etree library.)
+ * Returns 0 otherwise.
+ */
+int exclusivesearch ( double x, double y, double z, bounds_t bounds )
+{
+    if ( ( x >= bounds.xmin ) &&
+         ( x <  bounds.xmax ) &&
+         ( y >= bounds.ymin ) &&
+         ( y <  bounds.ymax ) &&
+         ( z >= bounds.zmin ) &&
+         ( z <  bounds.zmax ) )
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * Returns 0 if a point is not on one of the boundary faces defining a building.
+ * If it is on one or more faces it returns N > 0 as follows:
+ *  1: touches the bottom Z face that for this building is also the surface,
+ *  2: touches one of face (but it is not also the surface),
+ *  3: touches a lateral (X or Y) and the bottom (Z) face (also surface),
+ *  4: touches two faces (XY, XZ, or YZ) but Z is not also the surface,
+ *  5: touches Z (also surface) and X and Y,
+ *  6: touches three faces (XYZ) but Z is not also the surface
+ */
+int onboundarysearch ( double x, double y, double z, bounds_t bounds )
+{
+    int onX = 0, onY = 0, onZ = 0;
+    int faces = 0;
+
+    if ( inclusivesearch(x, y, z, bounds) ) {
+        if ( ( x == bounds.xmin ) ||
+             ( x == bounds.xmax ) ) {
+            onX = 2;
+        }
+        if ( ( y == bounds.ymin ) ||
+             ( y == bounds.ymax ) ) {
+            onY = 2;
+        }
+        if ( ( z == bounds.zmin ) ||
+             ( z == bounds.zmax ) ) {
+            onZ = 2;
+            if ( z == theSurfaceShift ) {
+                onZ = 1;
+            }
+        }
+        faces = onX + onY + onZ;
+    }
+
+    return faces;
+}
+
+/**
+ * Returns 1 if a point is in the interior of a building.
+ * Returns 0 otherwise.
+ */
+int ininteriorsearch ( double x, double y, double z, bounds_t bounds )
+{
+    if ( ( x > bounds.xmin ) &&
+         ( x < bounds.xmax ) &&
+         ( y > bounds.ymin ) &&
+         ( y < bounds.ymax ) &&
+         ( z > bounds.zmin ) &&
+         ( z < bounds.zmax ) )
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * Return 1 if a node is in a building, 0 otherwise.
+ */
+int bldg_exclusivesearch ( tick_t   x,
+                           tick_t   y,
+                           tick_t   z,
+                           double   ticksize,
+                           edata_t *edata,
+                           int      bldg )
+{
+    /**
+     * Checks if a an octant with left-upper-front origin coordinate and size
+     * equal edgesize is being crossed by a defining boundary.
+     *
+     * Returns
+     * 1: True
+     * 0: False
+     */
+
+    double   x_m, y_m, z_m;
+    double   esize;
+    bounds_t bounds;
+
+    x_m = x * ticksize;
+    y_m = y * ticksize;
+    z_m = z * ticksize;
+
+    esize = (double)edata->edgesize; /* TODO: Seems like I don't need this */
+
+    bounds = get_bldgbounds( bldg );
+
+    if ( exclusivesearch(x_m, y_m, z_m, bounds) ) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * Return 1 if an element is in the foundation, 0 otherwise.
+ */
+int bldg_meshingsearch ( octant_t *leaf,
+                         double    ticksize,
+                         edata_t  *edata,
+                         int       bldg )
+{
+    double   x_m, y_m, z_m;
+    double   esize;
+    bounds_t bounds;
+
+    x_m = leaf->lx * ticksize;
+    y_m = leaf->ly * ticksize;
+    z_m = leaf->lz * ticksize;
+
+    esize  = (double)edata->edgesize;
+
+    bounds = get_bldgbounds(bldg);
+
+    bounds.xmin -= FENCELIMIT * esize;
+    bounds.ymin -= FENCELIMIT * esize;
+    bounds.zmin -= FENCELIMIT * esize;
+
+    if ( exclusivesearch(x_m, y_m, z_m, bounds) ) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                        Collective Search Utilities                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Return N it the node is at the base of a building, N being the n-th building
+ * Return 0 otherwise
+ */
+int basenode_search ( tick_t x, tick_t y, tick_t z, double ticksize ) {
+
+    int i;
+    double x_m, y_m, z_m;
+
+    z_m = z * ticksize;
+
+    /* Discard nodes not at the surface */
+    if ( z_m != theSurfaceShift ) {
+        return 0;
+    }
+
+    x_m = x * ticksize;
+    y_m = y * ticksize;
+
+    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+        bounds_t bounds = get_bldgbounds(i);
+        if ( inclusivesearch(x_m, y_m, z_m, bounds) ) {
+            return i+1;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Return N if the element belongs to a building, N being the n-th building
+ * Return 0 otherwise.
+ */
+int bldgs_search ( octant_t *leaf, double ticksize, edata_t *edata ) {
+
+    int i;
+
+    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+        if ( bldg_meshingsearch( leaf, ticksize, edata, i ) == 1 ) {
+            /* the i-th building has index i-1 */
+            return i+1;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Depending on the position of a node wrt to a building it returns:
+ *      0: out of building bounds,
+ *     -1: in the interior of a building,
+ * 1,..,6: depending on the onboundarysearch method.
+ */
+int bldgs_nodesearch ( tick_t x, tick_t y, tick_t z, double ticksize ) {
+
+    int    i;
+    double x_m, y_m, z_m;
+
+    x_m = x * ticksize;
+    y_m = y * ticksize;
+    z_m = z * ticksize;
+
+    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+        bounds_t bounds = get_bldgbounds(i);
+        if ( inclusivesearch(x_m, y_m, z_m, bounds) ) {
+            if ( ininteriorsearch(x_m, y_m, z_m, bounds) ) {
+                return -1;
+            }
+            int faces = onboundarysearch(x_m, y_m, z_m, bounds);
+            if ( faces == 0 ) {
+                solver_abort ( __FUNCTION_NAME, NULL,
+                               "Wrong node faces touches at "
+                               "east = %f, north = %f, depth =%f\n", y, x, z);
+            }
+            return faces;
+        }
+    }
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              Setrec Packet                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Complement for the setrec function in psolve.
+ * Return 1 if data is assigned to the octant, 0 otherwise.
+ *
+ * TODO: This function assumes the domain origin is 0,0,0. If this is not true
+ *       as it will be for DRM implementation, one will need to consider
+ *       theXForMeshOrigin, theYForMeshOrigin, (and theXForMeshOrigin ?)
+ */
+
+int bldgs_setrec ( octant_t *leaf, double ticksize,
+                   edata_t *edata, etree_t *cvm,double xoriginm,
+                   double yoriginm, double zoriginm)
+{
+    int          res;
+    double       z_m;
+    cvmpayload_t props;
+
+    res = bldgs_search( leaf, ticksize, edata );
+    if ( res > 0 ) {
+        props    = get_props( res, z_m );
+        edata->Vp  = props.Vp;
+        edata->Vs  = props.Vs;
+        edata->rho = props.rho;
+        return 1;
+    }
+
+    z_m = leaf->lz * ticksize;
+
+    if ( z_m < theSurfaceShift ) {
+        get_airprops( leaf, ticksize, edata, cvm,xoriginm,yoriginm,zoriginm);
+        return 1;
+    }
+
+    return 0;
+}
+
+
+/* -------------------------------------------------------------------------- */
+/*                             To Expand Packet                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Return 1 if an element in foundation need to be refined , 0 otherwise.
+ */
+int bldgs_refine ( octant_t *leaf,
+                     double    ticksize,
+                     edata_t  *edata,
+                     int       bldg,
+                     double    theFactor )
+{
+    bounds_t bounds;
+    double   edgesize;
+    double   z_m;
+
+    bounds   = get_bldgbounds(bldg);
+    edgesize = edata->edgesize;
+    z_m      = leaf->lz * ticksize;
+
+    /* Elements crossing the surface */
+    if ( crossing_rule( leaf->lz, ticksize, edata, theSurfaceShift ) ) {
+        return 1;
+    }
+
+    /* Elements not complying with minimum subdivisions */
+    if ( ( edgesize > ( (bounds.xmax - bounds.xmin) / theBuildingsNFactor ) ) ||
+         ( edgesize > ( (bounds.ymax - bounds.ymin) / theBuildingsNFactor ) ) )
+    {
+        return 1;
+    }
+
+    /* Elements not complying with vs-rule */
+    if ( z_m >= theSurfaceShift ) {
+        /* Element is in the foundation */
+        if ( edgesize > ( theBuilding[bldg].fdtnprops.Vs / theFactor ) ) {
+            return 1;
+        }
+    } else {
+        /* Element is in the building */
+        if ( edgesize > ( theBuilding[bldg].bldgprops.Vs / theFactor ) ) {
+            return 1;
+        }
+    }
+
+    /* Elements crossing the buildings adjusted boundaries */
+    if ( crossing_rule( leaf->lx, ticksize, edata, bounds.xmin ) ||
+         crossing_rule( leaf->lx, ticksize, edata, bounds.xmax ) ||
+         crossing_rule( leaf->ly, ticksize, edata, bounds.ymin ) ||
+         crossing_rule( leaf->ly, ticksize, edata, bounds.ymax ) ||
+         crossing_rule( leaf->lz, ticksize, edata, bounds.zmin ) ||
+         crossing_rule( leaf->lz, ticksize, edata, bounds.zmax ) ) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * Return  1 if an element is in a building and needs to be refined,
+ * Return  0 if an element in in a building does not need to be refined,
+ * Return -1 if an element is not in a building.
+ */
+int bldgs_toexpand ( octant_t *leaf,
+                     double    ticksize,
+                     edata_t  *edata,
+                     double    theFactor )
+{
+    int i;
+
+    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+        if ( bldg_meshingsearch( leaf, ticksize, edata, i ) ) {
+            return bldgs_refine( leaf, ticksize, edata, i, theFactor );
+        }
+    }
+
+    if ( crossing_rule( leaf->lz, ticksize, edata, theSurfaceShift ) ) {
+        return 1;
+    }
+
+    return -1;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                             Correct Properties                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Return 1 if an element is in foundation after its properties being corrected,
+ * 0 otherwise.
+ */
+int bldgs_correctproperties ( mesh_t *myMesh, edata_t *edata, int32_t lnid0 )
+{
+    int    i;
+    double ticksize;
+    tick_t x, y, z;
+
+    /* Element's lower left coordinates in ticks */
+    x = myMesh->nodeTable[lnid0].x;
+    y = myMesh->nodeTable[lnid0].y;
+    z = myMesh->nodeTable[lnid0].z;
+
+    /* ticks converter to physical coordinates */
+    ticksize = myMesh->ticksize;
+
+    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+
+        if ( bldg_exclusivesearch( x, y, z, ticksize, edata, i) == 1 ) {
+
+            double z_m = z * ticksize;
+
+            if ( z_m >= theSurfaceShift ) {
+                /* Element is in the foundation */
+                edata->Vp  = theBuilding[i].fdtnprops.Vp;
+                edata->Vs  = theBuilding[i].fdtnprops.Vs;
+                edata->rho = theBuilding[i].fdtnprops.rho;
+            } else {
+                /* Element is in the foundation */
+                edata->Vp  = theBuilding[i].bldgprops.Vp;
+                edata->Vs  = theBuilding[i].bldgprops.Vs;
+                edata->rho = theBuilding[i].bldgprops.rho;
+            }
+
+            return 1;
+        }
+    }
+
+    /* NOTE: If you want to see the carving process, activate this */
+/*
+    double z_m = z * ticksize;
+    if ( z_m < theSurfaceShift ) {
+        edata->Vp  = -500;
+        edata->Vs  = -200;
+        edata->rho = -1500;
+        return 1;
+    }
+*/
+
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/*       Initialization of parameters, structures and memory allocations      */
+/* -------------------------------------------------------------------------- */
+
+
+void bldgs_init ( int32_t myID, const char *parametersin )
+{
+    int     i;
+    int     int_message[3];
+    double  double_message[2];
+
+    /* Capturing data from file --- only done by PE0 */
+    if (myID == 0) {
+        if ( buildings_initparameters( parametersin ) != 0 ) {
+            fprintf(stderr,"Thread 0: buildings_local_init: "
+                    "buildings_initparameters error\n");
+            MPI_Abort(MPI_COMM_WORLD, ERROR);
+            exit(1);
+        }
+        adjust_dimensions();
+    }
+
+    /* Broadcasting data */
+
+    double_message[0] = theSurfaceShift;
+    double_message[1] = theMinOctSizeMeters;
+    int_message[0]    = theNumberOfBuildings;
+    int_message[1]    = theBuildingsNFactor;
+    int_message[2]    = areBaseFixed;
+
+    MPI_Bcast(double_message, 2, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(int_message,    3, MPI_INT,    0, comm_solver);
+
+    theSurfaceShift      = double_message[0];
+    theMinOctSizeMeters  = double_message[1];
+    theNumberOfBuildings = int_message[0];
+    theBuildingsNFactor  = int_message[1];
+    areBaseFixed         = (noyesflag_t)int_message[2];
+
+    /* allocate table of properties for all other PEs */
+
+    if (myID != 0) {
+
+        theBuildingsXMin   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+    	theBuildingsXMax   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsYMin   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsYMax   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsZMin   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsZMax   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsDepth  = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsHeight = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsVp     = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsVs     = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theBuildingsRho    = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theFoundationsVp   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theFoundationsVs   = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+        theFoundationsRho  = (double*)malloc( sizeof(double) * theNumberOfBuildings );
+
+    }
+
+    /* Broadcast table of properties */
+    MPI_Bcast(theBuildingsXMin,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsXMax,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsYMin,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsYMax,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsZMin,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsZMax,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsDepth,  theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsHeight, theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsVp,     theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsVs,     theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theBuildingsRho,    theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theFoundationsVp,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theFoundationsVs,   theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theFoundationsRho,  theNumberOfBuildings, MPI_DOUBLE, 0, comm_solver);
+
+    /* Broadcast fixed base data */
+    if ( areBaseFixed == YES ) {
+        MPI_Bcast(&theBaseFixedDT,         1, MPI_DOUBLE, 0, comm_solver);
+        MPI_Bcast(&theBaseFixedStartIndex, 1, MPI_INT,    0, comm_solver);
+        broadcast_char_array( theBaseFixedDir,   sizeof(theBaseFixedDir),
+                              0, comm_solver );
+        broadcast_char_array( theBaseFixedSufix, sizeof(theBaseFixedSufix),
+                              0, comm_solver );
+    }
+
+    theBuilding = (bldg_t *)malloc( sizeof(bldg_t) * theNumberOfBuildings );
+    if ( theBuilding == NULL ) {
+        solver_abort ( __FUNCTION_NAME, "NULL from malloc",
+                       "Error allocating theBuildings memory" );
+    }
+
+    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+
+        theBuilding[i].bounds.xmin = theBuildingsXMin[i];
+        theBuilding[i].bounds.xmax = theBuildingsXMax[i];
+        theBuilding[i].bounds.ymin = theBuildingsYMin[i];
+        theBuilding[i].bounds.ymax = theBuildingsYMax[i];
+        theBuilding[i].bounds.zmin = theBuildingsZMin[i];
+        theBuilding[i].bounds.zmax = theBuildingsZMax[i];
+
+        theBuilding[i].height = theBuildingsHeight[i];
+        theBuilding[i].depth  = theBuildingsDepth[i];
+
+        theBuilding[i].bldgprops.Vp  = theBuildingsVp[i];
+        theBuilding[i].bldgprops.Vs  = theBuildingsVs[i];
+        theBuilding[i].bldgprops.rho = theBuildingsRho[i];
+
+        theBuilding[i].fdtnprops.Vp  = theFoundationsVp[i];
+        theBuilding[i].fdtnprops.Vs  = theFoundationsVs[i];
+        theBuilding[i].fdtnprops.rho = theFoundationsRho[i];
+    }
+
+    free(theBuildingsXMin);
+    free(theBuildingsXMax);
+    free(theBuildingsYMin);
+    free(theBuildingsYMax);
+    free(theBuildingsZMin);
+    free(theBuildingsZMax);
+    free(theBuildingsHeight);
+    free(theBuildingsDepth);
+    free(theBuildingsVp);
+    free(theBuildingsVs);
+    free(theBuildingsRho);
+    free(theFoundationsVp);
+    free(theFoundationsVs);
+    free(theFoundationsRho);
+
+    return;
+}
+
+
+int32_t
+buildings_initparameters ( const char *parametersin )
+{
+    FILE   *fp;
+    int     iBldg, bldgsNfactor, numBldgs;
+    double  min_oct_size, surface_shift;
+    double *auxiliar;
+    char    consider_fixed_base[16];
+
+    // Assigning -1 to enum type is a bad idea
+    //noyesflag_t fixedbase = -1;    
+    noyesflag_t fixedbase;
+
+    /* Opens parametersin file */
+
+    if ( ( fp = fopen(parametersin, "r" ) ) == NULL ) {
+        fprintf( stderr,
+                 "Error opening %s\n at buildings_initparameters",
+                 parametersin );
+        return -1;
+    }
+
+    /* Parses parametersin to capture building single-value parameters */
+
+    if ( ( parsetext(fp, "number_of_buildings", 'i', &numBldgs           ) != 0) ||
+         ( parsetext(fp, "buildings_n_factor",  'i', &bldgsNfactor       ) != 0) ||
+         ( parsetext(fp, "min_octant_size_m",   'd', &min_oct_size       ) != 0) ||
+         ( parsetext(fp, "surface_shift_m",     'd', &surface_shift      ) != 0) ||
+         ( parsetext(fp, "consider_fixed_base", 's', &consider_fixed_base) != 0) )
+    {
+        fprintf( stderr,
+                 "Error parsing building parameters from %s\n",
+                 parametersin );
+        return -1;
+    }
+
+    /* Performs sanity checks */
+
+    if ( numBldgs < 0 ) {
+        fprintf( stderr,
+                 "Illegal number of buildings %d\n",
+                 numBldgs );
+        return -1;
+    }
+
+    if ( bldgsNfactor < 0 ) {
+        fprintf( stderr,
+                 "Illegal buildings_n_factor for buildings %d\n",
+                 bldgsNfactor );
+        return -1;
+    }
+
+    if ( min_oct_size < 0 ) {
+        fprintf( stderr,
+                 "Illegal minimum octant size for buildings %f\n",
+                 min_oct_size );
+        return -1;
+    }
+
+    if ( surface_shift < 0 ) {
+        fprintf( stderr,
+                 "Illegal surface_shift for buildings %f\n",
+                 surface_shift );
+        return -1;
+    }
+
+    if ( strcasecmp(consider_fixed_base, "yes") == 0 ) {
+        fixedbase = YES;
+    } else if ( strcasecmp(consider_fixed_base, "no") == 0 ) {
+        fixedbase = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+                "Unknown response for considering"
+                "fixed base option (yes or no): %s\n",
+                consider_fixed_base );
+    }
+
+    /* Initialize the static global variables */
+
+    theNumberOfBuildings = numBldgs;
+    theBuildingsNFactor  = bldgsNfactor;
+    theMinOctSizeMeters  = min_oct_size;
+    theSurfaceShift      = surface_shift;
+    areBaseFixed         = fixedbase;
+
+    /* Detour for fixed base option */
+    if ( areBaseFixed == YES ) {
+        fixedbase_read( fp );
+    }
+
+    auxiliar           = (double*)malloc( sizeof(double) * numBldgs * 12 );
+    theBuildingsXMin   = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsXMax   = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsYMin   = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsYMax   = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsZMin   = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsZMax   = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsDepth  = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsHeight = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsDepth  = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsVp     = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsVs     = (double*)malloc( sizeof(double) * numBldgs );
+    theBuildingsRho    = (double*)malloc( sizeof(double) * numBldgs );
+    theFoundationsVp   = (double*)malloc( sizeof(double) * numBldgs );
+    theFoundationsVs   = (double*)malloc( sizeof(double) * numBldgs );
+    theFoundationsRho  = (double*)malloc( sizeof(double) * numBldgs );
+
+    if ( ( auxiliar           == NULL ) ||
+         ( theBuildingsXMin   == NULL ) ||
+         ( theBuildingsXMax   == NULL ) ||
+         ( theBuildingsYMin   == NULL ) ||
+         ( theBuildingsYMax   == NULL ) ||
+         ( theBuildingsDepth  == NULL ) ||
+         ( theBuildingsHeight == NULL ) ||
+         ( theBuildingsVp     == NULL ) ||
+         ( theBuildingsVs     == NULL ) ||
+         ( theBuildingsRho    == NULL ) ||
+         ( theFoundationsVp   == NULL ) ||
+         ( theFoundationsVs   == NULL ) ||
+         ( theFoundationsRho  == NULL ) )
+    {
+        fprintf( stderr, "Errror allocating transient building arrays"
+                         "in buildings_initparameters " );
+        return -1;
+    }
+
+    if ( parsedarray( fp, "building_properties", numBldgs*12, auxiliar ) != 0)
+    {
+    	fprintf( stderr,
+    	         "Error parsing building_properties list from %s\n",
+    	         parametersin );
+    	return -1;
+    }
+
+    /* We DO NOT convert physical coordinates into etree coordinates here */
+    for (iBldg = 0; iBldg < numBldgs; iBldg++) {
+
+        theBuildingsXMin   [ iBldg ] = auxiliar [ iBldg * 12      ];
+        theBuildingsXMax   [ iBldg ] = auxiliar [ iBldg * 12 +  1 ];
+        theBuildingsYMin   [ iBldg ] = auxiliar [ iBldg * 12 +  2 ];
+        theBuildingsYMax   [ iBldg ] = auxiliar [ iBldg * 12 +  3 ];
+        theBuildingsDepth  [ iBldg ] = auxiliar [ iBldg * 12 +  4 ];
+        theBuildingsHeight [ iBldg ] = auxiliar [ iBldg * 12 +  5 ];
+        theBuildingsVp     [ iBldg ] = auxiliar [ iBldg * 12 +  6 ];
+        theBuildingsVs     [ iBldg ] = auxiliar [ iBldg * 12 +  7 ];
+        theBuildingsRho    [ iBldg ] = auxiliar [ iBldg * 12 +  8 ];
+        theFoundationsVp   [ iBldg ] = auxiliar [ iBldg * 12 +  9 ];
+        theFoundationsVs   [ iBldg ] = auxiliar [ iBldg * 12 + 10 ];
+        theFoundationsRho  [ iBldg ] = auxiliar [ iBldg * 12 + 11 ];
+    }
+
+    fclose(fp);
+    free( auxiliar );
+
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                             Fixed Base Option                              */
+/* -------------------------------------------------------------------------- */
+
+void fixedbase_read ( FILE* fp ) {
+
+    if ( ( parsetext(fp, "fixedbase_input_dt",         'd', &theBaseFixedDT          ) != 0) ||
+         ( parsetext(fp, "fixedbase_input_dir",        's', &theBaseFixedDir         ) != 0) ||
+         ( parsetext(fp, "fixedbase_input_startindex", 'i', &theBaseFixedStartIndex  ) != 0) ||
+         ( parsetext(fp, "fixedbase_input_sufix",      's', &theBaseFixedSufix       ) != 0) )
+    {
+        solver_abort ( __FUNCTION_NAME, "Parsetext returned non-zero",
+                       "Error parsing fixed-based options" );
+    }
+
+    return;
+}
+
+int32_t count_base_nodes ( mesh_t *myMesh ) {
+
+    lnid_t  nindex;
+    double  ticksize;
+    int32_t count = 0;
+
+    ticksize = myMesh->ticksize;
+
+    for ( nindex = 0; nindex < myMesh->nharbored; nindex++ ) {
+
+        node_t node = myMesh->nodeTable[nindex];
+
+        int res = basenode_search(node.x, node.y, node.z, ticksize);
+
+        if ( res != 0 ) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+int32_t map_base_nodes ( mesh_t *myMesh ) {
+
+    lnid_t  nindex;
+    double  ticksize;
+    int32_t count = 0;
+
+    ticksize = myMesh->ticksize;
+
+    for ( nindex = 0; nindex < myMesh->nharbored; nindex++ ) {
+
+        node_t node = myMesh->nodeTable[nindex];
+
+        int bldg = basenode_search(node.x, node.y, node.z, ticksize);
+
+        if ( bldg != 0 ) {
+            theBaseNodes[count].nindex = nindex;
+            theBaseNodes[count].bldg   = bldg;
+            count++;
+        }
+    }
+
+    return count;
+}
+
+void read_base_input(double simTime) {
+
+    int i,j;
+    int steps = (int)(simTime / theBaseFixedDT);
+
+    theBaseSignals = (fvector_t**)malloc( sizeof(fvector_t*) *
+                                           theNumberOfBuildings );
+    if ( theBaseSignals == NULL ) {
+        solver_abort ( __FUNCTION_NAME, "NULL from malloc",
+                       "Error allocating theBaseSignals memory" );
+    }
+
+    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+
+        theBaseSignals[i] = (fvector_t*)malloc( sizeof(fvector_t) * steps );
+        if ( theBaseSignals[i] == NULL ) {
+            solver_abort ( __FUNCTION_NAME, "NULL from malloc",
+                           "Error allocating base signal memory" );
+        }
+
+        FILE* fp;
+        char filename[256];
+
+        sprintf( filename,
+                 "%s/%s.%d",
+                 theBaseFixedDir,
+                 theBaseFixedSufix,
+                 i + theBaseFixedStartIndex );
+        fp = fopen(filename, "r");
+        if ( fp == NULL ) {
+            solver_abort ( __FUNCTION_NAME, "NULL from fopen",
+                           "Error opening signals" );
+        }
+
+        char line[512];
+        for ( j = 0; j < 1; j++ ) {
+            if ( fgets(line, 512, fp) == NULL ) {
+                solver_abort ( __FUNCTION_NAME, "NULL from fgets",
+                               "Error reading signals" );
+            }
+        }
+
+        for ( j = 0; j < steps; j++ ) {
+            float aux, x,y,z;
+            if ( fgets(line, 512, fp) == NULL ) {
+                solver_abort ( __FUNCTION_NAME, "NULL from fgets",
+                               "Error reading signals" );
+            }
+            sscanf(line,"%g %g %g %g",&aux,&x,&y,&z);
+            theBaseSignals[i][j].f[0] = (double)x;
+            theBaseSignals[i][j].f[1] = (double)y;
+            theBaseSignals[i][j].f[2] = (double)z;
+        }
+    }
+}
+
+void bldgs_fixedbase_init ( mesh_t *myMesh, double simTime ) {
+
+    int32_t recount;
+
+    /* Get the number of nodes at the base of a building */
+    theBaseNodesCount = count_base_nodes(myMesh);
+
+    /* Allocate memory for the mapper */
+    theBaseNodes = (basenode_t*)malloc(sizeof(basenode_t) * theBaseNodesCount);
+    if ( theBaseNodes == NULL ) {
+        solver_abort ( __FUNCTION_NAME, "NULL from malloc",
+                       "Error allocating theBaseNodes memory" );
+    }
+
+    /* Map node indices and bldgs assingments */
+    recount = map_base_nodes(myMesh);
+
+    if ( recount != theBaseNodesCount ) {
+        solver_abort ( __FUNCTION_NAME, "NULL from malloc",
+                       "Error allocating theBaseNodes memory" );
+    }
+
+    read_base_input(simTime);
+
+    return;
+}
+
+double interpolatedisp ( double low, double high, double frac) {
+
+    return low + frac * (high - low);
+}
+
+fvector_t bldgs_get_base_disp ( int bldg, double simDT, int step ) {
+
+    double    truetime, supposedstep, frac;
+    int       i, lowstep, highstep;
+    fvector_t lowdisp, highdisp, disp;
+
+    truetime     = step * simDT;
+    supposedstep = truetime / (double)theBaseFixedDT;
+
+    lowstep  = (int)supposedstep;
+    highstep = lowstep + 1;
+    frac     = supposedstep - (double)lowstep;
+
+    lowdisp  = theBaseSignals[bldg][lowstep];
+    highdisp = theBaseSignals[bldg][highstep];
+
+    for ( i = 0; i < 3; i++ ) {
+        disp.f[i] = interpolatedisp( lowdisp.f[i], highdisp.f[i], frac);
+    }
+
+    return disp;
+}
+
+void bldgs_load_fixedbase_disps ( mysolver_t* solver, double simDT, int step ) {
+
+    lnid_t bnode;
+    lnid_t nindex;
+
+    for ( bnode = 0; bnode < theBaseNodesCount; bnode++ ) {
+
+        nindex = theBaseNodes[bnode].nindex;
+        int bldg = theBaseNodes[bnode].bldg-1;
+        fvector_t* dis = solver->tm2 + nindex;
+        *dis = bldgs_get_base_disp ( bldg, simDT, step );
+    }
+
+    return;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                             Dimensions Adjust                              */
+/* -------------------------------------------------------------------------- */
+
+double adjust (double input) {
+
+    return theMinOctSizeMeters * round(input / theMinOctSizeMeters);
+}
+
+/**
+ * Adjust the surface shift and the buildings' boundaries to the etree grid.
+ * The user is responsible for providing a valid value for the minimum
+ * octant size to be used as reference.
+ *
+ */
+void adjust_dimensions ( ) {
+
+    int iBldg;
+
+    theSurfaceShift = adjust( theSurfaceShift );
+
+    for (iBldg = 0; iBldg < theNumberOfBuildings; iBldg++) {
+
+        /* Compute Z limits based on surface shift and building vertical info */
+        theBuildingsZMin[iBldg] = theSurfaceShift - theBuildingsHeight[iBldg];
+        theBuildingsZMax[iBldg] = theSurfaceShift + theBuildingsDepth[iBldg];
+
+        /* Correct Z-min to avoid negative coords. This occurs if the height
+         * of a building is greater than the surface shift (pushdown) */
+        if ( theBuildingsZMin[iBldg] < 0 ) {
+            theBuildingsZMin[iBldg] = 0;
+        }
+
+        theBuildingsXMin   [ iBldg ] = adjust( theBuildingsXMin   [ iBldg ] );
+        theBuildingsXMax   [ iBldg ] = adjust( theBuildingsXMax   [ iBldg ] );
+        theBuildingsYMin   [ iBldg ] = adjust( theBuildingsYMin   [ iBldg ] );
+        theBuildingsYMax   [ iBldg ] = adjust( theBuildingsYMax   [ iBldg ] );
+        theBuildingsZMin   [ iBldg ] = adjust( theBuildingsZMin   [ iBldg ] );
+        theBuildingsZMax   [ iBldg ] = adjust( theBuildingsZMax   [ iBldg ] );
+        theBuildingsDepth  [ iBldg ] = adjust( theBuildingsDepth  [ iBldg ] );
+        theBuildingsHeight [ iBldg ] = adjust( theBuildingsHeight [ iBldg ] );
+
+    }
+
+    return;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Finalize                                  */
+/* -------------------------------------------------------------------------- */
+
+void bldgs_finalize() {
+
+    free( theBuilding );
+
+    return;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Obsolete                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Calls suitable functions based upon whether element is in foundation or not.
+ * In any case, returns 1 if element is needed to be expanded or 0 otherwise.
+ */
+
+//int buildingmagic ( octant_t *leaf,  double ticksize,
+//                    edata_t  *edata, int    theNumberOfBuildings ,
+//                    double    theFactor )
+//{
+//    int returnval;
+//
+//    returnval = bldgs_toexpand ( leaf, ticksize, (edata_t *)edata,
+//                                   theNumberOfBuildings, theFactor );
+//    if ( returnval != -1 ) {
+//        return returnval;
+//    } else {
+//        return vsrule( edata, theFactor );
+//    }
+//}
+
+/**
+ * Return 1 if the octant's origin is in the air, 0 otherwise.
+ */
+//int bldgs_airoctant ( octant_t *leaf, double ticksize ) {
+//
+//    int    i, air;
+//    double x, y, z;
+//
+//    z = leaf->lz * ticksize;
+//
+//    /* an octant may be in the air only if it is above the surface */
+//    if ( z >= theSurfaceShift ) {
+//        return 0;
+//    }
+//
+//    x = leaf->lx * ticksize;
+//    y = leaf->ly * ticksize;
+//
+//    air = 0;
+//    for ( i = 0; i < theNumberOfBuildings; i++ ) {
+//        air += outofbuilding(x, y, z, i);
+//    }
+//
+//    /* an octant is in the air only if it is out of bounds for all buildings */
+//    if ( air == theNumberOfBuildings ) {
+//        return 1;
+//    }
+//
+//    return 0;
+//}
+
+/**
+ * Returns 1 if a point is out of the i-th building bounds, 0 otherwise.
+ */
+//int outofbuilding ( double x, double y, double z, int i )
+//{
+//    bounds_t bounds = get_bldgbounds(i);
+//
+//    /* Air above a building */
+//    if ( ( x >= bounds.xmin ) &&
+//         ( x <= bounds.xmax ) ) {
+//
+//        if ( ( y >= bounds.ymin ) &&
+//             ( y <= bounds.ymax ) ) {
+//
+//            if ( z < bounds.zmin ) {
+//                return 1;
+//            }
+//        }
+//    }
+//
+//    /* Air around buildings and above surface */
+//    if ( ( x < bounds.xmin ) &&
+//         ( x > bounds.xmax ) ) {
+//
+//        if ( ( y < bounds.ymin ) &&
+//             ( y > bounds.ymax ) ) {
+//
+//            if ( z < theSurfaceShift ) {
+//                return 1;
+//            }
+//        }
+//    }
+//
+//    return 0;
+//}
+

--- a/quake/forward_gpu/buildings.h
+++ b/quake/forward_gpu/buildings.h
@@ -1,0 +1,59 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef BUILDINGS_H_
+#define BUILDINGS_H_
+
+#include "quake_util.h"
+
+/* -------------------------------------------------------------------------- */
+/*                          Public Method Prototypes                          */
+/* -------------------------------------------------------------------------- */
+
+double get_surface_shift();
+noyesflag_t get_fixedbase_flag();
+
+int bldgs_nodesearch ( tick_t x, tick_t y, tick_t z, double ticksize );
+
+int bldgs_setrec   ( octant_t *leaf,
+                     double    ticksize,
+                     edata_t  *edata,
+                     etree_t  *cvm,
+                     double xoriginm,
+                     double yoriginm,
+                     double zoriginm);
+
+int bldgs_toexpand ( octant_t *leaf,
+                     double    ticksize,
+                     edata_t  *edata,
+                     double    theFactor );
+
+int bldgs_correctproperties ( mesh_t *myMesh, edata_t *edata, int32_t lnid0 );
+
+void bldgs_fixedbase_init ( mesh_t *myMesh, double simTime );
+
+void bldgs_load_fixedbase_disps ( mysolver_t* mySolver, double simDT, int step );
+
+void bldgs_init ( int32_t myID, const char *parametersin );
+
+void bldgs_finalize();
+
+/* -------------------------------------------------------------------------- */
+
+#endif /* BUILDINGS_H_ */

--- a/quake/forward_gpu/commutil.cu
+++ b/quake/forward_gpu/commutil.cu
@@ -1,0 +1,91 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ * Description: Miscellaneous support functions.
+ */
+#include <string.h>
+#include "commutil.h"
+#include "util.h"
+
+
+/**
+ * Broadcast a string to all processes in a MPI communicator from the PE
+ * with the given rank.
+ *
+ * \param string    Character string to broadcast.  The root PE passes an
+ *		    initialized string.  The receiving PEs will allocate
+ *		    memory for the received string.
+ * \param root_rank Rank (i.e, PE ID) of the process sending the string.
+ *                  That is, root of the broadcast.
+ * \param comm      MPI communicator structure.
+ *
+ * \return 0 on success, -1 on error (really abort through \c solver_abort() ).
+ *
+ * \author jclopez
+ */
+int
+broadcast_string( char** string, int root_rank, MPI_Comm comm )
+{
+    int32_t string_len = 0;
+    int32_t myID;
+
+    HU_ASSERT_PTR( string );
+
+    MPI_Comm_rank( comm, &myID );
+
+    if (myID == root_rank) {
+	HU_ASSERT_PTR( *string );
+	string_len = strlen( *string );
+    }
+
+    MPI_Bcast( &string_len, 1, MPI_INT, root_rank, comm );
+
+    if (myID != root_rank) {
+	XMALLOC_STRING( (*string), string_len );
+    }
+
+    /* include terminating \0 character in the broadcast */
+    MPI_Bcast( *string, string_len + 1, MPI_CHAR, root_rank, comm );
+
+    (*string)[string_len] = '\0';	/* paranoid safeguard */
+
+    return 0;
+}
+
+/**
+ * Broadcast a char array (e.g., a string) of a given length.  The memory
+ * must be pre-allocated by the caller both at the sender and receiver.
+ * The destination buffer (on the receiver side must be of size equal or
+ * larger than the length specified on the sender side.
+ */
+int
+broadcast_char_array( char string[], size_t len, int root_rank, MPI_Comm comm )
+{
+    int32_t sender_len = len;
+
+    /* pass the length of the array to send */
+    MPI_Bcast( &sender_len, 1, MPI_INT, root_rank, comm );
+    HU_ASSERT_ALWAYS( sender_len <= len );
+
+    /* broadcast the actual char array */
+    MPI_Bcast( string, sender_len, MPI_CHAR, root_rank, comm );
+
+    return 0;
+}

--- a/quake/forward_gpu/commutil.h
+++ b/quake/forward_gpu/commutil.h
@@ -1,0 +1,37 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ * Description: Hercules common / communication support functions, e.g.,
+ *		ones that have MPI dependencies
+ */
+#ifndef H_COMM_UTIL_H
+#define H_COMM_UTIL_H
+
+#include <mpi.h>
+
+
+int
+broadcast_string( char** string, int root_rank, MPI_Comm comm );
+
+int
+broadcast_char_array( char string[], size_t len, int root_rank, MPI_Comm comm );
+
+
+#endif /* H_COMM_UTIL_H */

--- a/quake/forward_gpu/damping.cu
+++ b/quake/forward_gpu/damping.cu
@@ -1,0 +1,418 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "psolve.h"
+#include "quake_util.h"
+#include "damping.h"
+#include "stiffness.h"
+#include "kernel.h"
+
+void damping_addforce(mesh_t *myMesh, mysolver_t *mySolver, fmatrix_t (*theK1)[8], fmatrix_t (*theK2)[8]){
+
+    fvector_t localForce[8];
+    int       i,j;
+    int32_t   eindex;
+
+    fvector_t deltaDisp[8];
+
+    /* loop on the number of elements */
+    for (eindex = 0; eindex < myMesh->lenum; eindex++)
+    {
+        elem_t *elemp;
+        e_t    *ep;
+
+        elemp = &myMesh->elemTable[eindex];
+        ep = &mySolver->eTable[eindex];
+
+        /* Step 1. calculate the force due to the element stiffness */
+        memset(localForce, 0, 8 * sizeof(fvector_t));
+
+        /* compute the diff between disp(tm1) and disp(tm2) */
+
+        /* the_E1_timer -= MPI_Wtime();*/
+        for (i = 0; i < 8; i++) {
+            fvector_t *tm1Disp, *tm2Disp;
+            int32_t    lnid;
+
+            lnid = elemp->lnid[i];
+
+            tm1Disp = mySolver->tm1 + lnid;
+            tm2Disp = mySolver->tm2 + lnid;
+
+            deltaDisp[i].f[0] = tm1Disp->f[0] - tm2Disp->f[0];
+            deltaDisp[i].f[1] = tm1Disp->f[1] - tm2Disp->f[1];
+            deltaDisp[i].f[2] = tm1Disp->f[2] - tm2Disp->f[2];
+        }
+
+        if(vector_is_zero( deltaDisp ) != 0) {
+            /*the_E3_timer += MPI_Wtime();  */
+
+            for (i = 0; i < 8; i++)
+            {
+                fvector_t* toForce;
+                toForce = &localForce[i];
+
+                for (j = 0; j < 8; j++)
+                {
+                    fvector_t *myDeltaDisp;
+
+                    /* contribution by ( - b * deltaT * Ke * ( Ut - Ut-1 ) ) */
+                    /* But if myDeltaDisp is zero avoids multiplications     */
+                    myDeltaDisp = &deltaDisp[j];
+
+                    MultAddMatVec(&theK1[i][j], myDeltaDisp, -ep->c3, toForce);
+                    MultAddMatVec(&theK2[i][j], myDeltaDisp, -ep->c4, toForce);
+
+                }
+            }
+        }
+        for (i = 0; i < 8; i++) {
+            int32_t lnid;
+            fvector_t *nodalForce;
+
+            lnid = elemp->lnid[i];
+
+            nodalForce = mySolver->force + lnid;
+            nodalForce->f[0] += localForce[i].f[0];
+            nodalForce->f[1] += localForce[i].f[1];
+            nodalForce->f[2] += localForce[i].f[2];
+        }
+
+    } /* for all the elements */
+
+    return;
+}
+
+/**
+ * Introduce BKT Model: Compute and add the force due to the element
+ *              damping.
+ */
+
+void calc_conv(mesh_t *myMesh, mysolver_t *mySolver, double theFreq, double theDeltaT, double theDeltaTSquared){
+
+    int32_t eindex;
+    int i;
+    double rmax = 2. * M_PI * theFreq * theDeltaT;
+
+    for (eindex = 0; eindex < myMesh->lenum; eindex++)
+    {
+    	elem_t *elemp;
+    	edata_t *edata;
+
+    	elemp = &myMesh->elemTable[eindex];
+    	edata = (edata_t *)elemp->data;
+
+        // SHEAR RELATED CONVOLUTION
+
+    	if ( (edata->g0_shear != 0) && (edata->g1_shear != 0) ) {
+
+            double c0_shear = edata->g0_shear;
+            double c1_shear = edata->g1_shear;
+
+            double g0_shear = c0_shear * rmax;
+            double g1_shear = c1_shear * rmax;
+
+            double coef_shear_1 = g0_shear / 2.;
+            double coef_shear_2 = coef_shear_1 * ( 1. - g0_shear );
+
+            double coef_shear_3 = g1_shear / 2.;
+            double coef_shear_4 = coef_shear_3 * ( 1. - g1_shear );
+
+            double exp_coef_shear_0 = exp( -g0_shear );
+            double exp_coef_shear_1 = exp( -g1_shear );
+
+            for(i = 0; i < 8; i++)
+            {
+                int32_t     lnid, cindex;
+                fvector_t   *f0_tm1, *f1_tm1, *tm1Disp, *tm2Disp;
+
+                lnid = elemp->lnid[i];
+
+                /* cindex is the index of the node in the convolution vector */
+                cindex = eindex * 8 + i;
+
+                tm1Disp = mySolver->tm1 + lnid;
+                tm2Disp = mySolver->tm2 + lnid;
+
+                f0_tm1 = mySolver->conv_shear_1 + cindex;
+                f1_tm1 = mySolver->conv_shear_2 + cindex;
+
+                f0_tm1->f[0] = coef_shear_2 * tm1Disp->f[0] + coef_shear_1 * tm2Disp->f[0] + exp_coef_shear_0 * f0_tm1->f[0];
+                f0_tm1->f[1] = coef_shear_2 * tm1Disp->f[1] + coef_shear_1 * tm2Disp->f[1] + exp_coef_shear_0 * f0_tm1->f[1];
+                f0_tm1->f[2] = coef_shear_2 * tm1Disp->f[2] + coef_shear_1 * tm2Disp->f[2] + exp_coef_shear_0 * f0_tm1->f[2];
+
+                f1_tm1->f[0] = coef_shear_4 * tm1Disp->f[0] + coef_shear_3 * tm2Disp->f[0] + exp_coef_shear_1 * f1_tm1->f[0];
+                f1_tm1->f[1] = coef_shear_4 * tm1Disp->f[1] + coef_shear_3 * tm2Disp->f[1] + exp_coef_shear_1 * f1_tm1->f[1];
+                f1_tm1->f[2] = coef_shear_4 * tm1Disp->f[2] + coef_shear_3 * tm2Disp->f[2] + exp_coef_shear_1 * f1_tm1->f[2];
+
+            } // For local nodes (0:7)
+
+    	} // end if null coefficients
+
+        // DILATATION RELATED CONVOLUTION
+
+        if ( (edata->g0_kappa != 0) && (edata->g1_kappa != 0) ) {
+
+            double c0_kappa = edata->g0_kappa;
+            double c1_kappa = edata->g1_kappa;
+
+            double g0_kappa = c0_kappa * rmax;
+            double g1_kappa = c1_kappa * rmax;
+
+            double coef_kappa_1 = g0_kappa / 2.;
+            double coef_kappa_2 = coef_kappa_1 * ( 1. - g0_kappa );
+
+            double coef_kappa_3 = g1_kappa / 2.;
+            double coef_kappa_4 = coef_kappa_3 * ( 1. - g1_kappa );
+
+            double exp_coef_kappa_0 = exp( -g0_kappa );
+            double exp_coef_kappa_1 = exp( -g1_kappa );
+
+            for(i = 0; i < 8; i++)
+            {
+                int32_t     lnid, cindex;
+                fvector_t   *f0_tm1, *f1_tm1, *tm1Disp, *tm2Disp;
+
+                lnid = elemp->lnid[i];
+
+                /* cindex is the index of the node in the convolution vector */
+                cindex = eindex * 8 + i;
+
+                tm1Disp = mySolver->tm1 + lnid;
+                tm2Disp = mySolver->tm2 + lnid;
+
+                f0_tm1 = mySolver->conv_kappa_1 + cindex;
+                f1_tm1 = mySolver->conv_kappa_2 + cindex;
+
+                f0_tm1->f[0] = coef_kappa_2 * tm1Disp->f[0] + coef_kappa_1 * tm2Disp->f[0] + exp_coef_kappa_0 * f0_tm1->f[0];
+                f0_tm1->f[1] = coef_kappa_2 * tm1Disp->f[1] + coef_kappa_1 * tm2Disp->f[1] + exp_coef_kappa_0 * f0_tm1->f[1];
+                f0_tm1->f[2] = coef_kappa_2 * tm1Disp->f[2] + coef_kappa_1 * tm2Disp->f[2] + exp_coef_kappa_0 * f0_tm1->f[2];
+
+                f1_tm1->f[0] = coef_kappa_4 * tm1Disp->f[0] + coef_kappa_3 * tm2Disp->f[0] + exp_coef_kappa_1 * f1_tm1->f[0];
+                f1_tm1->f[1] = coef_kappa_4 * tm1Disp->f[1] + coef_kappa_3 * tm2Disp->f[1] + exp_coef_kappa_1 * f1_tm1->f[1];
+                f1_tm1->f[2] = coef_kappa_4 * tm1Disp->f[2] + coef_kappa_3 * tm2Disp->f[2] + exp_coef_kappa_1 * f1_tm1->f[2];
+
+            } // For local nodes (0:7)
+
+        } // end if null coefficients
+
+    } // For all elements
+
+    return;
+
+}
+
+/**
+ * new_damping: Compute and add the force due to the element
+ *              damping.
+ */
+void constant_Q_addforce(mesh_t *myMesh, mysolver_t *mySolver, double theFreq, double theDeltaT, double theDeltaTSquared)
+{
+	/* \todo use mu_and_lamda to compute first,second and third coefficients */
+
+	int i;
+	fvector_t localForce[8];
+	int32_t   eindex;
+	fvector_t damping_vector_shear[8], damping_vector_kappa[8];
+
+	double rmax = 2. * M_PI * theFreq * theDeltaT;
+
+	/* theAddForceETime -= MPI_Wtime(); */
+
+	/* loop on the number of elements */
+	for (eindex = 0; eindex < myMesh->lenum; eindex++)
+	{
+		elem_t *elemp;
+		e_t    *ep;
+		edata_t *edata;
+
+		double a0_shear, a1_shear, b_shear, a0_kappa, a1_kappa, b_kappa, csum;
+
+		elemp = &myMesh->elemTable[eindex];
+		edata = (edata_t *)elemp->data;
+		ep = &mySolver->eTable[eindex];
+
+		// SHEAR CONTRIBUTION
+
+        a0_shear = edata->a0_shear;
+        a1_shear = edata->a1_shear;
+        b_shear  = edata->b_shear;
+
+        csum = a0_shear + a1_shear + b_shear;
+
+		if ( csum != 0 ) {
+
+	        double coef_shear = b_shear / rmax;
+
+            for (i = 0; i < 8; i++) {
+
+                fvector_t *tm1Disp, *tm2Disp, *f0_tm1, *f1_tm1;
+                int32_t    lnid, cindex;
+
+                cindex = eindex * 8 + i;
+
+                lnid = elemp->lnid[i];
+
+                tm1Disp = mySolver->tm1 + lnid;
+                tm2Disp = mySolver->tm2 + lnid;
+                f0_tm1  = mySolver->conv_shear_1 + cindex;
+                f1_tm1  = mySolver->conv_shear_2 + cindex;
+
+                damping_vector_shear[i].f[0] = coef_shear * (tm1Disp->f[0] - tm2Disp->f[0])
+                                             - (a0_shear * f0_tm1->f[0] + a1_shear * f1_tm1->f[0])
+                                             + tm1Disp->f[0];
+
+                damping_vector_shear[i].f[1] = coef_shear * (tm1Disp->f[1] - tm2Disp->f[1])
+                                             - (a0_shear * f0_tm1->f[1] + a1_shear * f1_tm1->f[1])
+                                             + tm1Disp->f[1];
+
+                damping_vector_shear[i].f[2] = coef_shear * (tm1Disp->f[2] - tm2Disp->f[2])
+                                             - (a0_shear * f0_tm1->f[2] + a1_shear * f1_tm1->f[2])
+                                             + tm1Disp->f[2];
+
+            } // end for nodes in the element
+
+		} else {
+
+		    for (i = 0; i < 8; i++) {
+
+                fvector_t *tm1Disp, *tm2Disp;
+                int32_t    lnid;
+
+                lnid = elemp->lnid[i];
+                tm1Disp = mySolver->tm1 + lnid;
+                tm2Disp = mySolver->tm2 + lnid;
+
+                damping_vector_shear[i].f[0] = tm1Disp->f[0];
+                damping_vector_shear[i].f[1] = tm1Disp->f[1];
+                damping_vector_shear[i].f[2] = tm1Disp->f[2];
+
+            } // end for nodes in the element
+
+		} // end if for coefficients
+
+		// DILATATION CONTRIBUTION
+
+        a0_kappa   = edata->a0_kappa;
+        a1_kappa   = edata->a1_kappa;
+        b_kappa    = edata->b_kappa;
+
+        csum = a0_kappa + a1_kappa + b_kappa;
+
+        if ( csum != 0 ) {
+
+            double coef_kappa = b_kappa / rmax;
+
+            for (i = 0; i < 8; i++) {
+
+                fvector_t *tm1Disp, *tm2Disp, *f0_tm1, *f1_tm1;
+                int32_t    lnid, cindex;
+
+                cindex = eindex * 8 + i;
+
+                lnid = elemp->lnid[i];
+
+                tm1Disp = mySolver->tm1 + lnid;
+                tm2Disp = mySolver->tm2 + lnid;
+
+                f0_tm1  = mySolver->conv_kappa_1 + cindex;
+                f1_tm1  = mySolver->conv_kappa_2 + cindex;
+
+                damping_vector_kappa[i].f[0] = coef_kappa * (tm1Disp->f[0] - tm2Disp->f[0])
+                                             - (a0_kappa * f0_tm1->f[0] + a1_kappa * f1_tm1->f[0])
+                                             + tm1Disp->f[0];
+
+                damping_vector_kappa[i].f[1] = coef_kappa * (tm1Disp->f[1] - tm2Disp->f[1])
+                                             - (a0_kappa * f0_tm1->f[1] + a1_kappa * f1_tm1->f[1])
+                                             + tm1Disp->f[1];
+
+                damping_vector_kappa[i].f[2] = coef_kappa * (tm1Disp->f[2] - tm2Disp->f[2])
+                                             - (a0_kappa * f0_tm1->f[2] + a1_kappa * f1_tm1->f[2])
+                                             + tm1Disp->f[2];
+
+            } // end for nodes in the element
+
+        } else {
+
+            for (i = 0; i < 8; i++) {
+
+                fvector_t *tm1Disp, *tm2Disp;
+                int32_t    lnid;
+
+                lnid = elemp->lnid[i];
+                tm1Disp = mySolver->tm1 + lnid;
+                tm2Disp = mySolver->tm2 + lnid;
+
+                damping_vector_kappa[i].f[0] = tm1Disp->f[0];
+                damping_vector_kappa[i].f[1] = tm1Disp->f[1];
+                damping_vector_kappa[i].f[2] = tm1Disp->f[2];
+
+            } // end for nodes in the element
+
+        } // end if for coefficients
+
+		double kappa = -0.5625 * (ep->c2 + 2. / 3. * ep->c1);
+		double mu = -0.5625 * ep->c1;
+
+		double atu[24];
+		double firstVec[24];
+
+		for(i = 0; i<24; i++)
+			firstVec[i] = 0.;
+
+		memset(localForce, 0, 8 * sizeof(fvector_t));
+
+        if(vector_is_zero( damping_vector_shear ) != 0) {
+
+            aTransposeU( damping_vector_shear, atu );
+            firstVector_mu( atu, firstVec, mu);
+
+        }
+
+		if(vector_is_zero( damping_vector_kappa ) != 0) {
+
+			aTransposeU( damping_vector_kappa, atu );
+			firstVector_kappa( atu, firstVec, kappa);
+
+		}
+
+		au( localForce, firstVec );
+
+		for (i = 0; i < 8; i++) {
+			int32_t lnid;
+			fvector_t *nodalForce;
+
+			lnid = elemp->lnid[i];
+
+			nodalForce = mySolver->force + lnid;
+			nodalForce->f[0] += localForce[i].f[0];
+			nodalForce->f[1] += localForce[i].f[1];
+			nodalForce->f[2] += localForce[i].f[2];
+		}
+
+	} /* for all the elements */
+
+	return;
+
+}
+

--- a/quake/forward_gpu/damping.h
+++ b/quake/forward_gpu/damping.h
@@ -1,0 +1,36 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef DAMPING_H_
+#define DAMPING_H_
+
+/* physics related */
+
+typedef enum
+{
+
+  RAYLEIGH = 0, MASS, NONE, BKT
+
+} damping_type_t;
+
+void damping_addforce(mesh_t *myMesh, mysolver_t *mySolver, fmatrix_t (*theK1)[8], fmatrix_t (*theK2)[8]);
+void calc_conv(mesh_t *myMesh, mysolver_t *mySolver, double theFreq, double theDeltaT, double theDeltaTSquared);
+void constant_Q_addforce(mesh_t *myMesh, mysolver_t *mySolver, double theFreq, double theDeltaT, double theDeltaTSquared);
+
+#endif /* DAMPING_H_ */

--- a/quake/forward_gpu/drm.cu
+++ b/quake/forward_gpu/drm.cu
@@ -1,0 +1,2662 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+#include <mpi.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <unistd.h>
+
+#include "cvm.h"
+#include "psolve.h"
+#include "drm.h"
+#include "octor.h"
+#include "commutil.h"
+#include "util.h"
+#include "timers.h"
+#include "quake_util.h"
+#include "buildings.h"
+
+
+#define  NONE -1
+#define  MAX(a, b) (((a)>(b)) ? (a) : (b))
+#define  MIN(a, b) (((a)<(b)) ? (a) : (b))
+
+
+extern int compute_csi_eta_dzeta( octant_t *octant, vector3D_t pointcoords,
+				                  vector3D_t *localcoords, int32_t *localNodeID );
+
+
+/* -------------------------------------------------------------------------- */
+/*                             Global Variables                               */
+/* -------------------------------------------------------------------------- */
+
+static double  theDrmXMin,  theDrmXMax;
+static double  theDrmYMin,  theDrmYMax;
+static double  theDrmDepth;
+static double  theX_Offset;
+static double  theY_Offset;
+static double  thePart1DeltaT;
+static int     theDrmPrintRate;
+static double  theDrmEdgeSize;
+static double  *myDispWrite;
+
+static double  theSurfaceShift = 0;
+
+/*
+ * These are the total drm elems and nodes numbers in all processors.
+ */
+static int32_t theNumberOfDrmNodes;
+static int32_t theNumberOfDrmElements;
+
+/*
+ * These are the local drm elems and nodes numbers in each processor.
+ */
+static int myNumberOfDrmNodes = 0;
+static int myNumberOfDupDrmNodes = 0;
+static int myNumberOfDrmElements = 0;
+
+static char  theDrmOutputDir[256];
+
+static drmhash_t  theDrmTable;
+/*This is to store drm nodes which are not owned by me */
+static drmhash_t  theDrmDupTable;
+static drm_part_t theDrmPart;
+
+/*To store local ids of drm nodes */
+static int64_t      *drmNodeIds;
+static int64_t      *drmDupNodesIds;
+static int32_t      *drmNodeOwner;
+static int32_t      theTableDim = 89;
+static int32_t      theTableDupDim = 89;
+static int32_t      *pesHaveDrmNodes;
+static int32_t      *dupNodesCount;
+
+static fvector_t    *theDrmNodeCoords;
+static fvector_t    *theDrmDisplacements1; // For Part 2 only and current timestep
+static fvector_t    *theDrmDisplacements2; // For Part 2 only and next timestep
+
+static drm_elem_t   *theDrmElem;
+static drm_node_t   *myDrmNodes;
+
+/*Total number of processors that has drm elements */
+static int                 drmFilesCount;
+static int                 filesToReadCnt = 0;
+static pes_drm_nodes_cnt   *partOneDrmNodesCnt;
+static drm_file_to_open    drmFileToOpen;
+static drm_file_to_read    *drmFilesToRead;
+
+/* this is for storing drm node coords for each processor . part 2*/
+static  int32_t  *rank; /*for comm */
+static  int32_t  *pes_per_file ;
+static  int32_t  *drmNodesCountP2;
+static  int  peshavenodes = 0; /* total number of processors with drm nodes--part2*/
+static	pes_with_drm_nodes   *pesDrmNodes; /* this is for drm files created in Part2 */
+
+static noyesflag_t  drmImplement = NO;
+static noyesflag_t  includeBuildings;
+
+static 	FILE   *drmDisp;
+
+/* -------------------------------------------------------------------------- */
+/*                             General Utilities                              */
+/* -------------------------------------------------------------------------- */
+
+drm_part_t drm_init (int32_t myID, const char *parametersin, noyesflag_t includeBldgs)
+{
+	double double_message[9];
+	int    int_message[2];
+
+	MPI_Datatype coords_mpi, coordscnt_mpi;
+
+	drmImplement = YES;
+	includeBuildings = includeBldgs;
+	if ( includeBuildings == YES ) {
+		theSurfaceShift = get_surface_shift();
+	}
+
+	/* Capturing data from file --- only done by PE0 */
+	if (myID == 0) {
+		if (drm_initparameters( parametersin) != 0) {
+			fprintf(stderr,"Thread 0: drm_init: "
+					"drm_initparameters error\n");
+			MPI_Abort(MPI_COMM_WORLD, ERROR);
+			exit(1);
+		}
+	}
+
+	/* Broadcasting data */
+
+	int_message[0]  = (int)theDrmPart;
+	int_message[1]  = theDrmPrintRate;
+
+	MPI_Bcast(int_message, 2, MPI_INT, 0, comm_solver);
+
+	theDrmPart = (drm_part_t)int_message[0] ;
+	theDrmPrintRate = int_message[1];
+
+	double_message[0] = theDrmXMin;
+	double_message[1] = theDrmYMin;
+	double_message[2] = theDrmXMax;
+	double_message[3] = theDrmYMax;
+	double_message[4] = theDrmDepth;
+	double_message[5] = theX_Offset;
+	double_message[6] = theY_Offset;
+	double_message[7] = theDrmEdgeSize;
+	double_message[8] = thePart1DeltaT;
+
+	MPI_Bcast(double_message, 9, MPI_DOUBLE, 0, comm_solver);
+
+	theDrmXMin     = double_message[0];
+	theDrmYMin     = double_message[1];
+	theDrmXMax     = double_message[2];
+	theDrmYMax     = double_message[3];
+	theDrmDepth    = double_message[4];
+	theX_Offset    = double_message[5];
+	theY_Offset    = double_message[6];
+	theDrmEdgeSize = double_message[7];
+	thePart1DeltaT = double_message[8];
+
+	broadcast_char_array( theDrmOutputDir, sizeof(theDrmOutputDir), 0,
+			comm_solver );
+
+	MPI_Barrier( comm_solver );
+
+
+	/* broadcast drm nodal coordinates if in par1 */
+	if ( theDrmPart == PART1 ) {
+
+		MPI_Bcast(&theNumberOfDrmNodes, 1, MPI_INT, 0, comm_solver);
+
+		if ( myID != 0 ) {
+			XMALLOC_VAR_N( theDrmNodeCoords, fvector_t, theNumberOfDrmNodes );
+		}
+
+		MPI_Type_contiguous(3, MPI_DOUBLE, &coords_mpi);
+		MPI_Type_commit(&coords_mpi);
+
+		MPI_Bcast(theDrmNodeCoords, theNumberOfDrmNodes, coords_mpi, 0, comm_solver);
+
+	}
+
+	if ( theDrmPart == PART2 ) {
+
+		MPI_Bcast(&theNumberOfDrmNodes, 1, MPI_INT, 0, comm_solver);
+		MPI_Bcast(&drmFilesCount, 1, MPI_INT, 0, comm_solver);
+
+		if ( myID != 0 ) {
+			XMALLOC_VAR_N( partOneDrmNodesCnt, pes_drm_nodes_cnt, drmFilesCount );
+		}
+
+		MPI_Type_contiguous(2, MPI_INT, &coordscnt_mpi);
+		MPI_Type_commit(&coordscnt_mpi);
+
+		MPI_Bcast(partOneDrmNodesCnt, drmFilesCount, coordscnt_mpi, 0, comm_solver);
+
+	}
+
+	return theDrmPart;
+}
+
+int32_t drm_initparameters (const char *parametersin) {
+
+	FILE   *fp;
+
+	double *auxiliar,
+			drm_edgesize,
+			x_offset,
+			y_offset,
+			part1_delta_t;
+
+	int    drm_print_rate;
+	char   which_drm_part[64],
+       	   drm_output_directory[64];
+
+	// Assigning -1 to enum type is a bad idea
+	//drm_part_t drmPart = -1;
+	drm_part_t drmPart;
+
+	/* Opens parametersin file */
+
+	if ( ( fp = fopen(parametersin, "r" ) ) == NULL ) {
+		fprintf( stderr,
+				"Error opening %s\n drm_initparameters",
+				parametersin );
+		return -1;
+	}
+
+	if ((parsetext ( fp, "drm_directory",  's', &drm_output_directory ) != 0) ||
+	    (parsetext ( fp, "which_drm_part", 's', &which_drm_part       ) != 0) ||
+	    (parsetext ( fp, "drm_edgesize",   'd', &drm_edgesize         ) != 0) ||
+	    (parsetext ( fp, "drm_offset_x",   'd', &x_offset             ) != 0) ||
+	    (parsetext ( fp, "drm_offset_y",   'd', &y_offset             ) != 0) ||
+	    (parsetext ( fp, "drm_print_rate", 'i', &drm_print_rate       ) != 0) ||
+	    (parsetext ( fp, "part1_delta_t",  'd', &part1_delta_t        ) != 0) )
+	{
+		solver_abort ( "drm_initparameters", NULL,
+				"Error parsing fields from %s\n", parametersin);
+	}
+
+	if ( strcasecmp(which_drm_part, "part0") == 0) {
+        drmPart = PART0;
+    } else if (strcasecmp(which_drm_part, "part1") == 0) {
+        drmPart = PART1;
+    } else if (strcasecmp(which_drm_part, "part2") == 0) {
+        drmPart = PART2;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+        	"Unknown drm type: %s\n",
+                drmPart );
+    }
+
+	XMALLOC_VAR_N( auxiliar, double, 5 );
+
+	if ( parsedarray( fp, "drm_boundary", 5 , auxiliar ) != 0)
+	{
+		fprintf( stderr,
+				"Error parsing drm_boundaries list from %s\n",
+				parametersin );
+		return -1;
+	}
+
+	/* Init the static global variables */
+
+	/*We DO NOT convert physical coordinates into etree coordinates
+	 */
+	theDrmXMin  = auxiliar [ 0 ];
+	theDrmYMin  = auxiliar [ 1 ];
+	theDrmXMax  = auxiliar [ 2 ];
+	theDrmYMax  = auxiliar [ 3 ];
+	theDrmDepth = auxiliar [ 4 ];
+
+	free( auxiliar );
+
+	thePart1DeltaT = part1_delta_t;
+	theDrmPrintRate = drm_print_rate;
+
+	theDrmPart  = drmPart;
+
+	theDrmEdgeSize = drm_edgesize;
+
+	theX_Offset = x_offset;
+	theY_Offset = y_offset;
+
+	strcpy( theDrmOutputDir, drm_output_directory );
+
+	fclose(fp);
+
+	/* Read drm nodal coordinates if in Part1 or Part2 */
+	if ( theDrmPart == PART1 || theDrmPart == PART2 ) {
+		if ( drm_read_coords( ) != 0 ) {
+			fprintf(stderr,"Thread 0: drm_read_coords: "
+					"drm_read_coords error\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int32_t drm_read_coords ( ) {
+
+	FILE* fp;
+
+	int32_t    local_number_drm_nodes, total_num_files, i, prev_count=0;
+	int32_t    *file_numbers;
+
+	char       filename [256];
+
+	if ( theDrmPart == PART1 ) {
+		sprintf(filename, "%s%s", theDrmOutputDir, "/part0/drm_processor_info");
+	}
+
+	if ( theDrmPart == PART2 ) {
+		sprintf(filename, "%s%s", theDrmOutputDir, "/part1/drm_processor_info");
+		//sprintf(filename, "%s", "/lustre/scratch/yigit/DRM_TEST/outputfiles/DRM/part1/drm_processor_info");
+
+	}
+
+	if ((fp = fopen(filename, "r")) == NULL) {
+		fprintf(stderr, "Error opening %s\n", filename);
+		return -1;
+	}
+
+	if ( theDrmPart == PART1 ) {
+
+		/* First open drm_processor_info  to read  number of processors that have
+		 * drm nodes and their ids from part 0. */
+		hu_fread(&total_num_files, sizeof(int32_t), 1, fp );
+
+		XMALLOC_VAR_N( file_numbers, int32_t, total_num_files );
+
+		hu_fread(file_numbers, sizeof(int32_t), total_num_files, fp);
+
+		/*Then read total number of nodes*/
+		hu_fread(&theNumberOfDrmNodes, sizeof(int32_t), 1, fp);
+
+		/*Allocate memory for  global array and read coordinates from drm_coordinates_0*/
+
+		XMALLOC_VAR_N( theDrmNodeCoords, fvector_t, theNumberOfDrmNodes );
+
+		fclose(fp);
+
+		/*Read all the  files  */
+		for ( i = 0; i < total_num_files; ++i ) {
+			sprintf(filename, "%s%s_%d", theDrmOutputDir, "/part0/drm_coordinates", file_numbers[i]);
+			if ( (fp = fopen(filename, "r")) == NULL) {
+				fprintf(stderr, "Error opening %s\n", filename);
+				return -1;
+			}
+			hu_fread(&local_number_drm_nodes, sizeof(int32_t), 1, fp);
+			hu_fread(theDrmNodeCoords+prev_count, sizeof(fvector_t), local_number_drm_nodes, fp);
+			prev_count = prev_count + local_number_drm_nodes;
+			fclose(fp);
+		}
+
+		/* Surface- shift is taken care of in case of buildings */
+		if ( includeBuildings == YES )
+		for ( i = 0; i < theNumberOfDrmNodes; ++i ) {
+			theDrmNodeCoords[i].f[2] += theSurfaceShift;
+		}
+
+		free(file_numbers);
+	}
+
+	if ( theDrmPart == PART2 ) {
+
+		hu_fread(&theNumberOfDrmNodes, sizeof(int32_t), 1, fp);
+		hu_fread(&drmFilesCount, sizeof(int32_t), 1, fp);
+
+		XMALLOC_VAR_N( partOneDrmNodesCnt, pes_drm_nodes_cnt, drmFilesCount );
+
+		for( i = 0; i < drmFilesCount; ++i ) {
+			hu_fread(&(partOneDrmNodesCnt[i].id), sizeof(int32_t), 1, fp);
+			hu_fread(&(partOneDrmNodesCnt[i].count), sizeof(int32_t), 1, fp);
+		}
+
+		fclose(fp);
+	}
+
+	return 0;
+}
+
+/* If key equals 1 insert mode is on.Otherwise just counts the number of drm elems */
+void  search_drm_elems(mesh_t  *myMesh, int32_t key) {
+
+	int32_t   i, n_0, n_7, elementcounter = 0;
+	edata_t   *edata_temp;
+
+	/* Loop each element to find drm nodes.
+	 */
+	for ( i = 0; i < (myMesh->lenum); ++i ) {
+
+		int    keys_array[5];
+		double coords_array[6];
+
+		edata_temp = (edata_t *)(myMesh)->elemTable[i].data;
+		/* n_0 and n_7 are local nodal id's of 0th and 7th node.
+		 * Coordinates of 7th node are always bigger than 0th node.
+		 * */
+		n_0 = myMesh->elemTable[i].lnid[0]; /* looking at first node of the element(at top) */
+		n_7 = myMesh->elemTable[i].lnid[7]; /* looking at last node of the element(at bottom) */
+
+		/* these are  coordinates of 0th  node  */
+		coords_array[0] = myMesh->nodeTable[n_0].x;
+		coords_array[1] = myMesh->nodeTable[n_0].y;
+		coords_array[2] = myMesh->nodeTable[n_0].z;
+
+		/* these are  coordinates of 7th node  */
+		coords_array[3] = myMesh->nodeTable[n_7].x;
+		coords_array[4] = myMesh->nodeTable[n_7].y;
+		coords_array[5] = myMesh->nodeTable[n_7].z;
+
+		if ( is_drm_elem(coords_array, keys_array, 1,myMesh->ticksize) ) {
+			elementcounter++;
+			/* Insert nodes if I am in part0 or part2 */
+			if ( theDrmPart != PART1 && key == 1 ) {
+				insertNode(myMesh, i);
+			}
+		}
+	}
+
+	if (  theDrmPart != PART1 && key == 1  ) {
+		myNumberOfDrmNodes = theDrmTable.tableCnt;
+		if (  theDrmPart == PART0 )
+			myNumberOfDupDrmNodes = theDrmDupTable.tableCnt;
+	}
+
+	myNumberOfDrmElements = elementcounter;
+}
+
+/* Return  1 if an element is a drm boundary element
+ * Return  0 if an element is not a drm element.
+ * theDrm's are in etree coordinates.
+ * If only interested with return val , key should be 1.
+ * If ,in additon, want to know the face keys in detail , key should be 2.This
+ * time it returns  number of faces it belongs to */
+/* This also takes care of the surface shift due to buildings */
+int is_drm_elem(double *coords_array, int *keys_array, int key, double  ticksize) {
+
+	int    i, cnt = 0;
+	double x_coord_0 = coords_array[0],
+	       y_coord_0 = coords_array[1],
+		   z_coord_0 = coords_array[2],
+	       x_coord_7 = coords_array[3],
+	       y_coord_7 = coords_array[4],
+	       z_coord_7 = coords_array[5];
+
+	if ( includeBuildings == YES ) {
+		z_coord_0 -= theSurfaceShift/ticksize;
+		z_coord_7 -= theSurfaceShift/ticksize;
+	}
+
+	for ( i = 0 ;i < 5; ++i ) {
+		keys_array[i] = 0;
+	}
+	/* these are  total 5 faces where elements needs to be traversed */
+
+	/* This takes care of 1 x face closer to origin */
+		if ( z_coord_0 <=  theDrmDepth )
+		if ( x_coord_0 <  theDrmXMin && x_coord_7 >= theDrmXMin )
+		if ( y_coord_0 <= theDrmYMax && y_coord_7 >= theDrmYMin ) {
+			cnt++;
+			keys_array[0] = 1;
+			if ( key==1 ) {
+				return 1;
+			}
+		}
+
+		/* This takes care of 1 x face far away from origin */
+		if ( z_coord_0 <= theDrmDepth )
+		if ( x_coord_0 <= theDrmXMax && x_coord_7 >  theDrmXMax )
+		if ( y_coord_0 <= theDrmYMax && y_coord_7 >= theDrmYMin){
+			cnt++;
+			keys_array[1] = 1;
+			if ( key==1 ) {
+				return 1;
+			}
+		}
+
+		/* This takes care of 1 y face closer to origin */
+		if ( z_coord_0 <=  theDrmDepth )
+		if ( y_coord_0 <  theDrmYMin  &&  y_coord_7 >= theDrmYMin )
+		if ( x_coord_0 <= theDrmXMax  &&  x_coord_7 >= theDrmXMin ){
+			cnt++;
+			keys_array[2] = 1;
+			if ( key==1 ) {
+				return 1;
+			}
+		}
+
+		/* This takes care of 1 y face far away from origin */
+		if ( z_coord_0 <=  theDrmDepth )
+		if ( y_coord_0 <= theDrmYMax  &&  y_coord_7 >  theDrmYMax )
+		if ( x_coord_0 <= theDrmXMax  &&  x_coord_7 >= theDrmXMin ){
+			cnt++;
+			keys_array[3] = 1;
+			if ( key==1 ) {
+				return 1;
+			}
+		}
+
+		/* This takes care of 1 z face */
+		if ( z_coord_0 <= theDrmDepth  && z_coord_7 >  theDrmDepth )
+		if ( x_coord_0 <= theDrmXMax   && x_coord_7 >= theDrmXMin )
+		if ( y_coord_0 <= theDrmYMax   && y_coord_7 >= theDrmYMin){
+			cnt++;
+			keys_array[4] = 1;
+			if( key==1 ) {
+				return 1;
+			}
+		}
+
+		return cnt;
+}
+
+/**
+ * Return  1 if an element is a drm boundary element and needs to be refined,
+ * Return  0 if an element is a drm boundary element and does not need to be refined,
+ * Return -1 if an element is not a drm element.
+ * This is for having same size elements in drm boundary to avoid dangling nodes */
+int drm_toexpand ( octant_t *leaf, double  ticksize, edata_t  *edata ) {
+
+	/* Send this keys_array even if we dont use it */
+	int    keys_array[5];
+	double coords_array[6];
+
+	/*These are in etree coordinates */
+	coords_array[0] = (leaf->lx);
+	coords_array[1] = (leaf->ly);
+	coords_array[2] = (leaf->lz);
+
+	coords_array[3] = (leaf->lx) + edata->edgesize/ticksize;
+	coords_array[4] = (leaf->ly) + edata->edgesize/ticksize;
+	coords_array[5] = (leaf->lz) + edata->edgesize/ticksize;
+
+	if ( is_drm_elem (coords_array, keys_array, 1, ticksize) ) {
+		if ( (double)edata->edgesize > theDrmEdgeSize )
+			return 1;
+		else
+			return 0;
+	}
+
+	return -1;
+}
+
+/*We  convert physical coordinates into etree coordinates*/
+void  drm_fix_coordinates(double ticksize) {
+
+	theDrmXMin  = theDrmXMin/ticksize;
+	theDrmYMin  = theDrmYMin/ticksize;
+	theDrmXMax  = theDrmXMax/ticksize;
+	theDrmYMax  = theDrmYMax/ticksize;
+	theDrmDepth = theDrmDepth/ticksize;
+}
+
+void solver_drm_close () {
+
+	if ( drmImplement == YES && theDrmPart == PART1 ) {
+
+		free(myDispWrite);
+		if ( myNumberOfDrmNodes != 0 ) {
+			hu_fclose(drmDisp);
+			free (myDrmNodes );
+		}
+	}
+
+	if ( drmImplement == YES && theDrmPart == PART2 ) {
+
+		int32_t i;
+
+		free (theDrmDisplacements1);
+	    free (theDrmDisplacements2);
+
+		for ( i = 0; i < myNumberOfDrmElements; i++ ) {
+			free( theDrmElem[i].lnid_b);
+			free( theDrmElem[i].lnid_e);
+		}
+		free (theDrmElem );
+	}
+}
+
+void drm_output(mesh_t *myMesh, int32_t myID, int32_t  theGroupSize,
+		        int *array_have_nodes, int64_t  *drm_array, drm_node_t *drm_node)
+{
+	FILE  *nodecoords;
+	FILE  *drminfo;
+	FILE  *procinfo;
+
+	double  x_coord, y_coord, z_coord;
+	int32_t i, procs_with_drm_nodes = 0;
+
+	static char    filename [256];
+
+	/* this is to avoid opening empty files */
+	if ( myNumberOfDrmNodes != 0 ) {
+
+		if ( theDrmPart == PART0 ) {
+			sprintf( filename, "%s%s_%d", theDrmOutputDir, "/part0/drm_coordinates", myID);
+		}
+
+		if ( theDrmPart == PART1 ) {
+			sprintf( filename, "%s%s_%d", theDrmOutputDir, "/part1/drm_coordinates", myID);
+		}
+
+		if ( (nodecoords = fopen(filename, "w")) == NULL ) {
+			fprintf(stderr, "Error opening %s\n", filename);
+		}
+
+		/* All processors which  have drm nodes  prints the number of its drm nodes first,
+		 * then prints the coordinates (after adding/subtracting the offset distances)
+		 * Also surface-shift is  taken care of */
+		hu_fwrite( &myNumberOfDrmNodes,   sizeof(int32_t), 1, nodecoords );
+
+		for ( i = 0; i < myNumberOfDrmNodes; ++i ) {
+			if ( theDrmPart == PART0 ) {
+				x_coord = myMesh->nodeTable[drm_array[i]].x*(myMesh->ticksize) + theX_Offset;
+				y_coord = myMesh->nodeTable[drm_array[i]].y*(myMesh->ticksize) + theY_Offset;
+
+				if ( includeBuildings == YES )
+					z_coord = myMesh->nodeTable[drm_array[i]].z*(myMesh->ticksize) - theSurfaceShift;
+				else
+					z_coord = myMesh->nodeTable[drm_array[i]].z*(myMesh->ticksize);
+			}
+			if ( theDrmPart == PART1 ) {
+				x_coord = drm_node[i].coords.x[0] - theX_Offset;
+				y_coord = drm_node[i].coords.x[1] - theY_Offset;
+				if ( includeBuildings == YES )
+					z_coord = drm_node[i].coords.x[2] - theSurfaceShift;
+				else
+					z_coord = drm_node[i].coords.x[2];
+			}
+
+			hu_fwrite( &x_coord, sizeof(double), 1, nodecoords );
+			hu_fwrite( &y_coord, sizeof(double), 1, nodecoords );
+			hu_fwrite( &z_coord, sizeof(double), 1, nodecoords );
+		}
+
+		fclose(nodecoords);
+	}
+
+	/* PE0 prints the number of drm nodes each processor has in a seperate file */
+	if ( myID == 0 ) {
+		for( i = 0 ;i < theGroupSize; ++i ) {
+			if ( array_have_nodes[i] )
+				procs_with_drm_nodes ++;
+		}
+
+		/* If in part 0  PE0 , first,  prints the number of processors that have drm nodes and their ids.
+		 * Second, prints the total number of nodes */
+		if ( theDrmPart == PART0 ) {
+			sprintf( filename, "%s%s", theDrmOutputDir, "/part0/drm_processor_info");
+			if ( (procinfo = fopen(filename, "w")) == NULL )
+				fprintf(stderr, "Error opening %s\n", filename);
+			hu_fwrite(&procs_with_drm_nodes, sizeof(int32_t), 1, procinfo);
+			for( i = 0; i < theGroupSize; ++i ) {
+				if ( array_have_nodes[i] ) {
+					hu_fwrite(&i, sizeof(int32_t), 1, procinfo);
+				}
+			}
+			hu_fwrite(&theNumberOfDrmNodes, sizeof(int32_t), 1, procinfo);
+			fclose(procinfo);
+			/* Moreover, PE0 prints the total number of drm nodes and drm elements respectively.
+			 * It is going to be used in PART2 */
+			sprintf( filename, "%s%s", theDrmOutputDir, "/part0/drm_information");
+			drminfo = hu_fopen ( filename, "w" );
+			fprintf(drminfo, "drm_numberofnodes = %d \ndrm_numberofelements = %d",
+					theNumberOfDrmNodes,theNumberOfDrmElements);
+			fclose(drminfo);
+		}
+
+		/* If in part 1  PE0 ,first, prints the total number of nodes and the total number of processors with drm nodes*/
+		/* Then prints how many drm nodes each processor has with the processor ids.*/
+		if ( theDrmPart == PART1 ) {
+			sprintf( filename, "%s%s", theDrmOutputDir, "/part1/drm_processor_info");
+			if ( (procinfo = fopen(filename, "w")) == NULL )
+				fprintf(stderr, "Error opening %s\n", filename);
+			hu_fwrite(&theNumberOfDrmNodes, sizeof(int32_t), 1, procinfo);
+			hu_fwrite(&procs_with_drm_nodes, sizeof(int32_t), 1, procinfo);
+			for( i = 0; i < theGroupSize; ++i ) {
+				if ( array_have_nodes[i] ) {
+					hu_fwrite(&i, sizeof(int32_t), 1, procinfo);
+					hu_fwrite(&array_have_nodes[i], sizeof(int32_t), 1, procinfo);
+				}
+			}
+			fclose(procinfo);
+		}
+		if ( myNumberOfDrmNodes != 0 ) {
+			free(drm_array);
+		}
+	}
+}
+
+/*
+ * Prints statistics about number of drm nodes.
+ */
+void drm_print_stats(int32_t *drmNodesCount, int32_t  theGroupSize,
+		double   theXForMeshOrigin, double   theYForMeshOrigin,
+		double   theZForMeshOrigin)
+{
+	FILE *fp;
+
+	int pid;
+
+	peshavenodes = 0;
+
+	if ( theDrmPart == PART0 ) {
+		fp = hu_fopen( "stat-drm-part0.txt", "w" );
+	}
+
+	if ( theDrmPart == PART1 ) {
+		fp = hu_fopen( "stat-drm-part1.txt", "w" );
+	}
+
+	if ( theDrmPart == PART2 ) {
+		fp = hu_fopen( "stat-drm-part2.txt", "w" );
+	}
+
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+		if (drmNodesCount[pid] != 0) {
+			peshavenodes++;
+		}
+	}
+
+	fprintf( fp, " %d in %d pes have drm nodes \n", peshavenodes, theGroupSize );
+
+	fputs( "\n"
+			"# ---------------------------------------- \n"
+			"# Drm Nodes Count:                         \n"
+			"# ---------------------------------------- \n"
+			"# Rank       Nodes                         \n"
+			"# ---------------------------------------- \n", fp );
+
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+
+		if (drmNodesCount[pid] != 0) {
+			peshavenodes++;
+			fprintf( fp, "%06d %11d\n", pid, drmNodesCount[pid] );
+		}
+	}
+
+	if ( theDrmPart != PART2 ) {
+
+		fprintf( fp,
+				"# ---------------------------------------- \n"
+				"# Total%11d   \n"
+				"# ---------------------------------------- \n\n",
+				theNumberOfDrmNodes );
+	}
+
+
+	if ( theDrmPart == PART2 ) {
+
+		fprintf( fp,
+				"# ---------------------------------------- \n"
+				"# Total%11d (a common node may appear in multiple pes, so likely to be higher than the actual value)  \n"
+				"# ---------------------------------------- \n\n",
+				theNumberOfDrmNodes );
+	}
+	hu_fclosep( &fp );
+
+	/* output aggregate information to the monitor file / stdout */
+	fprintf( stdout,
+			"\nDrm  information\n"
+			"Origin of the sub region   x = %f\n"
+			"                           y = %f\n"
+			"                           z = %f\n"
+			"Drm Part:                  Part %d\n"
+			"Total number of drm nodes: %d",
+			theXForMeshOrigin,
+			theYForMeshOrigin,
+			theZForMeshOrigin,
+			theDrmPart,
+			theNumberOfDrmNodes);
+
+	if ( theDrmPart == PART2 ) {
+	fprintf( stdout, " (a common node may appear in multiple pes, so likely to be higher than the actual value)" );
+	}
+
+	fprintf( stdout,	"\n\n" );
+
+	fflush( stdout );
+}
+
+/*
+ * Collects statistics about number of drm nodes
+ */
+void drm_stats(int32_t  myID, int32_t  theGroupSize,
+		double   theXForMeshOrigin, double   theYForMeshOrigin,
+		double   theZForMeshOrigin)
+{
+	int32_t *drmNodesCount = NULL;
+
+	if ( myID == 0 ) {
+		XMALLOC_VAR_N( drmNodesCount, int32_t, theGroupSize);
+	}
+
+	MPI_Gather( &myNumberOfDrmNodes, 1, MPI_INT,
+			drmNodesCount,       1, MPI_INT, 0, comm_solver );
+
+	if ( myID == 0 ) {
+
+		drm_print_stats( drmNodesCount, theGroupSize,theXForMeshOrigin,
+				theYForMeshOrigin, theZForMeshOrigin);
+
+		xfree_int32_t( &drmNodesCount );
+	}
+
+	return;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                           Functions for Part0                              */
+/* -------------------------------------------------------------------------- */
+
+/*Find the drm nodes for PART0, store them in a hashtable avoiding duplicates.
+ *And print the coordinates of these nodes
+ */
+void find_drm_nodes( mesh_t     *myMesh,       int32_t   myID,
+					 const char *parametersin, double    ticksize,
+					 int32_t    theGroupSize)
+{
+	int have_drm_nodes = 0;  /* 1 if yes , 0 otherwise */
+	int i, j, k, owner;
+
+	/* These are for communication of PE0 with other processors. dup_nodes are
+	 * the nodes that I touch but are not owned by me  (owned by other processors.)
+	 * */
+
+	/* For PE0 to receive dup_nodes */
+	int64_t  *dup_nodes[theGroupSize];
+	 /* For PE0 to send dup_nodes after eliminating duplicates */
+	int64_t  *dup_nodes_to_send[theGroupSize];
+	int32_t   dup_nodes_count_send[theGroupSize]; /* For PE0 */
+	int      *dup_owners[theGroupSize]; /* For PE0 to receive dup_nodes owners */
+
+	int       dup_nodes_count = 0; /* For  all processors*/
+	int64_t  *dup_nodes_to_recieve; /* For all processors*/
+
+	/* For PE0 to eliminate duplicates from received dup_nodes  */
+	drmhash_t  dups[theGroupSize];
+
+	MPI_Status status;
+
+	/* Allocate memory */
+	if (myID == 0) {
+		XMALLOC_VAR_N( pesHaveDrmNodes, int32_t, theGroupSize );
+		XMALLOC_VAR_N( dupNodesCount, int32_t, theGroupSize );
+	}
+
+	/* Need to determine TableDim for HashTable. Need to know number of elements
+	 * for this. */
+	search_drm_elems(myMesh, 0);
+
+	/* Besides storing drm nodes that I own, also store drm nodes owned by other
+	 * processors in a seperate hashtable.
+	 */
+	if (myNumberOfDrmElements != 0)
+	{
+		/* Get tableDims for theDrmTable and theDrmDupTable */
+		get_table_dim(&theTableDim, myNumberOfDrmElements);
+		/* Assume theTableDupDim is approximately 1/16 th of theTableDim*/
+		get_table_dim(&theTableDupDim, (int32_t)(myNumberOfDrmElements/16));
+		/*  Init theDrmTable to store ids of nodes , whose  displacements/
+		 * coordinates  will be  stored afterwards */
+		drm_table_init(&theDrmTable, theTableDim);
+		/*Also init theDrmDupTable */
+		drm_table_init(&theDrmDupTable, theTableDupDim);
+		/* Find drm nodes that I own  and store them in hashtable avoiding duplicates.
+		 * Also find drm nodes that I do not own, store them in another hashtable
+		 * along with their owner processor ids. */
+		search_drm_elems(myMesh, 1);
+		/* construct an array with the non-sorted global ids of drm nodes
+		 * which are not owned by me. Also construct an array with the ids of
+		 * owner processors.*/
+		construct_drm_array(&theDrmDupTable, theTableDupDim, myNumberOfDupDrmNodes,
+				&drmDupNodesIds, 2);
+	}
+
+	/* This part is mainly the communication b/w PE0 and other processors.First,
+	 * all processors send their dup_nodes(nodes owned by other PEs) to PE0 along
+	 * with their owner PEids.After merging all dup_nodes ,coming from each PE,
+	 * Pe0 checks for duplicates, and sends those node ids to owner PEs. */
+
+	/* Send theDrmDupTable to PE0. Then it sends it to owner processor.*/
+	MPI_Gather(&myNumberOfDupDrmNodes, 1, MPI_INT, dupNodesCount,
+			1, MPI_INT, 0, comm_solver);
+
+	if ( myID == 0) {
+		for ( i = 0; i < theGroupSize; ++i ) {
+			if ( dupNodesCount[i] != 0 && i != 0 ) {
+				XMALLOC_VAR_N( dup_nodes[i], int64_t, dupNodesCount[i] );
+				XMALLOC_VAR_N( dup_owners[i], int32_t, dupNodesCount[i] );
+			}
+			/* This is used to collect dup_nodes according to owner PE id */
+			drm_table_init(&(dups[i]), 89);
+		}/* make it 89 for the time being */
+	}
+
+	/* Processors (with dup_nodes) send dup_nodes to PE0 along with their owner PE id */
+	if ( myID != 0 && myNumberOfDupDrmNodes != 0 ) {
+		MPI_Send( drmDupNodesIds, myNumberOfDupDrmNodes, MPI_LONG_LONG_INT, 0, myID, comm_solver );
+		MPI_Send( drmNodeOwner, myNumberOfDupDrmNodes, MPI_INT, 0, myID + 1, comm_solver );
+	}
+
+	/* PE0 receives what other PEs send to it.*/
+	if ( myID == 0) {
+
+		for( i = 1; i < theGroupSize; ++i ) {
+			if( dupNodesCount[i] != 0 ) {
+				MPI_Recv( dup_nodes[i], dupNodesCount[i], MPI_LONG_LONG_INT, i, i, comm_solver, &status );
+				MPI_Recv( dup_owners[i], dupNodesCount[i], MPI_INT, i, i+1, comm_solver, &status );
+			}
+		}
+
+		/* Then it eliminates the duplicates and merges dup_nodes wrt owner PE id */
+		/* This is for dup_nodes PE0 has */
+		for ( j = 0; j < myNumberOfDupDrmNodes; ++j ) {
+			k = drmDupNodesIds[j] % 89;
+			owner = drmNodeOwner[j];
+			insert(drmDupNodesIds[j], k, &(dups[owner]), NONE);
+		}
+
+		/* This is for dup_nodes coming from other PEs  */
+		for ( i = 1; i < theGroupSize; ++i ) {
+			for ( j = 0; j < dupNodesCount[i]; ++j ) {
+				k = dup_nodes[i][j] % 89;
+				owner = dup_owners[i][j];
+				insert(dup_nodes[i][j], k, &(dups[owner]), NONE);
+			}
+		}
+
+		/* It constructs arrays using hashtables ,filled with dup_nodes, for each
+		 * PE who owns dup_nodes.Then it sends these arrays to owner PEs*/
+		for ( i = 0; i < theGroupSize; ++i ) {
+			dup_nodes_count_send[i] = dups[i].tableCnt;
+
+			if ( dup_nodes_count_send[i] != 0 ) {
+				construct_drm_array(&(dups[i]),89,dup_nodes_count_send[i],&dup_nodes_to_send[i],1);
+			}
+
+			if ( i != 0 ) {
+				MPI_Send( &(dup_nodes_count_send[i]), 1 , MPI_INT, i, i, comm_solver );
+				if ( dup_nodes_count_send[i] != 0 ) {
+					MPI_Send( dup_nodes_to_send[i], dup_nodes_count_send[i], MPI_LONG_LONG_INT, i, i+1, comm_solver );
+				}
+			}
+		}
+	}
+
+	/*PEs other than PE0 receives global id of their drm_dup_nodes*/
+	if ( myID != 0 ) {
+		MPI_Recv( &dup_nodes_count, 1, MPI_INT, 0, myID, comm_solver, &status );
+		if ( dup_nodes_count != 0 ) {
+			XMALLOC_VAR_N( dup_nodes_to_recieve, int64_t, dup_nodes_count );
+			MPI_Recv( dup_nodes_to_recieve, dup_nodes_count, MPI_LONG_LONG_INT, 0, myID+1, comm_solver, &status );
+		}
+	}
+
+	if ( myID == 0) {
+		dup_nodes_count = dup_nodes_count_send[0];
+		dup_nodes_to_recieve = dup_nodes_to_send[0];
+	}
+
+	/* If I have drm_elements insert dup_nodes to hashtable to eliminate
+	 * duplicates */
+	if ( myNumberOfDrmElements != 0 ) {
+		for ( i = 0; i < dup_nodes_count; ++i ) {
+			for ( j = 0; j < myMesh->nharbored; ++j ) {
+				if ( dup_nodes_to_recieve[i] == myMesh->nodeTable[j].gnid ) {
+
+					k = j % theTableDim;
+					insert(j, k, &theDrmTable, NONE );
+
+				}
+			}
+		}
+		/* Update the number of drm nodes */
+		myNumberOfDrmNodes = theDrmTable.tableCnt;
+		/* construct an array with the sorted local nodal ids of drm nodes .*/
+		construct_drm_array(&theDrmTable, theTableDim, myNumberOfDrmNodes, &drmNodeIds, 1);
+	}
+
+	/* If I do not have any drm_elems, then automatically print the coordinates of
+	 * the nodes. But first need to find the local ids.No need of hashtable since
+	 * duplicates are already checked by PE0 */
+	if ( myNumberOfDrmElements == 0 ) {
+		k = 0;
+		/* only number of nodes is updated, number of elements does not change */
+		myNumberOfDrmNodes = dup_nodes_count;
+		if ( myNumberOfDrmNodes != 0 ) {
+			XMALLOC_VAR_N( drmNodeIds, int64_t, dup_nodes_count );
+			for ( i = 0; i < dup_nodes_count; ++i ) {
+				for ( j = 0; j < myMesh->nharbored; ++j ) {
+					if ( dup_nodes_to_recieve[i] == myMesh->nodeTable[j].gnid ) {
+						drmNodeIds[k] = j;
+						k++;
+					}
+				}
+			}
+			/* PE0 prints later */
+			if ( myID != 0 ) {
+				drm_output (myMesh, myID, theGroupSize, pesHaveDrmNodes, drmNodeIds, NULL);
+			}
+		}
+	}
+	/* Find total number of drm nodes and elements .*/
+	MPI_Reduce(&myNumberOfDrmNodes, &theNumberOfDrmNodes, 1, MPI_INT, MPI_SUM, 0, comm_solver);
+	MPI_Reduce(&myNumberOfDrmElements, &theNumberOfDrmElements, 1, MPI_INT, MPI_SUM, 0, comm_solver);
+
+	/*This is useful when printing coordinates to avoid opening empty files*/
+	if ( myNumberOfDrmNodes != 0 ) {
+		have_drm_nodes = 1;
+	}
+	/*Pe0 gathers the array of pes_have_elems.*/
+	MPI_Gather(&have_drm_nodes, 1, MPI_INT, pesHaveDrmNodes,
+			1, MPI_INT, 0, comm_solver);
+
+	/* PE0 prints data even it does not have any drm nodes */
+	if ( myNumberOfDrmElements != 0 || myID == 0 ) {
+		/* output the drm_node_table*/
+		drm_output(myMesh, myID, theGroupSize,pesHaveDrmNodes, drmNodeIds, NULL);
+	}
+
+	/* Now free all the allocated memory */
+	/* Free in PE0 only */
+	if ( myID == 0 ) {
+		for( i = 0; i < theGroupSize; ++i ) {
+			if ( dupNodesCount[i] != 0 && i != 0 ) {
+				free(dup_nodes[i]);
+				free(dup_owners[i]);
+			}
+
+			if ( dup_nodes_count_send[i] != 0 ) {
+				free(dup_nodes_to_send[i]);
+			}
+			freeHashTable(&(dups[i]), 89);
+		}
+		free(pesHaveDrmNodes);
+		free(dupNodesCount);
+	}
+
+	/* Free processors other than PE0 only */
+	if ( myID != 0 ) {
+		if ( dup_nodes_count != 0 ) {
+			free(dup_nodes_to_recieve);
+		}
+	}
+
+	/*free Hashtables */
+	if ( myNumberOfDrmElements != 0 ) {
+		freeHashTable(&theDrmTable, theTableDim);
+		freeHashTable(&theDrmDupTable, theTableDupDim);
+		if ( myNumberOfDupDrmNodes != 0 ) {
+			free(drmNodeOwner);
+			free(drmDupNodesIds);
+		}
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/*                           Functions for Part1                              */
+/* -------------------------------------------------------------------------- */
+/**
+ * Prepare all the info every drm node needs once it is located in a processor
+ */
+void setup_drm_data(mesh_t *myMesh, int32_t myID,  int32_t   theGroupSize) {
+
+	int      have_drm_nodes = 0;  /* 1 if yes , 0 otherwise */
+
+	int32_t  i, iLocal = 0;
+	int32_t  *drmNodesCount = NULL;
+
+	vector3D_t drm_node_coords;
+	octant_t   *octant;
+
+	char       filename [256];
+
+	/* look for the drm nodes in the domain each processor has */
+	for ( i = 0; i < theNumberOfDrmNodes; i++ ) {
+		drm_node_coords.x[0] = theDrmNodeCoords[i].f[0];
+		drm_node_coords.x[1] = theDrmNodeCoords[i].f[1];
+		drm_node_coords.x[2] = theDrmNodeCoords[i].f[2];
+		if ( search_point( drm_node_coords, &octant ) == 1 ) {
+			myNumberOfDrmNodes++;
+		}
+	}
+
+	/* Allocate memory */
+	if (myID == 0) {
+		XMALLOC_VAR_N( pesHaveDrmNodes, int32_t, theGroupSize );
+	}
+
+	/*This is useful when printing coordinates to avoid opening empty files*/
+	if ( myNumberOfDrmNodes != 0 ) {
+		have_drm_nodes = 1;
+	}
+	/*Pe0 gathers the array of pes_have_elems.*/
+	MPI_Gather(&have_drm_nodes, 1, MPI_INT, pesHaveDrmNodes,
+			1, MPI_INT, 0, comm_solver);
+
+	/* allocate memory if necessary and generate the list of drm nodes per
+	 * processor. Do not go any further if I do not have any drm nodes */
+	if ( myNumberOfDrmNodes != 0 ) {
+		/* Open files to write displacements. First print the total number of drm nodes */
+		sprintf(filename, "%s%s_%d", theDrmOutputDir, "/part1/drm_disp", myID);
+		drmDisp = hu_fopen( filename,"w" );
+		hu_fwrite( &myNumberOfDrmNodes,  sizeof(int32_t), 1, drmDisp );
+		XMALLOC_VAR_N(myDrmNodes, drm_node_t, myNumberOfDrmNodes);
+
+		for ( i = 0; i < theNumberOfDrmNodes; i++ ) {
+			drm_node_coords.x[0] = theDrmNodeCoords[i].f[0];
+			drm_node_coords.x[1] = theDrmNodeCoords[i].f[1];
+			drm_node_coords.x[2] = theDrmNodeCoords[i].f[2];
+
+			if (search_point( drm_node_coords, &octant ) == 1) {
+				myDrmNodes[iLocal].id = i;
+				myDrmNodes[iLocal].coords = drm_node_coords;
+
+				compute_csi_eta_dzeta(octant, myDrmNodes[iLocal].coords,
+						&(myDrmNodes[iLocal].localcoords),
+						myDrmNodes[iLocal].nodestointerpolate);
+				iLocal += 1;
+			}
+		}
+	}
+
+	free(theDrmNodeCoords);
+
+	/* These are for drm_output */
+	if ( myID == 0 ) {
+		XMALLOC_VAR_N( drmNodesCount, int32_t, theGroupSize);
+	}
+
+	MPI_Gather( &myNumberOfDrmNodes, 1, MPI_INT,
+				drmNodesCount,       1, MPI_INT, 0, comm_solver );
+
+	/* PE0 prints data even if it does not have any drm nodes */
+	if ( myNumberOfDrmNodes != 0 || myID == 0 ) {
+		/* output the drm_node_table*/
+		drm_output(myMesh, myID, theGroupSize, drmNodesCount, NULL, myDrmNodes);
+	}
+}
+
+
+void solver_output_drm_nodes ( mysolver_t* mySolver,int step, int32_t totalsteps) {
+
+	Timer_Start("Solver drm output");
+
+	if ( drmImplement == YES && theDrmPart == PART1 && myNumberOfDrmNodes != 0 )
+	{
+		if (step % theDrmPrintRate == 0 || step == totalsteps - 1) {
+
+			//printf("%d ",step);
+			int iPhi;
+			/* Auxiliary array to handle shape functions in a loop */
+			double  xi[3][8]={ {-1,  1, -1,  1, -1,  1, -1, 1} ,
+					{-1, -1,  1,  1, -1, -1,  1, 1} ,
+					{-1, -1, -1, -1,  1,  1,  1, 1} };
+
+			double     phi[8];
+			double     dis_x, dis_y, dis_z;
+			int32_t    i,nodesToInterpolate[8];;
+			vector3D_t localCoords; /* convenient renaming */
+
+			if ( step == 0) {
+				XMALLOC_VAR_N( myDispWrite, double, myNumberOfDrmNodes*3 );
+			}
+
+			for ( i = 0; i < myNumberOfDrmNodes; i++ ) {
+
+				localCoords = myDrmNodes[i].localcoords;
+
+				for ( iPhi = 0; iPhi < 8; iPhi++ ) {
+					nodesToInterpolate[iPhi] = myDrmNodes[i].nodestointerpolate[iPhi];
+				}
+
+				/* Compute interpolation function (phi) for each node and
+				 * load the displacements
+				 */
+				dis_x = 0;
+				dis_y = 0;
+				dis_z = 0;
+
+				for ( iPhi = 0; iPhi < 8; iPhi++ ) {
+					phi[ iPhi ] = ( 1 + xi[0][iPhi]*localCoords.x[0] )
+		             			* ( 1 + xi[1][iPhi]*localCoords.x[1] )
+		             			* ( 1 + xi[2][iPhi]*localCoords.x[2] ) / 8;
+
+					dis_x += phi[iPhi] * mySolver->tm1[ nodesToInterpolate[iPhi] ].f[0];
+					dis_y += phi[iPhi] * mySolver->tm1[ nodesToInterpolate[iPhi] ].f[1];
+					dis_z += phi[iPhi] * mySolver->tm1[ nodesToInterpolate[iPhi] ].f[2];
+				}
+
+				myDispWrite [3*i]   = dis_x;
+				myDispWrite [3*i+1] = dis_y;
+				myDispWrite [3*i+2] = dis_z;
+			}
+
+			fwrite( myDispWrite, sizeof(double), myNumberOfDrmNodes*3, drmDisp );
+
+		}
+	}
+	Timer_Stop("Solver drm output");
+
+}
+
+/* -------------------------------------------------------------------------- */
+/*                           Functions for Part2                              */
+/* -------------------------------------------------------------------------- */
+
+/* Find which nodes are exterior and which of them are interior in drm elements
+ * according to their positions.*/
+void proc_drm_elems( mesh_t   *myMesh,     int32_t   myID,
+		int32_t theGroupSize, int32_t theTotalSteps) {
+
+	Timer_Start("Find Drm File To Readjust");
+
+	find_drm_file_readjust ( theGroupSize, myID, theTotalSteps  ) ;
+
+	Timer_Stop("Find Drm File To Readjust");
+	Timer_Reduce("Find Drm File To Readjust", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+
+	Timer_Start("Fill Drm Struct");
+
+	/* keys are used to determine interior and exterior nodes.x_key_1 is for
+	 * x face that is closer to origin, x_key_2 is for far away x face. Other
+	 * keys have similar meanings. They are turned on if elements are in any of
+	 * these faces */
+
+	int32_t   i, n_0, n_7, iDrmElem = 0;
+	int32_t   x_key_1 , x_key_2 , y_key_1, y_key_2, depth_key;
+
+	/* Allocate memory for theDrmElem.First find the number of drm elements I own
+	 */
+	search_drm_elems(myMesh, 0);
+
+	/* Check if total number of drm elements is same as the total number of elements
+	 * from part0.
+	 */
+	drm_sanity_check(myID);
+
+	if (myNumberOfDrmElements != 0) {
+
+		/* First find drm nodes each processor has.*/
+
+		/* Get tableDims for theDrmTable */
+		get_table_dim(&theTableDim, myNumberOfDrmElements);
+		/*  Init theDrmTable to store ids of drm nodes. */
+		drm_table_init(&theDrmTable, theTableDim);
+		/* Find drm nodes that I own  and store them in hashtable avoiding duplicates.*/
+		search_drm_elems(myMesh, 1);
+		/* construct an array with the sorted local nodal ids of drm nodes .*/
+		construct_drm_array(&theDrmTable, theTableDim, myNumberOfDrmNodes, &drmNodeIds, 1);
+		/* Drm node local ids are stored in drmNodeIds now. */
+
+		/* Fill drmElem struct now. */
+
+		XMALLOC_VAR_N( theDrmElem, drm_elem_t, myNumberOfDrmElements );
+
+		/* Loop each element to fill drm element struct.
+		 */
+		for ( i = 0; i < (myMesh->lenum ); ++i ) {
+
+			int    res;
+			int    keys_array[5];
+			double coords_array[6];
+
+			/* n_0 and n_7 are local nodal id's of 0th and 7th node.
+			 * Coordinates of 7th node are always bigger than 0th node.
+			 * */
+
+			n_0 = myMesh->elemTable[i].lnid[0]; /* looking at first node of the element(at top) */
+			n_7 = myMesh->elemTable[i].lnid[7]; /* looking at last node of the element(at bottom) */
+
+			/* these are  coordinates of 0th  node  */
+			coords_array[0] = myMesh->nodeTable[n_0].x;
+			coords_array[1] = myMesh->nodeTable[n_0].y;
+			coords_array[2] = myMesh->nodeTable[n_0].z;
+
+			/* these are  coordinates of 7th node  */
+			coords_array[3] = myMesh->nodeTable[n_7].x;
+			coords_array[4] = myMesh->nodeTable[n_7].y;
+			coords_array[5] = myMesh->nodeTable[n_7].z;
+
+			/* we need to find the values for the keys.
+			 * these are  total 5 faces where elements needs to be traversed
+			 * we always try to keep inside boundary as large  as possible if
+			 * given limits intersect with element sides.*/
+
+			res = is_drm_elem(coords_array,keys_array,2, myMesh->ticksize);
+
+			x_key_1   = keys_array[0];
+			x_key_2   = keys_array[1];
+			y_key_1   = keys_array[2];
+			y_key_2   = keys_array[3];
+			depth_key = keys_array[4];
+
+			/*NOW CONSIDER DIFFERENT CASES.There are 18 different cases */
+
+			/*Do nothing if it is not a drm element */
+			if ( res == 0 ) {
+				continue;
+			}
+
+			/* Start to fill struct if it is drm element */
+			(theDrmElem[iDrmElem]).leid = i;
+
+			/* NEAR X FACE */
+
+			/* Element is on near x face, has 4 boundary and exterior nodes */
+			if ( x_key_1 == 1 && y_key_1 == 0  && y_key_2 == 0  && depth_key == 0 ){
+				int bound_ids[4]    = {1,3,5,7};
+				int exterior_ids[4] = {0,2,4,6};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 1, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  near x face and near y face intersection, but
+			 * away from depth (z) face. It has 2 boundary nodes and 6 exterior
+			 * nodes */
+			if ( x_key_1 == 1 && y_key_1 == 1  && depth_key == 0 ) {
+				int bound_ids[2]    = {3,7};
+				int exterior_ids[6] = {0,1,2,4,5,6};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  near x face and far y face intersection, but
+			 * away from depth (z) face. It has 2 boundary nodes and 6 exterior
+			 * nodes */
+			if ( x_key_1 == 1 &&  y_key_2 == 1  && depth_key == 0 ) {
+				int bound_ids[2]    = {1,5};
+				int exterior_ids[6] = {0,2,3,4,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  near x face and near y face intersection, also
+			 * intersects with depth (z) face. It has 1 boundary node and 7 exterior
+			 * nodes */
+			if ( x_key_1 == 1 && y_key_1 == 1  && depth_key == 1 ) {
+				int bound_ids[1]    = {3};
+				int exterior_ids[7] = {0,1,2,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 3, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  near x face and far y face intersection, also
+			 * intersects with depth (z) face. It has 1 boundary node and 7 exterior
+			 * nodes */
+			if ( x_key_1 == 1 && y_key_2 == 1  && depth_key == 1 ) {
+				int bound_ids[1]    = {1};
+				int exterior_ids[7] = {0,2,3,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 3, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  near x face and also intersects with depth (z)
+			 * face. It has 2 boundary node and 6 exterior nodes */
+			if ( x_key_1 == 1 && y_key_1 == 0  && y_key_2 == 0  && depth_key == 1 ) {
+				int bound_ids[2]    = {1,3};
+				int exterior_ids[6] = {0,2,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* NEAR Y FACE */
+
+			/* Element is on near y face, has 4 boundary and exterior nodes */
+			if ( y_key_1 == 1 && x_key_1 == 0  && x_key_2 == 0  && depth_key == 0 ) {
+				int bound_ids[4]    = {2,3,6,7};
+				int exterior_ids[4] = {0,1,4,5};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 1, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  near y face and also intersects with depth (z)
+			 * face. It has 2 boundary node and 6 exterior nodes */
+			if ( y_key_1 == 1 && x_key_1 == 0  && x_key_2 == 0  && depth_key == 1 ) {
+				int bound_ids[2]    = {2,3};
+				int exterior_ids[6] = {0,1,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* FAR X FACE */
+
+			/* Element is on far x face, has 4 boundary and exterior nodes */
+			if ( x_key_2 == 1 && y_key_1 == 0  && y_key_2 == 0  && depth_key == 0 ) {
+				int bound_ids[4]    = {0,2,4,6};
+				int exterior_ids[4] = {1,3,5,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 1, bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  far x face and near y face intersection, but
+			 * away from depth (z) face. It has 2 boundary nodes and 6 exterior
+			 * nodes */
+			if ( x_key_2 == 1 && y_key_1 == 1  && depth_key == 0 ) {
+				int bound_ids[2]    = {2,6};
+				int exterior_ids[6] = {0,1,3,4,5,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2 , bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  far x face and far y face intersection, but
+			 * away from depth (z) face. It has 2 boundary nodes and 6 exterior
+			 * nodes */
+			if ( x_key_2 == 1  && y_key_2 == 1  && depth_key == 0 ) {
+				int bound_ids[2]    = {0,4};
+				int exterior_ids[6] = {1,2,3,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2 , bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  far x face and near y face intersection, also
+			 * intersects with depth (z) face. It has 1 boundary node and 7 exterior
+			 * nodes */
+			if ( x_key_2 == 1 && y_key_1 == 1   && depth_key == 1 ) {
+				int bound_ids[1]    = {2};
+				int exterior_ids[7] = {0,1,3,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 3 , bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  far x face and far y face intersection, also
+			 * intersects with depth (z) face. It has 1 boundary node and 7 exterior
+			 * nodes */
+			if ( x_key_2 == 1  && y_key_2 == 1  && depth_key == 1 ) {
+				int bound_ids[1]    = {0};
+				int exterior_ids[7] = {1,2,3,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 3 , bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  far x face and also intersects with depth (z)
+			 * face. It has 2 boundary node and 6 exterior nodes */
+			if ( x_key_2 == 1 && y_key_1 == 0  && y_key_2 == 0  && depth_key == 1 ) {
+				int bound_ids[2]    = {0,2};
+				int exterior_ids[6] = {1,3,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2 , bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* FAR Y FACE */
+
+			/* Element is on far y face, has 4 boundary and exterior nodes */
+			if ( y_key_2 == 1 && x_key_1 == 0  && x_key_2 == 0  && depth_key == 0 ) {
+				int bound_ids[4]    = {0,1,4,5};
+				int exterior_ids[4] = {2,3,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 1 , bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* Element is at the  far y face and also intersects with depth (z)
+			 * face. It has 2 boundary node and 6 exterior nodes */
+			if ( y_key_2 == 1 && x_key_1 == 0  && x_key_2 == 0  && depth_key == 1 ) {
+				int bound_ids[2]    = {0,1};
+				int exterior_ids[6] = {2,3,4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 2 , bound_ids, exterior_ids );
+				continue;
+			}
+
+			/* WE DEALT EVERYTHING EXCEPT DEPTH(z) FACE*/
+
+			/* Element is on depth (z) face, has 4 boundary and exterior nodes */
+			if ( x_key_1 == 0 && x_key_2 == 0 && y_key_1 == 0  && y_key_2 == 0  && depth_key == 1 ) {
+				int bound_ids[4]    = {0,1,2,3};
+				int exterior_ids[4] = {4,5,6,7};
+				iDrmElem = fill_drm_struct(myMesh, iDrmElem, 1 , bound_ids, exterior_ids );
+				continue;
+			}
+		}
+	}
+
+
+	Timer_Stop("Fill Drm Struct");
+	Timer_Reduce("Fill Drm Struct", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+
+	Timer_Start("Comm of Drm Coordinates");
+
+	comm_drm_coordinates ( myMesh, theGroupSize, myID );
+
+	Timer_Stop("Comm of Drm Coordinates");
+	Timer_Reduce("Comm of Drm Coordinates", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+
+	rearrange_drm_files ( myMesh, theGroupSize, myID );
+
+}
+
+void find_drm_file_readjust ( int32_t theGroupSize, int32_t myID, int32_t theTotalSteps ) {
+
+	int32_t   i, pid, interval, total_pes_used = 0, max_pes_used_id = 0;
+	double   *pes_desired;
+	double 	 *pes_remainder;
+	int      timesteps_files; // total steps in drm files due to drm_print_rate
+
+	XMALLOC_VAR_N( pes_per_file, int32_t, drmFilesCount );
+	XMALLOC_VAR_N( pes_desired, double, drmFilesCount );
+	XMALLOC_VAR_N( pes_remainder, double, drmFilesCount );
+
+	timesteps_files = theTotalSteps/theDrmPrintRate;
+	/*
+	// For testing
+	for ( pid = 0; pid < drmFilesCount; pid++ ) {
+		partOneDrmNodesCnt[pid].count=10*pid;
+	}
+	theNumberOfDrmNodes=450;
+	 */
+
+	/* need to find out which file I need to open*/
+	for ( pid = 0; pid < drmFilesCount; pid++ ) {
+		double aux;
+		aux = (double)(theGroupSize)
+			* (double)(partOneDrmNodesCnt[pid].count)
+			/ (double)theNumberOfDrmNodes; /* at this point this is the desired value*/
+		pes_desired[pid] = aux;
+		pes_remainder[pid] = aux - 1; //Since we assign at least one processor to each file
+		pes_per_file[pid] = 1;
+	}
+
+	/*
+	// For testing
+	if (myID == 0)
+		for ( pid = 0; pid < drmFilesCount; pid++ ) {
+			printf( " %d - %f %f \n",pid,pes_desired[pid],pes_remainder[pid]);
+		}
+	 */
+
+	/* Distribute the remaining processors to the files */
+	for ( i = 0; i < (theGroupSize-drmFilesCount); ++i ) {
+		max_pes_used_id = 0;
+		for ( pid = 1; pid < drmFilesCount; pid++ ) {
+			if ( (double)(pes_remainder[pid] / pes_desired[pid]) >
+			(double)(pes_remainder[max_pes_used_id] / pes_desired[max_pes_used_id]) ) {
+				max_pes_used_id = pid;
+			}
+		}
+		pes_remainder[max_pes_used_id] = pes_remainder[max_pes_used_id] - 1.0;
+		pes_per_file[max_pes_used_id]++;
+	}
+
+	/* sanity check */
+	for ( pid = 0; pid < drmFilesCount; pid++ ) {
+		if ( pes_per_file[pid] <= 0 ) {
+			fprintf( stderr,
+					"Something went wrong in find_drm_file_readjust1.Negative pes number" );
+			MPI_Abort(MPI_COMM_WORLD, ERROR);
+			exit(1);
+		}
+		total_pes_used += pes_per_file[pid];
+	}
+
+	if ( total_pes_used != theGroupSize ) {
+		fprintf( stderr,
+				"Something went wrong in find_drm_file_readjust2." );
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	}
+	/* Now find which file to open and the offset  */
+
+	total_pes_used = 0;
+
+	for ( pid = 0; pid < drmFilesCount; pid++ ) {
+
+		total_pes_used += pes_per_file[pid];
+
+		if ( total_pes_used > myID ) {
+
+			/* Necessary for comm */
+
+			XMALLOC_VAR_N( rank, int32_t, pes_per_file[pid] );
+
+			for ( i = 0; i < pes_per_file[pid]; i++ ) {
+				rank[i] = total_pes_used - pes_per_file[pid] + i;
+			}
+
+			interval = (int)( 1 + (double)timesteps_files / (double)pes_per_file[pid]);
+
+			drmFileToOpen.cid = pid;
+			drmFileToOpen.id = partOneDrmNodesCnt[pid].id;
+			drmFileToOpen.root_pe = total_pes_used - pes_per_file[pid];
+			drmFileToOpen.pos = myID  - drmFileToOpen.root_pe;
+			drmFileToOpen.step_to_start = interval * drmFileToOpen.pos;
+			drmFileToOpen.step_to_end = drmFileToOpen.step_to_start + interval;
+
+			if ( drmFileToOpen.step_to_start >= timesteps_files ) {
+				fprintf( stderr,
+						"Something went wrong in find_drm_file_readjust3" );
+				MPI_Abort(MPI_COMM_WORLD, ERROR);
+				exit(1);
+			}
+
+			if( drmFileToOpen.step_to_end > timesteps_files ) {
+				drmFileToOpen.step_to_end = timesteps_files  ;
+			}
+			break;
+		}
+	}
+
+	free(pes_remainder);
+	free(pes_desired);
+
+	//printf(" %d %d %d %d %d\n",myID,drmFileToOpen.cid, drmFileToOpen.step_to_start,drmFileToOpen.step_to_end,drmFileToOpen.step_to_end-drmFileToOpen.step_to_start );
+}
+
+/* Each processor should know the which processors has which drm nodes.*/
+
+void comm_drm_coordinates ( mesh_t  *myMesh , int32_t theGroupSize, int32_t myID) {
+
+	MPI_Datatype coords_mpi;
+
+	int32_t   i = 0, j, pid;
+
+	/* Find the total number of drm nodes, then print it in stats.Note that this is likely to be
+	 * higher than the actual value, since a single drm node may be counted in multiple processors*/
+	MPI_Reduce(&myNumberOfDrmNodes, &theNumberOfDrmNodes, 1, MPI_INT, MPI_SUM, 0, comm_solver);
+
+	XMALLOC_VAR_N( drmNodesCountP2, int32_t, theGroupSize);
+
+	MPI_Allgather( &myNumberOfDrmNodes, 1, MPI_INT,
+					drmNodesCountP2,      1, MPI_INT, comm_solver );
+
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+		if (drmNodesCountP2[pid] != 0) {
+			peshavenodes++;
+		}
+	}
+
+	XMALLOC_VAR_N( pesDrmNodes, pes_with_drm_nodes, peshavenodes );
+
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+
+		if ( drmNodesCountP2[pid] != 0 ) {
+
+			/* Initialize struct */
+			pesDrmNodes[i].id = pid;
+			pesDrmNodes[i].minx = 0;
+			pesDrmNodes[i].miny = 0;
+			pesDrmNodes[i].minz = 0;
+			pesDrmNodes[i].maxx = 0;
+			pesDrmNodes[i].maxy = 0;
+			pesDrmNodes[i].maxz = 0;
+
+			XMALLOC_VAR_N( pesDrmNodes[i].drmNodeCoords, vector3D_t, drmNodesCountP2[pid] );
+
+			if ( pid == myID ) {
+
+				for ( j = 0; j < drmNodesCountP2[pid]; j++ ) {
+
+					pesDrmNodes[i].drmNodeCoords[j].x[0] = (myMesh->ticksize)*myMesh->nodeTable[drmNodeIds[j]].x;
+					pesDrmNodes[i].drmNodeCoords[j].x[1] = (myMesh->ticksize)*myMesh->nodeTable[drmNodeIds[j]].y;
+					pesDrmNodes[i].drmNodeCoords[j].x[2] = (myMesh->ticksize)*myMesh->nodeTable[drmNodeIds[j]].z;
+				}
+			}
+			++i;
+		}
+	}
+
+	MPI_Type_contiguous(3, MPI_DOUBLE, &coords_mpi);
+	MPI_Type_commit(&coords_mpi);
+
+	i = 0;
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+		if (drmNodesCountP2[pid] != 0) {
+			MPI_Bcast(pesDrmNodes[i].drmNodeCoords, drmNodesCountP2[pid], coords_mpi, pid, comm_solver);
+			++i;
+		}
+	}
+}
+
+void rearrange_drm_files ( mesh_t  *myMesh, int32_t theGroupSize, int32_t myID ) {
+
+	FILE* fp;
+
+	MPI_Offset disp;
+	MPI_Offset disp2;
+
+	MPI_Status status;
+	MPI_Group group_world;
+	MPI_Group newgroup[drmFilesCount];
+	MPI_Comm  comm_world;
+	MPI_Comm  newcomm[drmFilesCount];
+
+	int32_t   local_number_drm_nodes = 0, disp_cnt = 0, pes_i_owe_cnt = 0, pid_cnt = 0, l = 0, m = 0,
+			  n = 0, count = 0, i = 0, j = 0, pid = 0, interval = 0, recv_cnt,pes_grp_owe_cnt = 0;
+	int32_t   *node_count_to_send_me; /* Find which processors needs how many nodes*/
+	int32_t   **coord_i_owe ;      /* the order of coordinates (that I owe to processors )in the array */
+	int32_t   *pes_i_owe_id ;      /* the ID of processor that I owe displacements*/
+	int32_t   *array_cnt_me;       /* keep track number of elements in each array */
+
+	int32_t   *pes_i_owe_grp_cnt ;     /* has information for all pes in the group. */
+	int32_t   pes_i_owe_cnt_send = 0;  /* non zero if i am reading the beginning of the file */
+
+	int32_t   *pes_id_cumulative;
+
+	int64_t   local_id, node_id, elem_id;
+
+	int32_t   *node_count_to_send_grp; /* Find which processors needs how many nodes in group*/
+	int32_t   **coord_grp_owe ;        /* the order of coordinates (that group owes to processors )in the array */
+	int32_t   *pes_grp_owe_id ;        /* the ID of processor that group owes displacements*/
+	int32_t   *array_cnt_grp;          /* keep track number of elements in each array */
+
+
+	/* these are the coords from the file I need to readjust */
+	fvector_t  *drmCoordsAdjust;
+	fvector_t  *to_read,  *to_write;
+
+	//off_t   whereToRead;
+
+	double  x, y, z; /* in physical coordinates */
+	double  myminx = 0, mymaxx = 0, myminy = 0, mymaxy = 0, myminz = 0, mymaxz = 0;
+	int 	total_pes_cnt = 0;
+
+	static char    filename [256];
+	comm_world = comm_solver;
+
+	MPI_Comm_group(comm_world, &group_world);
+	MPI_Group_incl(group_world, pes_per_file[drmFileToOpen.cid], rank,&(newgroup[drmFileToOpen.cid]));
+	MPI_Comm_create ( comm_world, newgroup[drmFileToOpen.cid], &(newcomm[drmFileToOpen.cid]) );
+
+	Timer_Start("Find Which Drm Files To Print");
+
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+		if (drmNodesCountP2[pid] != 0) {
+
+			for ( j = 0; j < drmNodesCountP2[pid]; ++j ) {
+
+				pesDrmNodes[i].minx = MIN(pesDrmNodes[i].minx,
+										  pesDrmNodes[i].drmNodeCoords[j].x[0]);
+				pesDrmNodes[i].miny = MIN(pesDrmNodes[i].miny,
+										  pesDrmNodes[i].drmNodeCoords[j].x[1]);
+				pesDrmNodes[i].minz = MIN(pesDrmNodes[i].minz,
+										  pesDrmNodes[i].drmNodeCoords[j].x[2]);
+
+				pesDrmNodes[i].maxx = MAX(pesDrmNodes[i].maxx,
+										  pesDrmNodes[i].drmNodeCoords[j].x[0]);
+				pesDrmNodes[i].maxy = MAX(pesDrmNodes[i].maxy,
+										  pesDrmNodes[i].drmNodeCoords[j].x[1]);
+				pesDrmNodes[i].maxz = MAX(pesDrmNodes[i].maxz,
+										  pesDrmNodes[i].drmNodeCoords[j].x[2]);
+			}
+			++i;
+		}
+	}
+
+	/* Now we know which file to open to adjust displacements */
+
+	sprintf( filename, "%s%s_%d", theDrmOutputDir, "/part1/drm_coordinates", drmFileToOpen.id);
+	//sprintf( filename, "%s_%d","/lustre/scratch/yigit/DRM_TEST/outputfiles/DRM/part1/drm_coordinates", drmFileToOpen.id);
+
+	if ( (fp = fopen(filename, "r")) == NULL ) {
+		fprintf(stderr, "Error opening %s\n", filename);
+	}
+
+	hu_fread(&local_number_drm_nodes, sizeof(int32_t), 1, fp);
+
+	XMALLOC_VAR_N( drmCoordsAdjust, fvector_t, local_number_drm_nodes );
+
+	hu_fread(drmCoordsAdjust, sizeof(fvector_t), local_number_drm_nodes, fp);
+
+	/* We need to adjust coordinates for Surface Shift */
+	for ( j = 0; j < local_number_drm_nodes; ++j ) {
+		drmCoordsAdjust[j].f[2] += theSurfaceShift;
+	}
+
+	fclose(fp);
+
+	/* Distribute coords among processors as well */
+
+	interval = (int)( 1 + (double)local_number_drm_nodes / (double)pes_per_file[drmFileToOpen.cid]);
+
+	if(pes_per_file[drmFileToOpen.cid] == 1 ) {
+		interval = local_number_drm_nodes;
+	}
+
+	drmFileToOpen.coord_to_start = interval * drmFileToOpen.pos;
+	drmFileToOpen.coord_to_end = interval * drmFileToOpen.pos + interval;
+
+	if ( drmFileToOpen.coord_to_start >= local_number_drm_nodes ) {
+		fprintf( stderr,
+				"Something went wrong in rearrange_drm_files" );
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	}
+
+	if( drmFileToOpen.coord_to_end > local_number_drm_nodes ) {
+		drmFileToOpen.coord_to_end = local_number_drm_nodes  ;
+	}
+
+//	printf("%d %d %d \n",drmFileToOpen.coord_to_start,drmFileToOpen.coord_to_end,myID);
+
+	for ( i = drmFileToOpen.coord_to_start; i < drmFileToOpen.coord_to_end; ++i ) {
+
+		myminx = MIN(myminx,drmCoordsAdjust[i].f[0]);
+		myminy = MIN(myminy,drmCoordsAdjust[i].f[1]);
+		myminz = MIN(myminz,drmCoordsAdjust[i].f[2]);
+
+		mymaxx = MAX(mymaxx,drmCoordsAdjust[i].f[0]);
+		mymaxy = MAX(mymaxy,drmCoordsAdjust[i].f[1]);
+		mymaxz = MAX(mymaxz,drmCoordsAdjust[i].f[2]);
+
+		//	printf ("%f %f %f \n",drmCoordsAdjust[i].f[0],drmCoordsAdjust[i].f[1], drmCoordsAdjust[i].f[2]);
+	}
+
+	/* Now we have everything, just need to know for which processors I will send data */
+	node_count_to_send_me = (int32_t *)calloc(theGroupSize,sizeof(int32_t));
+
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+
+		if ( (pesDrmNodes[pid_cnt].minx >=myminx && pesDrmNodes[pid_cnt].minx <=mymaxx) ||
+			 (pesDrmNodes[pid_cnt].maxx >=myminx && pesDrmNodes[pid_cnt].maxx <=mymaxx) ||
+			 (pesDrmNodes[pid_cnt].minx <=myminx && pesDrmNodes[pid_cnt].maxx >=mymaxx) )
+		if ( (pesDrmNodes[pid_cnt].miny >=myminy && pesDrmNodes[pid_cnt].miny <=mymaxy) ||
+		     (pesDrmNodes[pid_cnt].maxy >=myminy && pesDrmNodes[pid_cnt].maxy <=mymaxy) ||
+			 (pesDrmNodes[pid_cnt].miny <=myminy && pesDrmNodes[pid_cnt].maxy >=mymaxy) )
+		if ( (pesDrmNodes[pid_cnt].minz >=myminz && pesDrmNodes[pid_cnt].minz <=mymaxz) ||
+			 (pesDrmNodes[pid_cnt].maxz >=myminz && pesDrmNodes[pid_cnt].maxz <=mymaxz) ||
+			 (pesDrmNodes[pid_cnt].minz <=myminz && pesDrmNodes[pid_cnt].maxz >=mymaxz) )
+
+			for ( j = 0; j < drmNodesCountP2[pid]; j++ ) {
+
+				if ( pesDrmNodes[pid_cnt].drmNodeCoords[j].x[0] >= myminx &&
+					 pesDrmNodes[pid_cnt].drmNodeCoords[j].x[1] >= myminy &&
+					 pesDrmNodes[pid_cnt].drmNodeCoords[j].x[2] >= myminz &&
+				 	 pesDrmNodes[pid_cnt].drmNodeCoords[j].x[0] <= mymaxx &&
+					 pesDrmNodes[pid_cnt].drmNodeCoords[j].x[1] <= mymaxy &&
+					 pesDrmNodes[pid_cnt].drmNodeCoords[j].x[2] <= mymaxz ) {
+
+					for ( i = drmFileToOpen.coord_to_start; i < drmFileToOpen.coord_to_end; ++i ) {
+
+						if ( drmCoordsAdjust[i].f[0] == pesDrmNodes[pid_cnt].drmNodeCoords[j].x[0]  &&
+							 drmCoordsAdjust[i].f[1] == pesDrmNodes[pid_cnt].drmNodeCoords[j].x[1]  &&
+							 drmCoordsAdjust[i].f[2] == pesDrmNodes[pid_cnt].drmNodeCoords[j].x[2] ) {
+							node_count_to_send_me[pesDrmNodes[pid_cnt].id]++;
+							break;
+						}
+					}
+				}
+			}
+		if ( drmNodesCountP2[pid] ) pid_cnt++;
+	}
+
+	for ( i = 0; i < theGroupSize; ++i ) {
+		if(node_count_to_send_me[i]) {
+			pes_i_owe_cnt++;
+		}
+	}
+
+	coord_i_owe = (int32_t **)calloc(theGroupSize,sizeof(int32_t*));
+	pes_i_owe_id = (int32_t *)calloc(pes_i_owe_cnt,sizeof(int32_t));
+	array_cnt_me = (int32_t *)calloc(pes_i_owe_cnt,sizeof(int32_t));
+
+	j = 0;
+	for ( i = 0; i < theGroupSize; ++i ) {
+		if(node_count_to_send_me[i]) {
+			pes_i_owe_id[j] = i;
+			coord_i_owe[i] = (int32_t *)calloc(node_count_to_send_me[i],sizeof(int32_t));
+			++j;
+		}
+	}
+
+	l = 0;
+	pid_cnt = 0;
+
+	/* this time fill coord_i_owe */
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+		if (node_count_to_send_me[pid]) {
+			for ( j = 0; j < drmNodesCountP2[pid]; j++ ) {
+				for ( i = drmFileToOpen.coord_to_start; i < drmFileToOpen.coord_to_end; ++i ) {
+					if ( drmCoordsAdjust[i].f[0] == pesDrmNodes[pid_cnt].drmNodeCoords[j].x[0]  &&
+							drmCoordsAdjust[i].f[1] == pesDrmNodes[pid_cnt].drmNodeCoords[j].x[1]  &&
+							drmCoordsAdjust[i].f[2] == pesDrmNodes[pid_cnt].drmNodeCoords[j].x[2] ) {
+						coord_i_owe[pid][array_cnt_me[l]] = i ; // the order
+						array_cnt_me[l]++;
+						break;
+					}
+				}
+				if ( array_cnt_me[l] == node_count_to_send_me[pesDrmNodes[pid_cnt].id]) break;
+			}
+			l++;
+		}
+		if (drmNodesCountP2[pid] ) pid_cnt++;
+	}
+
+	/* Now, drm coords_I_owe needs to be broadcasted all together */
+	node_count_to_send_grp = (int32_t *)calloc(theGroupSize,sizeof(int32_t));
+
+	MPI_Allreduce( node_count_to_send_me, node_count_to_send_grp,
+				   theGroupSize, MPI_INT, MPI_SUM, newcomm[drmFileToOpen.cid] );
+
+	/*
+	for ( i = 0; i < theGroupSize; ++i ) {
+		if (node_count_to_send_grp[i] && drmFileToOpen.cid == 4 )
+	printf("%d %d %d\n",node_count_to_send_me[i],node_count_to_send_grp[i], i);
+	}
+	 */
+
+	for ( i = 0; i < theGroupSize; ++i ) {
+		if(node_count_to_send_grp[i]) {
+			pes_grp_owe_cnt++;
+		}
+	}
+
+	coord_grp_owe = (int32_t **)calloc(pes_grp_owe_cnt,sizeof(int32_t*));
+	pes_grp_owe_id = (int32_t *)calloc(pes_grp_owe_cnt,sizeof(int32_t));
+	array_cnt_grp = (int32_t *)calloc(pes_grp_owe_cnt,sizeof(int32_t));
+
+	j = 0;
+	for ( i = 0; i < theGroupSize; ++i ) {
+		if(node_count_to_send_grp[i]) {
+			pes_grp_owe_id[j] = i;
+			coord_grp_owe[j] = (int32_t *)calloc(node_count_to_send_grp[i],sizeof(int32_t));
+			/* Each Processor in the group broadcast coordinates(order) */
+			for( l = 0; l < pes_per_file[drmFileToOpen.cid]; ++l ) {
+
+				recv_cnt = node_count_to_send_me[i];
+				MPI_Bcast( &recv_cnt, 1, MPI_INT, l, newcomm[drmFileToOpen.cid] );
+
+				if (recv_cnt != 0 ) {
+					if (myID == drmFileToOpen.root_pe + l ) {
+						for ( m = 0; m < recv_cnt; ++m ) {
+							coord_grp_owe[j][array_cnt_grp[j] + m] = coord_i_owe[i][m];
+						}
+					}
+					MPI_Bcast( &coord_grp_owe[j][array_cnt_grp[j]], recv_cnt, MPI_INT, l, newcomm[drmFileToOpen.cid] );
+
+					array_cnt_grp[j]+=recv_cnt;
+				}
+			}
+			++j;
+		}
+	}
+
+	Timer_Stop("Find Which Drm Files To Print");
+	Timer_Reduce("Find Which Drm Files To Print", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+
+	Timer_Start("Read And Rearrange Drm Files");
+
+	/*Important Part -- Read and Arrange Files*/
+
+	MPI_File fp_write[pes_grp_owe_cnt];
+	MPI_File fp_grp;
+	/* Print header first( total number of nodes and their x-y-z coordinates) */
+	for ( pid = 0; pid < pes_grp_owe_cnt; pid++ ) {
+		sprintf(filename, "%s%s_%d_%d", theDrmOutputDir, "/part2/drm_disp2", pes_grp_owe_id[pid],drmFileToOpen.id);
+		MPI_File_open(newcomm[drmFileToOpen.cid], filename, MPI_MODE_WRONLY | MPI_MODE_CREATE , MPI_INFO_NULL, &fp_write[pid]);
+
+		if (drmFileToOpen.step_to_start == 0) {
+			MPI_File_write_at(fp_write[pid],0,&(array_cnt_grp[pid]),1,MPI_INT,&status);
+			for ( l = 0; l < array_cnt_grp[pid]; l++ ) {
+				disp = ((MPI_Offset)sizeof(int32_t))
+		 			 + (MPI_Offset)l *(MPI_Offset) sizeof(double) *(MPI_Offset) 3;
+				MPI_File_write_at(fp_write[pid],disp,&drmCoordsAdjust[coord_grp_owe[pid][l]],3,MPI_DOUBLE,&status);
+			}
+		}
+
+		disp = (( MPI_Offset)sizeof(int32_t))
+		     + (MPI_Offset)array_cnt_grp[pid] * (MPI_Offset)sizeof(double) * (MPI_Offset)3
+		     + (MPI_Offset)array_cnt_grp[pid] * (MPI_Offset)drmFileToOpen.step_to_start * (MPI_Offset)sizeof(double) * (MPI_Offset)3;
+
+		MPI_File_seek(fp_write[pid],disp,MPI_SEEK_SET);
+	}
+
+	sprintf(filename, "%s%s_%d", theDrmOutputDir, "/part1/drm_disp",drmFileToOpen.id );
+	//sprintf( filename, "%s_%d","/lustre/scratch/yigit/DRM_TEST/outputfiles/DRM/part1/drm_disp", drmFileToOpen.id);
+
+	MPI_File_open(newcomm[drmFileToOpen.cid], filename, MPI_MODE_RDONLY , MPI_INFO_NULL, &fp_grp);
+
+	/*
+	if ( (fp = fopen(filename, "rb")) == NULL) {
+		fprintf(stderr, "Error opening %s\n", filename);
+	}
+	 */
+//	hu_fread(&disp_cnt, sizeof(int32_t), 1, fp);
+
+	MPI_File_read_at(fp_grp,0,&disp_cnt,1,MPI_INT,&status);
+
+	for ( i = drmFileToOpen.step_to_start ; i < drmFileToOpen.step_to_end ; ++i ) {
+
+		XMALLOC_VAR_N( to_read, fvector_t, disp_cnt );
+
+		if (i == drmFileToOpen.step_to_start) {
+
+			disp2 = ((MPI_Offset)sizeof(int32_t))
+				 + (MPI_Offset) disp_cnt * (MPI_Offset)i * (MPI_Offset)sizeof(double) * (MPI_Offset)3;
+
+			MPI_File_seek(fp_grp,disp2,MPI_SEEK_SET);
+			/*
+			whereToRead = ((off_t)sizeof(int32_t))
+				        + (off_t) disp_cnt * (off_t)i * (off_t)sizeof(double) * (off_t)3;
+
+			hu_fseeko( fp, whereToRead, SEEK_SET );
+			 */
+		}
+
+		MPI_File_read(fp_grp ,to_read,disp_cnt*3,MPI_DOUBLE,&status);
+
+		for ( pid = 0; pid < pes_grp_owe_cnt; pid++ ) {
+
+			XMALLOC_VAR_N( to_write, fvector_t, array_cnt_grp[pid] );
+
+			for ( l = 0; l < array_cnt_grp[pid]; l++ ) {
+				to_write[l] = to_read[coord_grp_owe[pid][l]];
+				/*
+				to_write[l].f[0] = to_read[coord_grp_owe[pid][l]].f[0];
+				to_write[l].f[1] = to_read[coord_grp_owe[pid][l]].f[1];
+				to_write[l].f[2] = to_read[coord_grp_owe[pid][l]].f[2];
+				 */
+			}
+
+			MPI_File_write(fp_write[pid] ,to_write,array_cnt_grp[pid]*3,MPI_DOUBLE,&status);
+			free(to_write);
+		}
+		free(to_read);
+	}
+
+	//fclose(fp);
+	MPI_File_close(&fp_grp);
+
+	for ( pid = 0; pid < pes_grp_owe_cnt; pid++ ) {
+		MPI_File_close(&fp_write[pid]);
+	}
+
+	Timer_Stop("Read And Rearrange Drm Files");
+	Timer_Reduce("Read And Rearrange Drm Files", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+
+	Timer_Start("Find Which Drm Files To Read");
+
+	pes_i_owe_grp_cnt = (int32_t *)calloc(theGroupSize,sizeof(int32_t));
+
+	if (drmFileToOpen.step_to_start == 0) {
+
+		pes_i_owe_cnt_send = pes_grp_owe_cnt ;
+	}
+
+	MPI_Allgather( &pes_i_owe_cnt_send, 1, MPI_INT,
+			pes_i_owe_grp_cnt, 1, MPI_INT, comm_solver );
+
+	/* Print the id of processors I owe.(print if only I am reading the beginning of file */
+	sprintf(filename, "%s%s", theDrmOutputDir, "/part2/drm_file_index" );
+
+	MPI_File_open(comm_solver, filename, MPI_MODE_WRONLY | MPI_MODE_CREATE , MPI_INFO_NULL, &fp_grp);
+
+	for ( pid = 0; pid < theGroupSize; pid++ ) {
+		if ( pes_i_owe_grp_cnt[pid] && myID == pid ) {
+
+			disp = ((MPI_Offset)sizeof(int)*total_pes_cnt);
+
+			MPI_File_write_at(fp_grp,disp,pes_grp_owe_id,pes_grp_owe_cnt,MPI_INT,&status);
+		}
+		total_pes_cnt += pes_i_owe_grp_cnt[pid]  ;
+	}
+
+	MPI_File_close(&fp_grp);
+	MPI_Barrier(comm_solver);
+
+	/* Find out which files I need to open */
+
+	pes_id_cumulative = (int32_t *)calloc(total_pes_cnt,sizeof(int32_t));
+
+	if ( myID == 0 ) {
+		sprintf(filename, "%s%s", theDrmOutputDir, "/part2/drm_file_index" );
+		if ( (fp = fopen(filename, "rb")) == NULL) {
+			fprintf(stderr, "Error opening %s\n", filename);
+		}
+
+		hu_fread( pes_id_cumulative, sizeof(int32_t), total_pes_cnt, fp );
+
+		fclose(fp);
+	}
+
+	MPI_Bcast( pes_id_cumulative, total_pes_cnt, MPI_INT, 0, comm_solver );
+
+	/* fill drm_file_to_read */
+
+	Timer_Stop("Find Which Drm Files To Read");
+	Timer_Reduce("Find Which Drm Files To Read", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+
+	Timer_Start("Locate where I am in file");
+
+	if (myNumberOfDrmNodes) {
+		/* First loop pes_id_cumulative to find out how many files I need to open */
+		for( i = 0; i < total_pes_cnt; ++i ) {
+			if( pes_id_cumulative[i] == myID )
+				filesToReadCnt++;
+		}
+		XMALLOC_VAR_N( drmFilesToRead, drm_file_to_read, filesToReadCnt );
+		l = 0;
+		j = 0;
+		total_pes_cnt = 0;
+
+		for ( pid = 0; pid < theGroupSize; pid++ ) {
+			for ( i = 0; i < pes_i_owe_grp_cnt[pid] ; i++ ) {
+				if( pes_id_cumulative[total_pes_cnt+i] == myID ) {
+					drmFilesToRead[l].file_id = partOneDrmNodesCnt[j].id;
+					l++;
+					break;
+				}
+			}
+			if ( pes_i_owe_grp_cnt[pid] ) j++;
+			total_pes_cnt += pes_i_owe_grp_cnt[pid];
+		}
+
+		/* Continue filling drmFilesToRead */
+
+		for ( i = 0; i < filesToReadCnt; ++i) {
+			sprintf(filename, "%s%s_%d_%d", theDrmOutputDir, "/part2/drm_disp2", myID,drmFilesToRead[i].file_id);
+
+			if ( (drmFilesToRead[i].fp = fopen(filename, "rb")) == NULL) {
+				fprintf(stderr, "Error opening %s\n", filename);
+			}
+
+			hu_fread(&(drmFilesToRead[i].nodes_cnt), sizeof(int32_t), 1, drmFilesToRead[i].fp);
+			XMALLOC_VAR_N( drmFilesToRead[i].coords, vector3D_t, drmFilesToRead[i].nodes_cnt );
+			hu_fseeko( drmFilesToRead[i].fp, (off_t)sizeof(int32_t), SEEK_SET );
+			hu_fread(drmFilesToRead[i].coords, sizeof(double), 3*drmFilesToRead[i].nodes_cnt, drmFilesToRead[i].fp);
+
+			if ( i == 0 ) drmFilesToRead[i].total_nodes_cnt = 0;
+			else drmFilesToRead[i].total_nodes_cnt = drmFilesToRead[i - 1].total_nodes_cnt
+					+ drmFilesToRead[i - 1].nodes_cnt;
+		}
+		/* Check if everything goes right */
+		if ( (drmFilesToRead[filesToReadCnt-1].total_nodes_cnt + drmFilesToRead[filesToReadCnt - 1].nodes_cnt)
+				!= myNumberOfDrmNodes) {
+
+			fprintf( stderr, "Internal error.I read more/less drm displacements than needed " );
+			MPI_Abort(MPI_COMM_WORLD, ERROR);
+			exit(1);
+		}
+
+		/* Fill whereIam in theDrmElem	 */
+		for (i = 0; i < myNumberOfDrmElements; i++) {
+			/* For both exterior and interior count */
+			elem_id = theDrmElem[i].leid;
+			for ( l = 0; l < 2; l++ ) {
+
+				if ( l==0 ) count = theDrmElem[i].exteriornodescount;
+				if ( l==1 ) count = theDrmElem[i].boundarynodescount;
+
+				for (j = 0; j < count; j++) {
+
+					if ( l==0 ) local_id = theDrmElem[i].lnid_e[j];
+					if ( l==1 ) local_id = theDrmElem[i].lnid_b[j];
+
+					node_id  = myMesh->elemTable[elem_id].lnid[local_id];
+					x = (myMesh->nodeTable[node_id].x)*(myMesh->ticksize);
+					y = (myMesh->nodeTable[node_id].y)*(myMesh->ticksize);
+					z = (myMesh->nodeTable[node_id].z)*(myMesh->ticksize);
+
+					for (m = 0; m < filesToReadCnt; m++) {
+						for (n = 0; n < drmFilesToRead[m].nodes_cnt; n++) {
+
+							if (drmFilesToRead[m].coords[n].x[0] == x &&
+									drmFilesToRead[m].coords[n].x[1] == y &&
+									drmFilesToRead[m].coords[n].x[2] == z) {
+
+								theDrmElem[i].whereIam[local_id] = drmFilesToRead[m].total_nodes_cnt + n ;
+								m = filesToReadCnt; // so that it breaks the outer loop as well
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+
+	Timer_Stop("Locate where I am in file");
+	Timer_Reduce("Locate where I am in file", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+
+
+	/* Free allocated memory */
+	for( i = 0; i < peshavenodes; ++i ) {
+		free(pesDrmNodes[i].drmNodeCoords);
+	}
+
+	for( i = 0; i < pes_i_owe_cnt; ++i ) {
+		free(coord_i_owe[i]);
+	}
+
+	for( i = 0; i < pes_grp_owe_cnt; ++i ) {
+		free(coord_grp_owe[i]);
+	}
+
+	free(pesDrmNodes);
+	free(drmNodesCountP2);
+	free(drmCoordsAdjust);
+	free(pes_i_owe_grp_cnt);
+	free(coord_i_owe);
+	free(node_count_to_send_me);
+	free(pes_i_owe_id);
+	free(pes_grp_owe_id);
+	free(pes_id_cumulative);
+	free(array_cnt_me);
+	free(array_cnt_grp);
+	free(pes_per_file);
+	free(rank);
+}
+
+int32_t	 fill_drm_struct( mesh_t  *myMesh, int32_t i, int32_t key, int *bound, int *exterior )
+{
+	int32_t   j, bound_cnt, exterior_cnt;
+	int64_t   elem_id, node_id;
+
+	if ( key==1 ) {
+		bound_cnt     = 4;
+		exterior_cnt  = 4;
+	}
+	if ( key==2 ) {
+		bound_cnt     = 2;
+		exterior_cnt  = 6;
+	}
+	if ( key==3 ) {
+		bound_cnt     = 1;
+		exterior_cnt  = 7;
+	}
+
+	XMALLOC_VAR_N( theDrmElem[i].lnid_b, int32_t, bound_cnt );
+	XMALLOC_VAR_N( theDrmElem[i].lnid_e, int32_t, exterior_cnt );
+
+	if ( theDrmElem[i].lnid_b == NULL || theDrmElem[i].lnid_e == NULL  ) {
+		fprintf( stderr, "Err allocing mem in fill_drm_struct" );
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	}
+	for ( j = 0; j < bound_cnt ; ++j ) {
+		(theDrmElem[i].lnid_b)[j] = bound[j];
+	}
+	for (j = 0; j < exterior_cnt; ++j ) {
+		(theDrmElem[i].lnid_e)[j] = exterior[j];
+	}
+	theDrmElem[i].boundarynodescount = bound_cnt;
+	theDrmElem[i].exteriornodescount = exterior_cnt;
+
+	elem_id = theDrmElem[i].leid;
+	for ( j = 0; j < 8 ;++j ) {
+		/*local id of the node */
+		node_id = myMesh->elemTable[elem_id].lnid[j];
+	}
+	return i+1;
+}
+
+/*
+ * For the first step read two displacements.
+ */
+void solver_read_drm_displacements( int32_t step, double deltat, int32_t totalsteps ) {
+
+	Timer_Start("Solver drm read displacements");
+
+	if ( drmImplement == YES && theDrmPart == PART2 && myNumberOfDrmNodes != 0 )
+	{
+		int aux, i;
+        fvector_t* tmpvector;
+
+		aux = (int)(theDrmPrintRate*thePart1DeltaT/deltat);
+		if (step % aux == 0 ) {
+			step = step / aux;
+			if (step != totalsteps /aux - 1 ) {  step++; }
+			//printf("%d ", step);
+			//step++;
+			if ((step - 1) == 0 ) {
+				XMALLOC_VAR_N( theDrmDisplacements1, fvector_t, myNumberOfDrmNodes );
+				XMALLOC_VAR_N( theDrmDisplacements2, fvector_t, myNumberOfDrmNodes );
+			}
+			if ((step - 1) != 0 ) {
+				tmpvector     = theDrmDisplacements2;
+				theDrmDisplacements2 = theDrmDisplacements1;
+				theDrmDisplacements1 = tmpvector;
+			}
+
+			if ((step - 1) == 0 ) {
+				for( i=0; i<filesToReadCnt;++i) {
+					off_t   whereToRead;
+					whereToRead = ((off_t)sizeof(int32_t))
+		    					+ (off_t)drmFilesToRead[i].nodes_cnt * (off_t)sizeof(double) *(off_t) 3;
+					hu_fseeko( drmFilesToRead[i].fp, whereToRead, SEEK_SET );
+					hu_fread( theDrmDisplacements1 + drmFilesToRead[i].total_nodes_cnt
+							,sizeof(double), 3 * drmFilesToRead[i].nodes_cnt,
+							drmFilesToRead[i].fp );
+				}
+			}
+
+			for( i=0; i<filesToReadCnt;++i) {
+				off_t   whereToRead;
+				whereToRead = ((off_t)sizeof(int32_t))
+		    				+(off_t)drmFilesToRead[i].nodes_cnt * (off_t)sizeof(double) *(off_t) 3
+		    				+(off_t)drmFilesToRead[i].nodes_cnt *(off_t) step *(off_t) sizeof(double) * (off_t)3;
+				hu_fseeko( drmFilesToRead[i].fp, whereToRead, SEEK_SET );
+				hu_fread( theDrmDisplacements2 + drmFilesToRead[i].total_nodes_cnt
+						,sizeof(double), 3 * drmFilesToRead[i].nodes_cnt,
+						drmFilesToRead[i].fp );
+			}
+		}
+	}
+	Timer_Stop("Solver drm read displacements");
+}
+
+
+void solver_compute_effective_drm_force( mysolver_t* mySolver , mesh_t* myMesh,
+				    fmatrix_t (*theK1)[8], fmatrix_t (*theK2)[8], int32_t step,
+				    double deltat)
+{
+	Timer_Start("Solver drm force compute");
+
+	if ( drmImplement == YES && theDrmPart == PART2 && myNumberOfDrmNodes != 0) {
+
+		int32_t    b, e, i ;
+		int32_t    lin_eindex;
+		int32_t    ln_drm_id_e, ln_drm_id_b;
+
+		int        remainder,aux;
+		double 	   fracture;
+		fvector_t  localForce[8];
+		fvector_t* toForce ;
+
+		/* For Interpolation */
+
+		aux = (int)(theDrmPrintRate*thePart1DeltaT/deltat);
+		remainder = step % aux;
+		fracture = (double)remainder/(double)aux;
+
+		//printf("%f ", fracture);
+		/* loop on the number of drm elements */
+		for (lin_eindex = 0; lin_eindex < myNumberOfDrmElements; lin_eindex++) {
+
+			elem_t* elemp;
+			e_t*    ep;
+
+			/*Local id of drm elment*/
+			int32_t ldrm_id = theDrmElem[lin_eindex].leid;
+
+			elemp  = &myMesh->elemTable[ldrm_id];
+			ep     = &mySolver->eTable[ldrm_id];
+
+			memset( localForce, 0, 8 * sizeof(fvector_t) );
+
+			/* step 1: calculate the force contribution at boundary nodes */
+			/* contribution by node e to node b */
+			for (b = 0; b < theDrmElem[lin_eindex].boundarynodescount; b++)
+			{
+				/*Local id of boundary node.b is b/w 0-7 */
+				ln_drm_id_b = theDrmElem[lin_eindex].lnid_b[b];
+				toForce = &localForce[ln_drm_id_b];
+
+				for (e = 0; e < theDrmElem[lin_eindex].exteriornodescount; e++)
+				{
+					int position,index;
+					double low[3], high[3];
+					fvector_t  myDisp[1];
+					/*id of exterior node.e is b/w 0-7 */
+					ln_drm_id_e = theDrmElem[lin_eindex].lnid_e[e];
+
+					position = theDrmElem[lin_eindex].whereIam[ln_drm_id_e];
+
+					/* Interpolation is done here */
+					for( index = 0; index < 3; index++) {
+						low[index]  = theDrmDisplacements1[position].f[index];
+						high[index] = theDrmDisplacements2[position].f[index];
+						myDisp[0].f[index] = low[index] + fracture*(high[index] - low[index]);
+					}
+
+					/* effective  force contribution ( fb = - deltaT_square * Kbe * Ue )
+					 * But if myDisp is zero avoids multiplications
+					 */
+					if ( (vector_is_all_zero( myDisp ) != 0)) {
+						MultAddMatVec( &theK1[ln_drm_id_b][ln_drm_id_e], myDisp, -ep->c1, toForce );
+						MultAddMatVec( &theK2[ln_drm_id_b][ln_drm_id_e], myDisp, -ep->c2, toForce );
+					}
+				}
+			}
+
+			/* step 2: calculate the force at exterior nodes */
+			/* contribution by node b to node e */
+			for (e = 0; e < theDrmElem[lin_eindex].exteriornodescount; e++)
+			{
+				/*Local id of exterior node.e is b/w 0-7 */
+				ln_drm_id_e = theDrmElem[lin_eindex].lnid_e[e];
+				toForce = &localForce[ln_drm_id_e];
+
+				for (b = 0; b < theDrmElem[lin_eindex].boundarynodescount; b++)
+				{
+					int position, index;
+					double low[3], high[3];
+
+					fvector_t  myDisp[1];
+					/*id of boundary node.b is b/w 0-7 */
+					ln_drm_id_b = theDrmElem[lin_eindex].lnid_b[b];
+
+					position = theDrmElem[lin_eindex].whereIam[ln_drm_id_b];
+
+					/* Interpolation is done here */
+					for( index = 0; index < 3; index++) {
+						low[index]  = theDrmDisplacements1[position].f[index];
+						high[index] = theDrmDisplacements2[position].f[index];
+						myDisp[0].f[index] = low[index] + fracture*(high[index] - low[index]);
+					}
+
+					/* effective  force contribution ( fe = + deltaT_square * Keb * Ub )
+					 * But if myDisp is zero avoids multiplications
+					 */
+					if ( (vector_is_all_zero( myDisp ) != 0)) {
+						MultAddMatVec( &theK1[ln_drm_id_e][ln_drm_id_b], myDisp, ep->c1, toForce );
+						MultAddMatVec( &theK2[ln_drm_id_e][ln_drm_id_b], myDisp, ep->c2, toForce );
+					}
+				}
+			}
+
+			/* step 3: sum up my contribution to my vertex nodes */
+			for (i = 0; i < 8; i++) {
+				int32_t    lnid       = elemp->lnid[i];
+				fvector_t* nodalForce = mySolver->force + lnid;
+				nodalForce->f[0] += localForce[i].f[0];
+				nodalForce->f[1] += localForce[i].f[1];
+				nodalForce->f[2] += localForce[i].f[2];
+			}
+		}
+	}
+	Timer_Stop("Solver drm force compute");
+}
+
+void drm_sanity_check(int32_t  myID) {
+
+	FILE  *drminfo;
+	static char    filename [256];
+	int numberofdrmelements;
+
+	/* Find total number of drm elements.*/
+	MPI_Reduce(&myNumberOfDrmElements,&theNumberOfDrmElements,1,MPI_INT,MPI_SUM,0,comm_solver);
+
+	if ( myID == 0 ) {
+		sprintf(filename, "%s%s", theDrmOutputDir, "/part0/drm_information");
+		drminfo = hu_fopen ( filename, "r" );
+
+		if ((parsetext ( drminfo, "drm_numberofelements", 'i', &numberofdrmelements  ) != 0) ) {
+			fprintf( stderr,
+					"Error opening %s\n drm_sanity_check",
+					filename );
+			MPI_Abort(MPI_COMM_WORLD, ERROR);
+			exit(1);
+		}
+
+		if ( theNumberOfDrmElements != numberofdrmelements ) {
+			fprintf( stderr, "drm boundary has changed"
+					"(number of drm elems does not match)");
+			MPI_Abort(MPI_COMM_WORLD, ERROR);
+			exit(1);
+		}
+
+		fclose(drminfo);
+	}
+}
+
+
+/* ------------------------------------------------------------------------- *
+ *                  Functions related to HashTables				             *
+ * ------------------------------------------------------------------------- */
+
+void drm_table_init(drmhash_t *drmTable, int32_t tableDim) {
+
+	int32_t i;
+
+	drmTable->drmBucketArray = (drmbucket_t *)calloc(tableDim, sizeof(drmbucket_t));
+	drmTable->tableCnt = 0;
+
+	for ( i = 0; i < tableDim; ++i ) {
+		(drmTable->drmBucketArray[i]).bucketCnt     = 0;
+		(drmTable->drmBucketArray[i]).drmBucketList = NULL;
+	}
+}
+
+void construct_drm_array( drmhash_t *drmTable, int32_t tableDim,
+						  int32_t   arraysize, int64_t **drm_array, int key)
+{
+	if ( arraysize !=0 ) {
+
+		int32_t i, j=0;
+
+		XMALLOC_VAR_N( (*drm_array) , int64_t, arraysize );
+
+		if ( key == 2) {
+			XMALLOC_VAR_N( drmNodeOwner , int32_t, arraysize );
+		}
+
+		for ( i = 0; i < tableDim; ++i ) {
+			drmbucketelem_t * aux=drmTable->drmBucketArray[i].drmBucketList;
+
+			while (1) {
+				if ( (drmTable->drmBucketArray[i]).bucketCnt == 0 ) {
+					break;
+				}
+				(*drm_array)[j] = aux->nodeid;
+				if ( key == 2 ) {
+					drmNodeOwner[j] = aux->owner;
+				}
+				j++;
+				if ( aux->next == NULL ) {
+					break;
+				}
+				aux=aux->next;
+			}
+		}
+
+		if ( key == 1 ) {
+			qsort((*drm_array), arraysize , sizeof(int64_t), compare);
+		}
+
+	}
+}
+
+/*Table dimension = (2n+1)*prevguess which obeys the rule, where initialguess=89
+ *i.e> tableDim = 89,179,359...*/
+void get_table_dim(int32_t *tableDim, int32_t limit) {
+
+	int i = 0;
+
+	while (1) {
+		(*tableDim) = (*tableDim) * (2*i+1);
+		/* rule assumes an average of 10 nodes in each bucket
+		 * also assumes 1 to 2 ratio b/w drm elems and drm nodes*/
+		if ( 2*limit <= 10*(*tableDim) ) {
+			return;
+		}
+		++i;
+	}
+}
+
+/* Insert drmnodes for part0 avoiding duplicates*/
+void insertNode(mesh_t  *myMesh, int32_t index) {
+
+	int32_t   j, k, nodeid, owner;
+
+	for ( j = 0; j < 8; ++j ) {
+		nodeid = myMesh->elemTable[index].lnid[j];
+
+		/* For part2, i need to insert every single node my drm elements touch. */
+
+		if ( theDrmPart==PART2 ) {
+			k = nodeid % theTableDim;
+			insert(nodeid, k, &theDrmTable, NONE);
+		}
+
+		if ( theDrmPart==PART0 ) {
+			/* This is a bit tricky because, if I dont own it, there is a possibility
+			 * that drm node may never be inserted.So if I do not own it, send that
+			 * node to PE0 and it sends to the owner processor  after checking for
+			 * duplicates.*/
+			if ( myMesh->nodeTable[nodeid].ismine ) {
+				k = nodeid % theTableDim;
+				insert(nodeid, k, &theDrmTable, NONE);
+			}
+			else {
+				/* if I dont own this node,  store in a seperate hashtable , and
+				 * then send it to PE0(later)  */
+				k = nodeid % theTableDupDim;
+				owner = myMesh->nodeTable[nodeid].proc.ownerid;
+				/* This time insert global id instead of local id and owner processor
+				 * id too*/
+				insert(myMesh->nodeTable[nodeid].gnid, k, &theDrmDupTable,owner);
+			}
+		}
+	}
+}
+
+void insert(int64_t nodeid, int32_t i, drmhash_t *drmTable, int32_t owner) {
+
+	drmbucket_t *bucket_arr= &(drmTable->drmBucketArray[i]);
+
+	if ((bucket_arr->bucketCnt == 0) ||
+			searchBucketList(bucket_arr->drmBucketList, nodeid) == 0 )
+	{
+		insertAtFrontOfBucketList(&(bucket_arr->drmBucketList), nodeid ,owner);
+		(bucket_arr->bucketCnt)++;
+		(drmTable->tableCnt)++;
+		return;
+	}
+
+	return;
+}
+
+void insertAtFrontOfBucketList(drmbucketelem_t ** bucketList, int64_t nodeid,
+							   int32_t owner) {
+
+        drmbucketelem_t *newbucket = (drmbucketelem_t *)malloc ( sizeof(drmbucketelem_t) );
+
+	if ( newbucket == NULL ) {
+		fprintf( stderr, "Err allocing mem in insertAtFrontOfBucketList" );
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	}
+
+	newbucket->nodeid = nodeid;
+	if ( owner != NONE) {
+		newbucket->owner = owner;
+	}
+	newbucket->next = (*bucketList);
+	(*bucketList) = newbucket;
+
+}
+
+int32_t searchBucketList(drmbucketelem_t *bucketList, int64_t nodeid) {
+
+	drmbucketelem_t * aux = bucketList;
+	while (1) {
+		if ( aux->nodeid == nodeid ) {
+			return 1;
+		}
+		if ( aux->next == NULL ) {
+			return 0;
+		}
+		aux = aux->next;
+	}
+	// should never reach here
+	// return 2;
+
+}
+
+void removeAtFrontOfBucketList(drmbucketelem_t ** bucketList) {
+
+	drmbucketelem_t * deadElem = (*bucketList);
+	if (*bucketList == NULL) return; /* nothing to remove */
+	*bucketList = deadElem->next;
+	free( deadElem );
+
+}
+
+void freeHashTable(drmhash_t *drmTable, int32_t tableDim) {
+
+	int32_t i;
+	for (i = 0; i < tableDim; ++i ) {
+		while( (drmTable->drmBucketArray[i]).drmBucketList ) {
+			removeAtFrontOfBucketList(&((drmTable->drmBucketArray[i]).drmBucketList));
+		}
+	}
+
+	free( drmTable->drmBucketArray);
+
+}
+
+int32_t compare (const void * a, const void * b) {
+
+	return ( *(int32_t*)a - *(int32_t*)b );
+
+}

--- a/quake/forward_gpu/drm.h
+++ b/quake/forward_gpu/drm.h
@@ -1,0 +1,227 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef DRM_H_
+#define DRM_H_
+
+#include "quake_util.h"
+
+
+/* -------------------------------------------------------------------------- */
+/*                                Structures                                  */
+/* -------------------------------------------------------------------------- */
+
+typedef enum {
+
+  PART0 = 0, PART1, PART2
+
+} drm_part_t;
+
+typedef struct drmbucketelem_t {
+
+	int64_t  nodeid;
+	int32_t  owner;
+	struct   drmbucketelem_t * next;
+
+} drmbucketelem_t;
+
+
+typedef struct drmbucket_t {
+
+	int32_t           bucketCnt;
+	drmbucketelem_t * drmBucketList;
+
+} drmbucket_t;
+
+typedef struct drmhash_t {
+
+	drmbucket_t * drmBucketArray;
+	int32_t       tableCnt;
+
+} drmhash_t;
+
+typedef struct drm_elem_t {
+
+	int64_t    leid;               /* Local element  */
+	int32_t    *lnid_e;            /* exterior node local ids  b/w 0-7 */
+	int32_t    *lnid_b;            /* boundary node local ids  b/w 0-7*/
+	int32_t    boundarynodescount; /* Number of interior nodes */
+	int32_t    exteriornodescount; /* Number of exterior nodes */
+
+	int     whereIam[8];           /* Position of the node in theDrmDisplacements array */
+
+} drm_elem_t;
+
+typedef struct  pes_with_drm_nodes {
+
+	int32_t    id;            /* processor id */
+
+	double     minx, miny, minz,
+	     	   maxx, maxy, maxz;   /* limits*/
+
+	vector3D_t *drmNodeCoords;
+
+} pes_with_drm_nodes;
+
+typedef struct  pes_drm_nodes_cnt {
+
+	int32_t    id;            /* processor id */
+    int32_t    count;         /* drm node count */
+
+} pes_drm_nodes_cnt;
+
+typedef struct  drm_node_t {
+
+	int32_t    id, nodestointerpolate[8];
+    vector3D_t coords;        /* cartesian */
+    vector3D_t localcoords;   /* csi, eta, dzeta in (-1,1) x (-1,1) x (-1,1) */
+
+} drm_node_t;
+
+typedef struct  drm_file_to_open {
+
+	int32_t    cid;             /* comm id */
+	int32_t    id;              /* which file to open */
+	int32_t	   root_pe;			/* leading processor id in the group */
+	int32_t	   pos;				/* position in group */
+	int32_t    coord_to_start;  /* which coord to start reading*/
+	int32_t    coord_to_end;    /* which coord to end reading */
+	int32_t    step_to_start;   /* which timestep to start reading*/
+	int32_t    step_to_end;     /* which timestep to end reading */
+
+} drm_file_to_open;
+
+
+/* For part2 */
+typedef struct  drm_file_to_read {
+
+	int32_t    file_id;           /* which file to read */
+	int32_t    nodes_cnt;         /* how many nodes in this file */
+	int32_t    total_nodes_cnt;   /* how many nodes I read before opening this file */
+    vector3D_t *coords;           /* coords of the nodes */
+	FILE*      fp;                /* File pointers to read disp */
+
+
+} drm_file_to_read;
+
+/* -------------------------------------------------------------------------- */
+/*                                Functions                                  */
+/* -------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+/*                             General Utilities                              */
+/* -------------------------------------------------------------------------- */
+drm_part_t drm_init ( int32_t  myID ,  const char *parametersin, noyesflag_t includeBldgs);
+
+int32_t drm_initparameters ( const char *parametersin);
+
+void  search_drm_elems(mesh_t  *myMesh, int32_t key);
+
+int is_drm_elem(double *coords_array, int *keys_array, int key, double  ticksize);
+
+int drm_toexpand ( octant_t *leaf, double  ticksize, edata_t  *edata );
+
+void solver_drm_close ();
+
+void  drm_fix_coordinates(double ticksize);
+
+void drm_stats(int32_t  myID,
+			   int32_t  theGroupSize,
+			   double   theXForMeshOrigin,
+               double   theYForMeshOrigin,
+               double   theZForMeshOrigin);
+
+void drm_print_stats(int32_t *drmNodesCount,
+                     int32_t  theGroupSize,
+                     double   theXForMeshOrigin,
+                     double   theYForMeshOrigin,
+                     double   theZForMeshOrigin);
+/* -------------------------------------------------------------------------- */
+/*                           Functions for Part0                              */
+/* -------------------------------------------------------------------------- */
+
+void find_drm_nodes( mesh_t     *myMesh,       int32_t   myID,
+					 const char *parametersin, double    ticksize,
+					 int32_t    theGroupSize) ;
+
+void drm_output(mesh_t *myMesh, int32_t myID, int32_t  theGroupSize,
+		        int *array_have_nodes, int64_t  *drm_array, drm_node_t *drm_node);
+
+/* -------------------------------------------------------------------------- */
+/*                           Functions for Part1                              */
+/* -------------------------------------------------------------------------- */
+
+int32_t drm_read_coords ( ) ;
+
+void setup_drm_data(mesh_t *myMesh, int32_t myID, int32_t   theGroupSize);
+
+void solver_output_drm_nodes ( mysolver_t* mySolver, int step, int32_t totalsteps );
+
+/* -------------------------------------------------------------------------- */
+/*                           Functions for Part2                              */
+/* -------------------------------------------------------------------------- */
+
+void proc_drm_elems( mesh_t   *myMesh,     int32_t   myID,
+		int32_t theGroupSize, int32_t theTotalSteps);
+
+void find_drm_file_readjust ( int32_t theGroupSize, int32_t myID, int32_t theTotalSteps );
+
+void comm_drm_coordinates ( mesh_t  *myMesh , int32_t theGroupSize, int32_t myID);
+
+void rearrange_drm_files ( mesh_t  *myMesh , int32_t theGroupSize, int32_t myID ) ;
+
+int32_t	 fill_drm_struct( mesh_t  *myMesh, int32_t i, int32_t key, int *bound, int *exterior);
+
+void solver_compute_effective_drm_force( mysolver_t* mySolver , mesh_t* myMesh,
+				    fmatrix_t (*theK1)[8], fmatrix_t (*theK2)[8], int32_t step,
+				    double deltat);
+
+void solver_read_drm_displacements( int32_t step, double deltat,int32_t totalsteps ) ;
+
+void drm_sanity_check(int32_t  myID);
+
+/* ------------------------------------------------------------------------- *
+ *                  Functions related to HashTables				             *
+ * ------------------------------------------------------------------------- */
+
+void drm_table_init(drmhash_t *drmTable, int32_t tableDim);
+
+void construct_drm_array( drmhash_t *drmTable, int32_t tableDim,
+						  int32_t   arraysize, int64_t **drm_array, int key);
+
+void get_table_dim(int32_t *tableDim, int32_t limit);
+
+void insertNode(mesh_t  *myMesh, int32_t index);
+
+void insert(int64_t nodeid, int32_t i, drmhash_t *drmTable, int32_t owner);
+
+void insertAtFrontOfBucketList(drmbucketelem_t ** bucketList, int64_t nodeid,
+							   int32_t owner);
+
+int32_t searchBucketList(drmbucketelem_t *bucketList, int64_t nodeid);
+
+void removeAtFrontOfBucketList(drmbucketelem_t ** bucketList);
+
+void freeHashTable(drmhash_t *drmTable, int32_t tableDim);
+
+int32_t compare (const void * a, const void * b);
+
+
+#endif /* DRM_H_ */
+

--- a/quake/forward_gpu/funcname.h
+++ b/quake/forward_gpu/funcname.h
@@ -1,0 +1,26 @@
+/* -*- C -*- */
+#ifndef FUNCNAME_H
+#define FUNCNAME_H
+
+#ifndef __GNUC_PREREQ
+#  define __GNUC_PREREQ(foo,bar)	0
+#endif
+
+
+/* Version 2.4 and later of GCC define a magical variable
+ * `__PRETTY_FUNCTION__' which contains the name of the function currently
+ * being defined.  This is broken in G++ before version 2.6.  C9x has a
+ * similar variable called __func__, but prefer the GCC one since it
+ * demangles C++ function names.
+ */
+#if defined(__cplusplus) ? __GNUC_PREREQ (2, 6) : __GNUC_PREREQ (2, 4)
+# define __FUNCTION_NAME                __PRETTY_FUNCTION__
+#else
+# if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#  define __FUNCTION_NAME       __func__
+# else
+#  define __FUNCTION_NAME       ((__const char *) 0)
+# endif
+#endif
+
+#endif /* FUNCNAME_H */

--- a/quake/forward_gpu/geometrics.cu
+++ b/quake/forward_gpu/geometrics.cu
@@ -1,0 +1,244 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "geometrics.h"
+
+/*
+ * Transforms a point from the local coordinates of the fault to the
+ * global coordinates.
+ *
+ */
+vector3D_t
+compute_global_coords( vector3D_t origin, vector3D_t local, double dip,
+		       double rake, double strike )
+{
+    double x, y, z;
+    double d, l, p;
+    int i;
+
+    vector3D_t xGlobal;
+
+    d = dip    * PI / 180;
+    l = rake   * PI / 180;
+    p = strike * PI / 180;
+
+    x = local.x[ 0 ];
+    y = local.x[ 1 ];
+    z = local.x[ 2 ];
+
+    xGlobal.x[ 0 ] =
+	( cos( p ) * cos( l ) + sin( p ) * cos( d ) * sin( l )) * x -
+	(-cos( p ) * sin( l ) + sin( p ) * cos( d ) * cos( l )) * y -
+	(-sin( p ) * sin( d ) ) * z;
+
+    xGlobal.x[ 1 ] =
+	( sin( p ) * cos( l ) - cos( p ) * cos( d ) * sin( l )) * x -
+	(-sin( p ) * sin( l ) - cos( p ) * cos( d ) * cos( l )) * y -
+	( cos( p ) * sin( d ) ) * z;
+
+    xGlobal.x[ 2 ] =
+	- sin( d ) * sin( l ) * x
+	+ sin( d ) * cos( l ) * y 
+	+ cos( d ) * z;
+
+    for (i = 0; i < 3; i++) {
+	xGlobal.x[ i ] = xGlobal.x[ i ] + origin.x[ i ];
+    }
+
+    return xGlobal;
+}
+
+
+vector3D_t compute_centroid( vector3D_t* p )
+{
+    vector3D_t centroid;
+    int i, j;
+
+    for (i = 0; i < 3; i++) {
+	centroid.x[ i ] = 0;
+
+	for (j = 0; j < 3; j++) {
+	    centroid.x[ i ] += p[ j ].x[ i ];
+	}
+
+	centroid.x[ i ] = centroid.x[ i ] / 3;
+    }
+
+    return centroid;
+}
+
+
+double compute_area( vector3D_t* p )
+{
+    double area;
+    double x1, x2, x3, y1, y2, y3;
+
+    x1 = p[ 0 ].x[ 0 ];
+    y1 = p[ 0 ].x[ 1 ];
+    x2 = p[ 1 ].x[ 0 ];
+    y2 = p[ 1 ].x[ 1 ];
+    x3 = p[ 2 ].x[ 0 ];
+    y3 = p[ 2 ].x[ 1 ];
+
+    area = .5 * ( x1 * ( y2 - y3 ) - x2 * ( y1 - y3 ) + x3 * ( y1 - y2 ) );
+
+    return area;
+}
+
+
+int compute_1D_grid( double cellSize, int numberOfCells, int pointsInCell,
+		     double minimumEdgeTriangle, double* grid )
+{
+    int i, j, k;
+
+    k = 0;
+
+    for (i = 0; i < numberOfCells; i++) {
+	for (j = 0; j < pointsInCell; j++) {
+	    grid [ k ] = i * cellSize + j * minimumEdgeTriangle;
+	    k = k + 1;
+	}
+    }
+
+    grid [ k ] = i * cellSize;
+    k = k + 1;
+
+    return k;
+}
+
+
+/**
+ * Rotates the x domain and y domain components of the given point if the
+ * rectangular prism is not alinged with the north.
+ *
+ * \param azimuth in degrees
+ */
+vector3D_t compute_domain_coords( vector3D_t point, double azimuth )
+{
+    int	       iRow, iCol;
+    double     transformation[3][3];
+    vector3D_t pointTransformed;
+
+    for (iRow = 0; iRow < 3; iRow++) {
+	for (iCol = 0; iCol < 3; iCol++) {
+	    transformation[iRow][iCol] = 0;
+	}
+    }
+
+    azimuth = PI * azimuth / 180;
+
+    transformation[ 0 ][ 0 ] =  cos( azimuth );
+    transformation[ 1 ][ 0 ] = -sin( azimuth );
+    transformation[ 0 ][ 1 ] =  sin( azimuth );
+    transformation[ 1 ][ 1 ] =  cos( azimuth );
+    transformation[ 2 ][ 2 ] =  1;
+
+    pointTransformed.x[0] = 0;
+    pointTransformed.x[1] = 0;
+    pointTransformed.x[2] = 0;
+
+    for (iRow = 0; iRow < 3; iRow++) {
+	for (iCol = 0; iCol < 3; iCol++) {
+	    pointTransformed.x[iRow]
+		+= transformation[iRow][iCol] * point.x[iCol];
+	}
+    }
+
+    return pointTransformed;
+}
+
+
+
+/**
+ * Computes the domain coordinates of a point based corners of the global
+ * coordinates (long lat depth).
+ */
+vector3D_t
+compute_domain_coords_linearinterp( double  lon , double lat,
+				    double* longcorner,
+				    double* latcorner,
+				    double  domainlengthetha,
+				    double  domainlengthcsi )
+{
+    int i;
+    double Ax,Ay,Bx,By,Cx,Cy,Dx,Dy;
+    double res;
+    double Xi[4],Yi[4],XN[2];
+    double M[2][2],F[2],DXN[2];
+    double X,Y;
+    vector3D_t domainCoords;
+
+    X=lat;
+    Y=lon;
+
+    for (i = 0; i < 4; i++) {
+	Xi[i] = latcorner[i];
+	Yi[i] = longcorner[i];
+    }
+
+    Ax = 4*X - (Xi[0] + Xi[1] + Xi[2] + Xi[3]);
+    Ay = 4*Y - (Yi[0] + Yi[1] + Yi[2] + Yi[3]);
+
+    Bx = -Xi[0] + Xi[1] + Xi[2] - Xi[3];
+    By = -Yi[0] + Yi[1] + Yi[2] - Yi[3];
+
+    Cx = -Xi[0] - Xi[1] + Xi[2] + Xi[3];
+    Cy = -Yi[0] - Yi[1] + Yi[2] + Yi[3];
+
+    Dx = Xi[0] - Xi[1] + Xi[2] - Xi[3];
+    Dy = Yi[0] - Yi[1] + Yi[2] - Yi[3];
+
+    /* initial values for csi and etha*/
+    XN[0] = 0;
+    XN[1] = 0;
+
+    res = 1e10;
+
+    while (res > 1e-6) {
+	M[0][0] = Bx + Dx * XN[1];
+	M[0][1] = Cx + Dx * XN[0];
+	M[1][0] = By + Dy * XN[1];
+	M[1][1] = Cy + Dy * XN[0];
+
+	F[0] = -Ax + Bx * XN[0] + Cx * XN[1] + Dx * XN[0] * XN[1];
+	F[1] = -Ay + By * XN[0] + Cy * XN[1] + Dy * XN[0] * XN[1];
+
+	DXN[0] = -(F[0]*M[1][1] - F[1]*M[0][1])
+	     / (M[0][0]*M[1][1] - M[1][0]*M[0][1]);
+
+	DXN[1] = -(F[1]*M[0][0] - F[0]*M[1][0])
+	     / (M[0][0]*M[1][1] - M[1][0]*M[0][1]);
+
+	res = fabs( F[0] ) + fabs( F[1] );
+
+	XN[0] = XN[0] + DXN[0];
+	XN[1] = XN[1] + DXN[1];
+    }
+
+    domainCoords.x[0] = .5 * (XN[0] + 1) * domainlengthcsi;
+    domainCoords.x[1] = .5 * (XN[1] + 1) * domainlengthetha;
+    domainCoords.x[2] = 0;
+
+    return domainCoords;
+}

--- a/quake/forward_gpu/geometrics.h
+++ b/quake/forward_gpu/geometrics.h
@@ -1,0 +1,62 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+#ifndef GEOMETRICS_H
+#define GEOMETRICS_H
+
+#include "psolve.h"
+
+
+#define PI 3.14159265358979323846264338327
+
+/*
+ * This struct was also in psolve.h, and was necessary to make it visible
+ * to the nonlinear module
+ *
+ * typedef struct vector3D_t{
+ *
+ *     double x [ 3 ];
+ *
+ * }vector3D_t;
+ */
+
+
+
+vector3D_t compute_global_coords( vector3D_t origin, vector3D_t local,
+				  double dip, double rake ,double strike );
+
+
+vector3D_t compute_centroid( vector3D_t* p );
+
+
+double compute_area(vector3D_t* p);
+
+
+int compute_1D_grid( double cellSize, int numberOfCells, int pointsInCell,
+		     double minimumEdgeTriangle, double* grid );
+
+
+vector3D_t compute_domain_coords( vector3D_t point, double azimuth );
+
+
+vector3D_t
+compute_domain_coords_linearinterp(
+	double lon , double lat, double* longcorner, double *latcorner,
+	double domainlengthetha, double domainlengthcsi );
+
+#endif /* GEOMETRICS_H */

--- a/quake/forward_gpu/htimer.h
+++ b/quake/forward_gpu/htimer.h
@@ -1,0 +1,185 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ *
+ * Copyright (C) 2007 Julio Lopez. All Rights Reserved.
+ * For copyright and disclaimer details see the file COPYING
+ * included in the package distribution.
+ *
+ * Package:     Quake project's Hercules numerical solver.
+ * Description: Timing utility functions.
+ *
+ * Author:      Julio Lopez (jclopez at ece dot cmu dot edu)
+ *
+ * File info:   $RCSfile: htimer.h,v $
+ *              $Revision: 1.3 $
+ *              $Date: 2009/08/08 20:57:08 $
+ *              $Author: jclopez $
+ */
+#ifndef HTIMER_H
+#define HTIMER_H
+
+#include <stdint.h>
+#include <sys/time.h>
+#include <stdio.h>
+
+
+#ifndef PERF_TIME_T_DEFINED
+# define PERF_TIME_T_DEFINED
+typedef uint64_t perf_time_t;
+#endif /* PERF_TIME_T_DEFINED */
+
+
+#ifndef MICROS_PER_SECOND
+#define MICROS_PER_SECOND       1000000
+#endif /* MICROS_PER_SECOND */
+
+
+struct htimerv_t {
+    perf_time_t    total;	/** Cummulative value	      */
+    struct timeval tv;		/** For calls to gettimeofday */
+};
+
+
+typedef struct htimerv_t htimerv_t;
+
+#define HTIMERV_ZERO	        { 0, { 0, 0 } }
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+
+static inline void     tv_reset (struct timeval* tv);
+static inline int      tv_print (const struct timeval* tv, FILE* stream);
+static inline double   tv_seconds (const struct timeval* tv);
+static inline uint64_t tv_usec (const struct timeval* tv);
+
+static inline double
+usec_to_sec( uint64_t usec )
+{
+    return ((double)usec) / MICROS_PER_SECOND;
+}
+
+
+static inline void
+tv_reset (struct timeval* tv)
+{
+    tv->tv_sec  = 0;
+    tv->tv_usec = 0;
+}
+
+
+static inline int
+tv_print (const struct timeval* tv, FILE* stream)
+{
+    return fprintf (stream, "%ld.%ld", tv->tv_sec, tv->tv_usec);
+}
+
+
+static inline double
+tv_seconds (const struct timeval* tv)
+{
+    return (double)tv->tv_sec + ((double)tv->tv_usec) / MICROS_PER_SECOND;
+}
+
+
+static inline uint64_t
+tv_usec (const struct timeval* tv)
+{
+    return ((uint64_t)tv->tv_sec) * MICROS_PER_SECOND + tv->tv_usec;
+}
+
+
+static inline void
+tv_start(struct timeval* tv)
+{
+    struct timeval t;
+
+    gettimeofday (&t, NULL);
+    tv->tv_sec  = -t.tv_sec;
+    tv->tv_usec = -t.tv_usec;
+}
+
+
+static inline void
+tv_stop( struct timeval* tv )
+{
+    struct timeval t;
+
+    gettimeofday (&t, NULL);
+    tv->tv_sec  += t.tv_sec;
+    tv->tv_usec += t.tv_usec;
+}
+
+
+/**
+ * Compute the time difference in seconds between two timeval structures
+ * \c a and \c b.  Assume a > b, i.e., a is more recent than b.
+ */
+static inline double
+tv_difftime( const struct timeval* a, const struct timeval* b)
+{
+    return ((double)(a->tv_sec - b->tv_sec))
+	+ (a->tv_usec - b->tv_usec) / 1000000.0;
+}
+
+
+static inline void
+htimerv_reset( htimerv_t* t )
+{
+    t->total = 0;
+    tv_reset( &t->tv );
+}
+
+
+static inline void
+htimerv_start( htimerv_t* t )
+{
+    tv_start( &t->tv );
+}
+
+
+static inline void
+htimerv_stop( htimerv_t* t )
+{
+    tv_stop( &t->tv );
+    t->total += tv_usec( &t->tv );
+}
+
+
+static inline uint64_t
+htimerv_get_total_usec( htimerv_t* t )
+{
+    return t->total;
+}
+
+
+static inline double
+htimerv_get_total_sec( htimerv_t* t )
+{
+    return usec_to_sec( t->total );
+}
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif /* __cplusplus */
+
+#endif /* HTIMER_H */

--- a/quake/forward_gpu/io_checkpoint.cu
+++ b/quake/forward_gpu/io_checkpoint.cu
@@ -1,0 +1,237 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <stdlib.h>
+#include <mpi.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include "timers.h"
+#include "io_checkpoint.h"
+#include "psolve.h"
+
+/* Writes header and tm1 and tm2 arrays */
+void checkpoint_write(int step, int myID, mesh_t* myMesh, char* theCheckPointingDirOut,
+		      int theGroupSize, mysolver_t* mySolver, MPI_Comm comm_solver ){
+
+    char       filename[256];
+    FILE*      fp;
+    int        nharboredmax, localnharbored;
+    off_t      offset;
+    size_t     written;
+    static int CheckpointNumber = 0;
+    int        GroupStart;
+
+    static int WriteGroupSize = 512; /* This determines how many PEs write at once */
+
+    Timer_Start("Checkpoint");
+
+    /* compute max nharbored for stripe size */
+    localnharbored = myMesh->nharbored;
+    MPI_Reduce( &localnharbored, &nharboredmax, 1, MPI_INT, MPI_MAX, 0,
+                comm_solver );
+    MPI_Bcast( &nharboredmax, 1, MPI_INT, 0, comm_solver );
+
+    /* Sanity check for nharbored */
+    if ((myMesh->nharbored > nharboredmax) || (localnharbored > nharboredmax)){
+        fprintf(stderr, "Checkpoint has nharbored greater than nharboredmax!");
+        MPI_Abort(MPI_COMM_WORLD, -1);
+        exit(1);
+    }
+
+    /* Create file name */
+    sprintf( filename, "%s%s%d", theCheckPointingDirOut, "/checkpoint.out",
+             CheckpointNumber );
+
+    /* PE 0 creates file and writes the header */
+    if (myID == 0) {
+	fp = fopen( filename, "wb" );
+	if(fp == NULL) {
+	    fprintf(stderr, "PE0 Can't Create Checkpoint File!");
+	    MPI_Abort(MPI_COMM_WORLD, -1);
+	    exit(1);
+	}
+        fwrite( &theGroupSize, sizeof(int), 1, fp );
+        fwrite( &step,         sizeof(int), 1, fp );
+        fwrite( &nharboredmax, sizeof(int), 1 ,fp );
+	fclose( fp );
+    }
+
+    MPI_Barrier( comm_solver );	
+
+    /* Go through all PEs in chunks of WriteGroupSize */
+    for (GroupStart = 0; GroupStart < theGroupSize; GroupStart += WriteGroupSize){
+
+	if ( (myID >= GroupStart) && (myID < GroupStart + WriteGroupSize) ){
+
+	    fp = fopen( filename, "rb+" );  /*Open Existing File*/
+	    if(fp == NULL) {
+		fprintf(stderr, "Can't Open Checkpoint File!");
+		MPI_Abort(MPI_COMM_WORLD, -1);
+		exit(1);
+	    }
+	    
+	    MPI_Barrier( comm_solver );  /* Needless, but may(?) help lustre */
+
+	    /* Determine offset to write tm1 field */
+	    offset = 
+		( 3 * sizeof(int) )  +                               /* Header Size */
+		( 2 * myID * nharboredmax * sizeof(fvector_t) );     /* Processor Offset */
+	    
+	    fseeko( fp, offset, SEEK_SET );
+	    
+	    /* write tm1 - due to some prior switch, this is tm2 here */
+	    written = fwrite( mySolver->tm2, sizeof(fvector_t), myMesh->nharbored, fp );
+	    if(written != myMesh->nharbored) {
+		fprintf(stderr, "Error writing Checkpoint File!");
+		MPI_Abort(MPI_COMM_WORLD, -1);
+		exit(1);
+	    }
+	
+	    /* Add fieldsize to get tm2 offset */
+	    offset += myMesh->nharbored * sizeof(fvector_t);
+	
+	    fseeko( fp, offset, SEEK_SET );
+	
+	    /* write tm2 - due to some prior switch, this is tm1 here */
+	    written = fwrite( mySolver->tm1, sizeof(fvector_t), myMesh->nharbored, fp );
+	    if(written != myMesh->nharbored) {
+		fprintf(stderr, "Error writing Checkpoint File!");
+		MPI_Abort(MPI_COMM_WORLD, -1);
+		exit(1);
+	    }
+	
+	    fclose( fp );
+	}
+
+	MPI_Barrier( comm_solver );	
+    }
+
+    /* Alternate checkpointing files */
+    CheckpointNumber ? (CheckpointNumber=0):(CheckpointNumber=1);
+
+    MPI_Barrier( comm_solver );	/*Just for Timer's sake*/
+    Timer_Stop("Checkpoint");
+
+}
+
+
+
+/* Reads tm1 and tm2 arrays and returns step */
+extern int  checkpoint_read ( int myID, mesh_t* myMesh, char* theCheckPointingDirOut,
+			      int theGroupSize, mysolver_t* mySolver, MPI_Comm comm_solver ){
+
+    char     filename[256];
+    FILE*    fp;
+    int      nharboredmax, PESize, step;
+    off_t    offset;
+    size_t   num_read;
+    int      GroupStart;
+
+    static int ReadGroupSize = 512; /* This determines how many PEs read at once */
+
+    Timer_Start("Checkpoint");
+
+    /* Create checkpointing file name */
+    sprintf( filename, "%s%s", theCheckPointingDirOut, "/checkpoint.in" );
+
+    /* PE 0 reads the header for all */
+    if (myID == 0) {
+        fp = fopen( filename, "rb" );
+	if(fp == NULL) {
+	    fprintf(stderr, "PE0 Can't Open Checkpoint File To Read Header!");
+	    MPI_Abort(MPI_COMM_WORLD, -1);
+	    exit(1);
+	}
+        fread( &PESize,       sizeof(int), 1 , fp );
+        fread( &step,         sizeof(int), 1 , fp );
+        fread( &nharboredmax, sizeof(int), 1 , fp );
+        fclose( fp );
+        /* check number of processors is right */
+        if (PESize != theGroupSize) {
+	    fprintf(stderr, "Checkpoint file PE count (%d) does not"
+		    "match current PE count (%d)!\n", PESize, theGroupSize);
+	    MPI_Abort(MPI_COMM_WORLD, -1);
+	    exit(1);
+	}
+    }
+
+    /* broadcast header data */
+    MPI_Bcast( &PESize,       1, MPI_INT, 0, comm_solver );
+    MPI_Bcast( &step,         1, MPI_INT, 0, comm_solver );
+    MPI_Bcast( &nharboredmax, 1, MPI_INT, 0, comm_solver );
+
+    /* sanity check nhabored */
+    if (myMesh->nharbored > nharboredmax) {
+	fprintf(stderr, "Local nhabored (%d) greater than checkpoint file nharboredmax! (%d)!\n",
+		myMesh->nharbored, nharboredmax);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+
+    MPI_Barrier( comm_solver );
+
+    /* Go through all PEs in chunks of ReadGroupSize */
+    for (GroupStart = 0; GroupStart < theGroupSize; GroupStart += ReadGroupSize){
+	
+	if ( (myID >= GroupStart) && (myID < GroupStart + ReadGroupSize) ){
+
+	    /* open checkpoint file */
+	    fp = fopen( filename, "rb" );
+	    if(fp == NULL) {
+		fprintf(stderr, "Can't Open Checkpoint File!");
+		MPI_Abort(MPI_COMM_WORLD, -1);
+		exit(1);
+	    }
+
+	    MPI_Barrier( comm_solver );  /* Needless, but may(?) help lustre */
+
+	    /* Determine offset to find tm1 field */
+	    offset = 
+		( 3 * sizeof(int) )  +                               /* Header Size */
+		( 2 * myID * nharboredmax * sizeof(fvector_t) );     /* Processor Offset */
+
+	    fseeko( fp, offset, SEEK_SET );
+
+	    num_read = fread( mySolver->tm1, sizeof(fvector_t), myMesh->nharbored, fp );
+	    if (num_read != myMesh->nharbored) {
+		fprintf(stderr, "Problem reading checkpoint file tm1 field!\n");
+		MPI_Abort(MPI_COMM_WORLD, -1);
+		exit(1);
+	    }
+
+	    offset += myMesh->nharbored * sizeof(fvector_t);
+
+	    fseeko( fp, offset, SEEK_SET );
+
+	    num_read = fread( mySolver->tm2, sizeof(fvector_t), myMesh->nharbored, fp );
+	    if (num_read != myMesh->nharbored) {
+		fprintf(stderr, "Problem reading checkpoint file tm2 field!\n");
+		MPI_Abort(MPI_COMM_WORLD, -1);
+		exit(1);
+	    }
+
+	    fclose( fp );
+	}
+    }
+
+    MPI_Barrier( comm_solver ); /*Just for Timer's sake*/
+    Timer_Stop("Checkpoint");
+
+    return step;
+}

--- a/quake/forward_gpu/io_checkpoint.h
+++ b/quake/forward_gpu/io_checkpoint.h
@@ -1,0 +1,28 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include "psolve.h"
+
+extern void checkpoint_write( int step, int myID, mesh_t* myMesh, char* theCheckPointingDirOut,
+			       int theGroupSize, mysolver_t* mySolver, MPI_Comm comm_solver );
+
+extern int  checkpoint_read ( int myID, mesh_t* myMesh, char* theCheckPointingDirOut,
+                               int theGroupSize, mysolver_t* mySolver, MPI_Comm comm_solver );

--- a/quake/forward_gpu/io_planes.cu
+++ b/quake/forward_gpu/io_planes.cu
@@ -1,0 +1,1278 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <float.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <math.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include "io_planes.h"
+#include "psolve.h"
+#include "geometrics.h"
+#include "quake_util.h"
+#include "util.h"
+
+extern int compute_csi_eta_dzeta( octant_t *octant, vector3D_t pointcoords,
+				  vector3D_t *localcoords, int32_t *localNodeID );
+
+#define LINESIZE       512
+
+#define STOP_SERVER    10 /* DATA MESSAGE TO STOP IO SERVER */
+
+#define MAX_STRIPS_PER_PLANE 5000
+/*Could be determined dynmamically but would cost search_point calls*/
+
+
+int  New_planes_print(int32_t myID, mysolver_t* mySolver, int theNumberOfPlanes);
+void New_planes_setup(int32_t myID, int32_t *thePlanePrintRate, int theNumberOfPlanes,
+		      const char *numericalin, double surfaceShift,
+		      double *theSurfaceCornersLong, double *theSurfaceCornersLat,
+		      double theDomainX, double theDomainY, double theDomainZ,
+		      char* planes_input_file);
+void New_planes_close(int32_t myID, int theNumberOfPlanes);
+void planes_IO_PES_main(int32_t myID);
+static void New_output_planes_construct_strips(int32_t myID, int theNumberOfPlanes);
+
+static void print_planeinfo(int32_t myID, int theNumberOfPlanes);
+
+int  Old_planes_print(int32_t myID, mysolver_t* mySolver, int theNumberOfPlanes);
+void Old_planes_setup(int32_t myID, int32_t *thePlanePrintRate, int theNumberOfPlanes, 
+		      const char *numericalin, double surfaceShift,
+		      double *theSurfaceCornersLong, double *theSurfaceCornersLat,
+		      double theDomainX, double theDomainY, double theDomainZ,
+		      char* planes_input_file);
+void Old_planes_close(int32_t myID, int theNumberOfPlanes);
+static int  Old_print_plane_displacements(int32_t myID, int ThisPlane);
+static void Old_output_planes_construct_strips(int32_t myID, int theNumberOfPlanes);
+
+typedef struct plane_strip_element_t {
+
+    int32_t nodestointerpolate[8];
+    vector3D_t localcoords;  /* csi, eta, dzeta in (-1,1) x (-1,1) x (-1,1)*/
+
+} plane_strip_element_t;
+
+
+typedef struct plane_t {
+
+    vector3D_t origincoords;              /**< cartesian */
+
+    FILE *fpoutputfile,*fpplanecoordsfile;
+
+    int numberofstepsalongstrike, numberofstepsdowndip;
+    double stepalongstrike, stepdowndip, strike, dip, rake;
+
+    int IO_PE_num;
+    int numberofstripsthisplane;
+    int globalnumberofstripsthisplane, globalnumberofstripsthisplane_recieved; /*valid only on output PE's*/
+
+    int stripstart[MAX_STRIPS_PER_PLANE];
+    int stripend[MAX_STRIPS_PER_PLANE];
+    plane_strip_element_t * strip[MAX_STRIPS_PER_PLANE];
+
+} plane_t;
+
+static plane_t* thePlanes;
+static int planes_GlobalLargestStripCount;
+static int planes_LocalLargestStripCount;
+static double* planes_output_buffer;
+static double* planes_stripMPISendBuffer;
+static double* planes_stripMPIRecvBuffer;
+
+/******* Wrapper on routines to maintain backwards compatiblity for single core routines ******/
+
+int planes_print(int32_t myID, int IO_pool_pe_count, int theNumberOfPlanes, mysolver_t* mySolver){
+    if (IO_pool_pe_count)
+         New_planes_print(myID, mySolver, theNumberOfPlanes);
+    else
+         Old_planes_print(myID, mySolver, theNumberOfPlanes);
+    return 1;
+}
+
+void planes_setup(int32_t myID, int32_t *thePlanePrintRate, int IO_pool_pe_count, 
+                  int theNumberOfPlanes, const char *numericalin, double surfaceShift,
+		  double *theSurfaceCornersLong, double *theSurfaceCornersLat,
+		  double theDomainX, double theDomainY, double theDomainZ,
+		  char* planes_input_file){
+
+    if (IO_pool_pe_count)
+	New_planes_setup(myID, thePlanePrintRate, theNumberOfPlanes, numericalin, surfaceShift,
+			 theSurfaceCornersLong, theSurfaceCornersLat,
+                         theDomainX, theDomainY, theDomainZ,
+                         planes_input_file);
+    else
+	Old_planes_setup(myID, thePlanePrintRate, theNumberOfPlanes, numericalin, surfaceShift,
+			 theSurfaceCornersLong, theSurfaceCornersLat,
+                         theDomainX, theDomainY, theDomainZ,
+                         planes_input_file);
+}
+
+void planes_close(int32_t myID, int IO_pool_pe_count, int theNumberOfPlanes){
+    if (IO_pool_pe_count)
+	New_planes_close(myID, theNumberOfPlanes);
+    else
+	Old_planes_close(myID, theNumberOfPlanes);
+}
+
+
+/********************* Old Version To Maintain Backwards Compatbility For One Core ******/
+
+/**
+ * Interpolate the displacenents and communicate strips to printing PE.
+ * Bigben version has no control flow, just chugs through planes.
+ */
+int Old_planes_print(int32_t myID, mysolver_t* mySolver, int theNumberOfPlanes)
+{
+    int iPlane, iPhi;
+    int stripLength;
+    int iStrip, elemnum, rStrip;
+    /* Auxiliar array to handle shapefunctions in a loop */
+    double  xi[3][8]={ {-1,  1, -1,  1, -1,  1, -1, 1} ,
+		       {-1, -1,  1,  1, -1, -1,  1, 1} ,
+		       {-1, -1, -1, -1,  1,  1,  1, 1} };
+
+    double      phi[8];
+    double      displacementsX, displacementsY, displacementsZ;
+    //    int32_t     howManyDisplacements, iDisplacement;
+    //    vector3D_t* localCoords; /* convinient renaming */
+    //    int32_t*    nodesToInterpolate[8];
+    MPI_Status  status;
+    //    MPI_Request sendstat;
+    int recvStripCount, StartLocation;
+
+    for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++) {
+	for (iStrip = 0; iStrip < thePlanes[iPlane].numberofstripsthisplane;
+	     iStrip++) {
+
+	    /* interpolate points directly into send buffer for this strip */
+	    for (elemnum = 0;
+		 elemnum < (thePlanes[iPlane].stripend[iStrip]
+			    -thePlanes[iPlane].stripstart[iStrip]+1);
+		 elemnum++)
+		{
+		    displacementsX = 0;displacementsY = 0;displacementsZ = 0;
+
+
+		    for (iPhi = 0; iPhi < 8; iPhi++){
+			phi[iPhi] = ( 1 + (xi[0][iPhi]) *
+				      (thePlanes[iPlane].strip[iStrip][elemnum].localcoords.x[0]) )
+			    * ( 1 + (xi[1][iPhi]) *
+				(thePlanes[iPlane].strip[iStrip][elemnum].localcoords.x[1]) )
+			    * ( 1 + (xi[2][iPhi]) *
+				(thePlanes[iPlane].strip[iStrip][elemnum].localcoords.x[2]) ) /8;
+
+			displacementsX += phi[iPhi]*
+			    (mySolver->tm1[ thePlanes[iPlane].strip[iStrip][elemnum].nodestointerpolate[iPhi] ].f[0]);
+			displacementsY += phi[iPhi]*
+			    (mySolver->tm1[ thePlanes[iPlane].strip[iStrip][elemnum].nodestointerpolate[iPhi] ].f[1]);
+			displacementsZ += phi[iPhi]*
+			    (mySolver->tm1[ thePlanes[iPlane].strip[iStrip][elemnum].nodestointerpolate[iPhi] ].f[2]);
+		    }
+
+		    planes_stripMPISendBuffer[elemnum*3]     = (double) (displacementsX);
+		    planes_stripMPISendBuffer[elemnum*3 + 1] = (double) (displacementsY);
+		    planes_stripMPISendBuffer[elemnum*3 + 2] = (double) (displacementsZ);
+
+		}
+
+	    /* add start location as last element, add .1 to insure
+	       int-float conversion (yes, bad form)*/
+            stripLength = thePlanes[iPlane].stripend[iStrip]
+		- thePlanes[iPlane].stripstart[iStrip] + 1;
+
+            planes_stripMPISendBuffer[stripLength*3]
+		= (double) (thePlanes[iPlane].stripstart[iStrip] + 0.1);
+
+            if (myID==0) { /* don't try to send to same PE, just memcopy */
+		memcpy( &(planes_output_buffer[ thePlanes[iPlane].stripstart[iStrip]*3 ] ), planes_stripMPISendBuffer,
+			stripLength*3*sizeof(double) );
+            }
+            else {
+		MPI_Send( planes_stripMPISendBuffer, (stripLength*3)+1,
+			  MPI_DOUBLE, 0 , iPlane, comm_solver );
+            }
+	} /*for iStrips*/
+
+	/* IO PE recieves for this plane */
+	if(myID == 0){
+	    /* Recv all strips not directly memory copied above */
+	    for (rStrip = 0;
+		 rStrip < (thePlanes[iPlane].globalnumberofstripsthisplane
+			   - thePlanes[iPlane].numberofstripsthisplane);
+		 rStrip++) {
+
+		MPI_Recv( planes_stripMPIRecvBuffer,
+			  planes_GlobalLargestStripCount * 3 + 1, MPI_DOUBLE,
+			  MPI_ANY_SOURCE, iPlane, comm_solver, &status );
+		MPI_Get_count(&status, MPI_DOUBLE, &recvStripCount);
+		StartLocation = (int)planes_stripMPIRecvBuffer[recvStripCount-1];
+		memcpy( &(planes_output_buffer[StartLocation * 3]),
+			planes_stripMPIRecvBuffer,
+			(recvStripCount-1)*sizeof(double) );
+	    }
+	}
+
+	/* do print for just this plane */
+	Old_print_plane_displacements(myID, iPlane );
+
+	/* may not be required */
+	MPI_Barrier( comm_solver );
+    } /* for iPlane */
+
+    return 1;
+}
+
+
+static int Old_print_plane_displacements(int32_t myID, int ThisPlane)
+{
+    int ret;
+
+    if  (myID == 0){
+	ret = fwrite( planes_output_buffer, sizeof(double),
+                      3 * thePlanes[ThisPlane].numberofstepsalongstrike
+		      * thePlanes[ThisPlane].numberofstepsdowndip,
+		      thePlanes[ThisPlane].fpoutputfile );
+	if (ret != (3*thePlanes[ThisPlane].numberofstepsalongstrike
+		    * thePlanes[ThisPlane].numberofstepsdowndip) ) {
+	    fprintf( stderr, "Error writing all values in planes file %d.\n",
+		     ThisPlane );
+	    exit(1);
+	}
+    }
+
+    return 1;
+}
+
+
+
+/**
+ * This is the stripped BigBen version.  It is simplified:
+ * 1. It assumes all output is PE0.
+ * 2. It does not have a strip size limit.
+ */
+
+void Old_planes_setup ( int32_t     myID, int32_t *thePlanePrintRate,
+			int theNumberOfPlanes,
+                        const char *numericalin,
+                        double      surfaceShift,
+			double *theSurfaceCornersLong, double *theSurfaceCornersLat,
+			double theDomainX, double theDomainY, double theDomainZ,
+			char* planes_input_file) {
+
+    char thePlaneDirOut[256];
+    static const char* fname = "output_planes_setup()";
+    double     *auxiliar;
+    char       planedisplacementsout[1024], planecoordsfile[1024];
+    int        iPlane, iCorner;
+    vector3D_t originPlaneCoords;
+    int        largestplanesize;
+    FILE*      fp;
+    FILE*      fp_planes;
+
+    if (myID == 0) {
+
+	/* obtain the general planes specifications in parameter file */
+	if ( (fp = fopen ( numericalin, "r")) == NULL ) {
+	    solver_abort (fname, numericalin,
+			  "Error opening parameters configuration file");
+	}
+	if ( (parsetext(fp, "output_planes_print_rate", 'i',
+			thePlanePrintRate) != 0) )
+	    {
+		solver_abort (fname, NULL, "Error parsing output_planes_print_rate field from %s\n",
+			      numericalin);
+	    }
+	auxiliar = (double *)malloc(sizeof(double)*8);
+	if ( parsedarray( fp, "domain_surface_corners", 8 ,auxiliar) !=0 ) {
+	    solver_abort (fname, NULL, "Error parsing domain_surface_corners field from %s\n",
+			  numericalin);
+	}
+	for ( iCorner = 0; iCorner < 4; iCorner++){
+	    theSurfaceCornersLong[ iCorner ] = auxiliar [ iCorner * 2 ];
+	    theSurfaceCornersLat [ iCorner ] = auxiliar [ iCorner * 2 +1 ];
+	}
+	free(auxiliar);
+
+	if ((parsetext(fp, "output_planes_directory", 's',
+		       &thePlaneDirOut) != 0))
+	    {
+		solver_abort( fname, NULL,
+			      "Error parsing output planes directory from %s\n",
+			      numericalin );
+	    }
+	thePlanes = (plane_t *) malloc ( sizeof( plane_t ) * theNumberOfPlanes);
+	if ( thePlanes == NULL ) {
+	    solver_abort( fname, "Allocating memory for planes array",
+			  "Unable to create plane information arrays" );
+	}
+	fclose(fp);
+
+
+	/* read in the individual planes coords in planes file */
+	if ( (fp_planes = fopen ( planes_input_file, "r")) == NULL ) {
+	    solver_abort (fname, planes_input_file,
+			  "Error opening planes configuration file");
+	}
+
+	int found=0;
+	while (!found) {
+	    char line[LINESIZE];
+	    char *name;
+	    char delimiters[] = " =\n";
+	    char querystring[] = "output_planes";
+	    /* Read in one line */
+	    if (fgets (line, LINESIZE, fp) == NULL) {
+		break;
+	    }
+	    name = strtok(line, delimiters);
+	    if ( (name != NULL) && (strcmp(name, querystring) == 0) ) {
+		largestplanesize = 0;
+		found = 1;
+		for ( iPlane = 0; iPlane < theNumberOfPlanes; iPlane++ ) {
+		    int fret0, fret1;
+		    FILE* fp0;
+		    FILE* fp1;
+		    fret0 = fscanf( fp_planes," %lf %lf %lf",
+				    &thePlanes[iPlane].origincoords.x[0],
+				    &thePlanes[iPlane].origincoords.x[1],
+				    &thePlanes[iPlane].origincoords.x[2] );
+
+		    /* RICARDO: Correction for buildings case */
+		    thePlanes[iPlane].origincoords.x[2] += surfaceShift;
+
+		    /* origin coordinates must be in Lat, Long and depth */
+		    if (fret0 == 0) {
+			solver_abort (fname, NULL,
+				      "Unable to read planes origin in %s",
+				      planes_input_file);
+		    }
+		    /* convert to cartesian refered to the mesh */
+                    originPlaneCoords =
+			compute_domain_coords_linearinterp(
+							   thePlanes[ iPlane ].origincoords.x[1],
+							   thePlanes[ iPlane ].origincoords.x[0],
+							   theSurfaceCornersLong ,
+							   theSurfaceCornersLat,
+							   theDomainY, theDomainX );
+
+                    thePlanes[iPlane].origincoords.x[0]=originPlaneCoords.x[0];
+                    thePlanes[iPlane].origincoords.x[1]=originPlaneCoords.x[1];
+
+                    fret1 = fscanf(fp_planes," %lf %d %lf %d %lf %lf",
+                                   &thePlanes[iPlane].stepalongstrike,
+                                   &thePlanes[iPlane].numberofstepsalongstrike,
+                                   &thePlanes[iPlane].stepdowndip,
+				   &thePlanes[iPlane].numberofstepsdowndip,
+                                   &thePlanes[iPlane].strike,
+                                   &thePlanes[iPlane].dip);
+                    /*Find largest plane for output buffer allocation */
+                    if ( (thePlanes[iPlane].numberofstepsdowndip
+                          * thePlanes[iPlane].numberofstepsalongstrike)
+                         > largestplanesize)
+			{
+			    largestplanesize
+				= thePlanes[iPlane].numberofstepsdowndip
+				* thePlanes[iPlane].numberofstepsalongstrike;
+			}
+                    if (fret1 == 0) {
+			solver_abort(fname, NULL,
+				     "Unable to read plane specification in %s",
+				     planes_input_file);
+                    }
+
+                    /* open displacement output files */
+                    sprintf( planedisplacementsout, "%s/planedisplacements.%d",
+                             thePlaneDirOut, iPlane );
+                    fp0 = hu_fopen( planedisplacementsout, "w" );
+
+                    thePlanes[iPlane].fpoutputfile = fp0;
+                    sprintf (planecoordsfile, "%s/planecoords.%d",
+                             thePlaneDirOut, iPlane);
+                    fp1 = hu_fopen (planecoordsfile, "w");
+                    thePlanes[iPlane].fpplanecoordsfile = fp1;
+		} /* for */
+	    } /* if ( (name != NULL) ... ) */
+	} /* while */
+
+	fclose(fp_planes);
+
+    } /* if (myID == 0) */
+
+    /* broadcast plane info */
+    MPI_Bcast( &theNumberOfPlanes, 1, MPI_INT, 0, comm_solver );
+    MPI_Bcast( thePlanePrintRate, 1, MPI_INT, 0, comm_solver );
+
+    /* initialize the local structures */
+    if (myID != 0) {
+	thePlanes = (plane_t*)malloc( sizeof( plane_t ) * theNumberOfPlanes );
+	if (thePlanes == NULL) {
+	    solver_abort( "broadcast_planeinfo", NULL,
+			  "Error: Unable to create plane information arrays" );
+	}
+    }
+
+    for ( iPlane = 0; iPlane < theNumberOfPlanes; iPlane++ ) {
+	MPI_Bcast( &(thePlanes[iPlane].numberofstepsalongstrike), 1, MPI_INT, 0, comm_solver);
+	MPI_Bcast( &(thePlanes[iPlane].numberofstepsdowndip), 1, MPI_INT, 0, comm_solver);
+	MPI_Bcast( &(thePlanes[iPlane].stepalongstrike), 1, MPI_DOUBLE,0, comm_solver);
+	MPI_Bcast( &(thePlanes[iPlane].stepdowndip), 1, MPI_DOUBLE,0, comm_solver);
+	MPI_Bcast( &(thePlanes[iPlane].strike), 1, MPI_DOUBLE,0, comm_solver);
+	MPI_Bcast( &(thePlanes[iPlane].dip), 1, MPI_DOUBLE,0, comm_solver);
+	MPI_Bcast( &(thePlanes[iPlane].rake), 1, MPI_DOUBLE,0, comm_solver);
+	MPI_Bcast( &(thePlanes[iPlane].origincoords.x[0]), 3, MPI_DOUBLE,0, comm_solver);
+	MPI_Barrier(comm_solver);
+    }
+
+    Old_output_planes_construct_strips(myID, theNumberOfPlanes);
+
+    /* master allocates largest plane */
+    if (myID == 0) {
+	planes_output_buffer = (double*)malloc( 3 * sizeof(double)
+						* largestplanesize );
+	if (planes_output_buffer == NULL) {
+	    fprintf(stderr, "Error creating buffer for plane output\n");
+	    exit(1);
+	}
+    }
+
+    print_planeinfo(myID, theNumberOfPlanes);
+
+    return;
+}
+
+/**
+ * This builds all of the strips used in the planes output. BigBen's
+ * version does not have strip size limits
+ */
+
+static void Old_output_planes_construct_strips(int32_t myID, int theNumberOfPlanes)
+{
+
+    //    int iNode, iPlane, iStrike, iDownDip;
+    int iPlane, iStrike, iDownDip;
+    double xLocal, yLocal;
+    vector3D_t origin, pointLocal, pointGlobal;
+    octant_t *octant;
+    int onstrip ;
+    //    int32_t nodesToInterpolate[8];
+
+    planes_LocalLargestStripCount = 0;
+
+    for ( iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++ ){
+	thePlanes[ iPlane ].numberofstripsthisplane = 0;
+	/* Compute the coordinates of the nodes of the plane */
+	origin.x[0] = thePlanes[ iPlane ].origincoords.x[0];
+	origin.x[1] = thePlanes[ iPlane ].origincoords.x[1];
+	origin.x[2] = thePlanes[ iPlane ].origincoords.x[2];
+
+	/*Find limits of consecutive strips*/
+	onstrip = 0;
+	for ( iStrike = 0;
+	      iStrike < thePlanes[iPlane].numberofstepsalongstrike;
+	      iStrike++ )
+	    {
+		xLocal = iStrike*thePlanes[iPlane].stepalongstrike;
+		for ( iDownDip = 0;
+		      iDownDip < thePlanes[iPlane].numberofstepsdowndip;
+		      iDownDip++ )
+		    {
+			yLocal = iDownDip*thePlanes[ iPlane ].stepdowndip;
+			pointLocal.x[0] = xLocal;
+			pointLocal.x[1] = yLocal;
+			pointLocal.x[2] = 0;
+			pointGlobal
+			    = compute_global_coords( origin, pointLocal,
+						     thePlanes[ iPlane ].dip, 0,
+						     thePlanes[ iPlane ].strike );
+
+			if (search_point( pointGlobal, &octant ) == 1) {
+			    if (!onstrip) { /* start new strip */
+				thePlanes[iPlane].stripstart[thePlanes[iPlane].numberofstripsthisplane]
+				    = (iStrike * thePlanes[iPlane].numberofstepsdowndip
+				       + iDownDip);
+				onstrip = 1;
+			    }
+
+			}
+
+			else {
+			    if (onstrip) { /* close strip */
+				onstrip = 0;
+				thePlanes[iPlane].stripend[thePlanes[iPlane]
+							   .numberofstripsthisplane]
+				    = (iStrike * thePlanes[iPlane].numberofstepsdowndip
+				       + iDownDip - 1);
+				thePlanes[ iPlane ].numberofstripsthisplane++;
+				if (thePlanes[ iPlane ].numberofstripsthisplane
+				    > MAX_STRIPS_PER_PLANE)
+				    {
+					fprintf( stderr,
+						 "Number of strips on plane exceeds "
+						 "MAX_STRIPS_PER_PLANE\n");
+					exit(1);
+				    }
+			    }
+			}
+		    }
+	    }
+
+	if (onstrip){  /*if on a strip at end of loop, close strip */
+            thePlanes[iPlane].stripend[thePlanes[iPlane].numberofstripsthisplane]
+		= (thePlanes[iPlane].numberofstepsdowndip
+		   * thePlanes[iPlane].numberofstepsalongstrike) - 1;
+            thePlanes[ iPlane ].numberofstripsthisplane++;
+	}
+
+	/* get strip counts to IO PEs */
+	MPI_Reduce( &thePlanes[ iPlane ].numberofstripsthisplane,
+		    &thePlanes[iPlane].globalnumberofstripsthisplane,
+		    1, MPI_INT, MPI_SUM, 0, comm_solver );
+
+	/* allocate strips */
+	int stripnum, stripLength;
+
+	for (stripnum = 0;
+	     stripnum < thePlanes[ iPlane ].numberofstripsthisplane;
+	     stripnum++)
+	    {
+		stripLength = thePlanes[iPlane].stripend[stripnum]
+		    - thePlanes[iPlane].stripstart[stripnum] + 1;
+
+		thePlanes[iPlane].strip[stripnum]
+		    = (plane_strip_element_t*)malloc( sizeof(plane_strip_element_t)
+						      * stripLength );
+		if (thePlanes[ iPlane ].strip[stripnum] == NULL) {
+		    fprintf( stderr,
+			     "Error malloc'ing array strips for plane output\n"
+			     "PE: %d  Plane: %d  Strip: %d  Size: %zu\n",
+			     myID, iPlane, stripnum,
+			     sizeof(plane_strip_element_t) * stripLength );
+		    exit(1);
+		}
+
+		if (stripLength>planes_LocalLargestStripCount) {
+		    planes_LocalLargestStripCount = stripLength;
+		}
+	    }
+
+	/* fill strips */
+	origin.x[0] = thePlanes[ iPlane ].origincoords.x[0];
+	origin.x[1] = thePlanes[ iPlane ].origincoords.x[1];
+	origin.x[2] = thePlanes[ iPlane ].origincoords.x[2];
+
+	int elemnum;
+	for (stripnum = 0;
+	     stripnum < thePlanes[ iPlane ].numberofstripsthisplane;
+	     stripnum++)
+	    {
+		for (elemnum = 0;
+		     elemnum < (thePlanes[iPlane].stripend[stripnum]
+				-thePlanes[iPlane].stripstart[stripnum] + 1);
+		     elemnum++)
+		    {
+			iStrike  = (elemnum+thePlanes[iPlane].stripstart[stripnum])
+			    / thePlanes[iPlane].numberofstepsdowndip;
+			iDownDip = (elemnum+thePlanes[iPlane].stripstart[stripnum])
+			    % thePlanes[iPlane].numberofstepsdowndip;
+			xLocal = iStrike*thePlanes[iPlane].stepalongstrike;
+			yLocal = iDownDip*thePlanes[ iPlane ].stepdowndip;
+			pointLocal.x[0] = xLocal;
+			pointLocal.x[1] = yLocal;
+			pointLocal.x[2] = 0;
+			pointGlobal
+			    =  compute_global_coords( origin, pointLocal,
+						      thePlanes[ iPlane ].dip, 0,
+						      thePlanes[ iPlane ].strike );
+			if (search_point( pointGlobal, &octant) == 1) {
+			    compute_csi_eta_dzeta( octant, pointGlobal,
+						   &(thePlanes[ iPlane ].strip[stripnum][elemnum].localcoords),
+						   thePlanes[ iPlane ].strip[stripnum][elemnum].nodestointerpolate);
+			}
+		    }
+	    }
+    } /* end of plane loop: for (stripnum = 0; ...) */
+
+    MPI_Reduce( &planes_LocalLargestStripCount,
+		&planes_GlobalLargestStripCount,
+		1, MPI_INT, MPI_MAX, 0, comm_solver );
+
+    /* allocate MPI recv buffers for IO PE */
+    if (myID == 0) {
+	int buf_len0 = (3 * planes_GlobalLargestStripCount) + 1;
+	planes_stripMPIRecvBuffer = (double*)malloc(sizeof(double) * buf_len0);
+
+	/* This is large enough for 3 double componants of biggest strip
+	   plus location number */
+	if (planes_stripMPIRecvBuffer == NULL) {
+	    perror("Error creating MPI master buffer strip for plane output\n");
+	    exit(1);
+	}
+    }
+
+    /* allocate MPI send buffers for all PEs */
+    int buf_len = (3 * planes_LocalLargestStripCount) + 1;
+    planes_stripMPISendBuffer = (double*)malloc( sizeof(double) * buf_len );
+
+    /* This is large enough for 3 double componants of biggest strip plus
+       location number */
+    if (planes_stripMPISendBuffer == NULL) {
+	fprintf(stderr,
+		"Error creating MPI send buffer strip for plane output\n");
+	exit(1);
+    }
+}
+
+/** Close planes files. */
+void Old_planes_close(int32_t myID, int theNumberOfPlanes)
+{
+    int iPlane;
+
+    if (myID==0){
+	for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++) {
+	    fclose( thePlanes[iPlane].fpoutputfile );
+	    fclose( thePlanes[iPlane].fpplanecoordsfile );
+	}
+    }
+}
+
+/** Print Plane Stats, and possibly old version plane coords file. */
+void print_planeinfo(int32_t myID, int theNumberOfPlanes)
+{
+    int iPlane;
+    int MaxStrip;
+
+    if (myID == 0) {
+	fprintf( stderr, "\nPlane Output Stats___________________________\n");
+
+	for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++) {
+	    fprintf( stderr, "Plane dimensions for plane #%d: %d,%d\n", iPlane,
+		     thePlanes[iPlane].numberofstepsalongstrike,
+		     thePlanes[iPlane].numberofstepsdowndip );
+	}
+
+	for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++) {
+	    fprintf( stderr, "Total strips for plane #%d: %d\n", iPlane,
+		     thePlanes[iPlane].globalnumberofstripsthisplane );
+	}
+    }
+
+    for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++) {
+	MPI_Reduce( &thePlanes[ iPlane ].numberofstripsthisplane, &MaxStrip,
+		    1, MPI_INT, MPI_MAX, 0, comm_solver );
+	if (myID==0) {
+	    fprintf(stderr, "Max strips for a PE in plane #%d: %d\n",
+		    iPlane, MaxStrip);
+	}
+    }
+
+    if (myID==0) {
+	fprintf(stderr,
+		"\nDone Plane Output Stats___________________________\n");
+	fflush( stderr );
+    }
+}
+
+
+/**************************************************************************/
+/*New IO Server Version Of Code Below Here*********************************/
+/**************************************************************************/
+
+
+void New_planes_setup( int32_t     PENum, int32_t *thePlanePrintRate,
+		       int theNumberOfPlanes,
+                       const char *numericalin,
+                       double      surfaceShift,
+		       double *theSurfaceCornersLong, double *theSurfaceCornersLat,
+		       double theDomainX, double theDomainY, double theDomainZ,
+                       char* planes_input_file) {
+
+    static const char* fname = "new_output_planes_setup()";
+    double     *auxiliar;
+    char       thePlaneDirOut[256];
+    int        iPlane, iCorner;
+    vector3D_t originPlaneCoords;
+    int largestplanesize;
+    FILE*      fp;
+    FILE*      fp_planes;
+
+    if (PENum == 0) {
+
+        /* obtain the general planes specifications in parameter file */
+	if ( (fp = fopen ( numericalin, "r")) == NULL ) {
+	    solver_abort (fname, numericalin,
+			  "Error opening parameters configuration file");
+	}
+	if ( (parsetext(fp, "output_planes_print_rate", 'i',
+			thePlanePrintRate) != 0) )
+	    {
+		solver_abort (fname, NULL, "Error parsing output_planes_print_rate field from %s\n",
+			      numericalin);
+	    }
+	auxiliar = (double *)malloc(sizeof(double)*8);
+	if ( parsedarray( fp, "domain_surface_corners", 8 ,auxiliar) !=0 ) {
+	    solver_abort (fname, NULL, "Error parsing domain_surface_corners field from %s\n",
+			  numericalin);
+	}
+	for ( iCorner = 0; iCorner < 4; iCorner++){
+	    theSurfaceCornersLong[ iCorner ] = auxiliar [ iCorner * 2 ];
+	    theSurfaceCornersLat [ iCorner ] = auxiliar [ iCorner * 2 +1 ];
+	}
+	free(auxiliar);
+
+	if ((parsetext(fp, "output_planes_directory", 's',
+		       &thePlaneDirOut) != 0))
+	    {
+		solver_abort( fname, NULL,
+			      "Error parsing output planes directory from %s\n",
+			      numericalin );
+	    }
+	thePlanes = (plane_t *) malloc ( sizeof( plane_t ) * theNumberOfPlanes);
+	if ( thePlanes == NULL ) {
+	    solver_abort( fname, "Allocating memory for planes array",
+			  "Unable to create plane information arrays" );
+	}
+	fclose(fp);
+
+        /* read in the individual planes coords in planes file */
+        if ( (fp_planes = fopen ( planes_input_file, "r")) == NULL ) {
+            solver_abort (fname, planes_input_file,
+                          "Error opening planes configuration file");
+        }
+
+	int found=0;
+	while (!found) {
+	    char line[LINESIZE];
+	    char *name;
+	    char delimiters[] = " =\n";
+	    char querystring[] = "output_planes";
+	    /* Read in one line */
+	    if (fgets (line, LINESIZE, fp) == NULL) {
+		break;
+	    }
+	    name = strtok(line, delimiters);
+	    if ( (name != NULL) && (strcmp(name, querystring) == 0) ) {
+		largestplanesize = 0;
+		found = 1;
+		for ( iPlane = 0; iPlane < theNumberOfPlanes; iPlane++ ) {
+		    int fret0, fret1;
+		    fret0 = fscanf( fp_planes," %lf %lf %lf",
+				    &thePlanes[iPlane].origincoords.x[0],
+				    &thePlanes[iPlane].origincoords.x[1],
+				    &thePlanes[iPlane].origincoords.x[2] );
+
+		    /* RICARDO: For buildings correction */
+		    thePlanes[iPlane].origincoords.x[2] += surfaceShift;
+
+		    /* origin coordinates must be in Lat, Long and depth */
+		    if (fret0 == 0) {
+			solver_abort (fname, NULL,
+				      "Unable to read planes origin in %s",
+				      planes_input_file);
+		    }
+		    /* convert to cartesian refered to the mesh */
+                    originPlaneCoords =
+			compute_domain_coords_linearinterp(
+							   thePlanes[ iPlane ].origincoords.x[1],
+							   thePlanes[ iPlane ].origincoords.x[0],
+							   theSurfaceCornersLong ,
+							   theSurfaceCornersLat,
+							   theDomainY, theDomainX );
+
+                    thePlanes[iPlane].origincoords.x[0]=originPlaneCoords.x[0];
+                    thePlanes[iPlane].origincoords.x[1]=originPlaneCoords.x[1];
+
+                    fret1 = fscanf(fp_planes," %lf %d %lf %d %lf %lf",
+                                   &thePlanes[iPlane].stepalongstrike,
+                                   &thePlanes[iPlane].numberofstepsalongstrike,
+                                   &thePlanes[iPlane].stepdowndip,
+				   &thePlanes[iPlane].numberofstepsdowndip,
+                                   &thePlanes[iPlane].strike,
+                                   &thePlanes[iPlane].dip);
+                    /*Find largest plane for output buffer allocation */
+                    if ( (thePlanes[iPlane].numberofstepsdowndip
+                          * thePlanes[iPlane].numberofstepsalongstrike)
+                         > largestplanesize)
+			{
+			    largestplanesize
+				= thePlanes[iPlane].numberofstepsdowndip
+				* thePlanes[iPlane].numberofstepsalongstrike;
+			}
+                    if (fret1 == 0) {
+			solver_abort(fname, NULL,
+				     "Unable to read plane specification in %s",
+				     planes_input_file);
+                    }
+
+		} /* for */
+	    } /* if ( (name != NULL) ... ) */
+	} /* while */
+
+	fclose(fp_planes);
+
+    } /* if (PENum == 0) */
+
+    /* broadcast plane info to whole IO group */
+    MPI_Bcast( &theNumberOfPlanes, 1, MPI_INT, 0, comm_IO );
+    MPI_Bcast( thePlanePrintRate, 1, MPI_INT, 0, comm_IO );
+    MPI_Bcast( &largestplanesize, 1, MPI_INT, 0, comm_IO );
+    MPI_Bcast( thePlaneDirOut, 256, MPI_CHAR, 0, comm_IO );
+
+
+    /* initialize the local structures */
+    if (PENum != 0) {
+	thePlanes = (plane_t*)malloc( sizeof( plane_t ) * theNumberOfPlanes );
+	if (thePlanes == NULL) {
+	    solver_abort( "broadcast_planeinfo", NULL,
+			  "Error: Unable to create plane information arrays" );
+	}
+    }
+
+    /* broadcast plane params to whole IO group */
+    for ( iPlane = 0; iPlane < theNumberOfPlanes; iPlane++ ) {
+	MPI_Bcast( &(thePlanes[iPlane].numberofstepsalongstrike), 1, MPI_INT, 0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].numberofstepsdowndip), 1, MPI_INT, 0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].stepalongstrike), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].stepdowndip), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].strike), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].dip), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].rake), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].origincoords.x[0]), 3, MPI_DOUBLE,0, comm_IO);
+	MPI_Barrier(comm_IO);
+    }
+
+    /* Assign IO Server PE to send this plane to */
+    for ( iPlane = 0; iPlane < theNumberOfPlanes; iPlane++ ) {
+	/* Simplest possible scheme, get more sophisticated later */
+	int IO_Group_Size;
+	MPI_Comm_size(comm_IO, &IO_Group_Size);
+	thePlanes[iPlane].IO_PE_num = IO_Group_Size-1;
+    }
+
+    New_output_planes_construct_strips(PENum, theNumberOfPlanes);
+
+    print_planeinfo(PENum, theNumberOfPlanes);
+
+    return;
+}
+
+
+/* This builds all of the strips used in the planes output. XT5
+   version does not have strip size limits */
+
+static void New_output_planes_construct_strips(int32_t myID, int theNumberOfPlanes)
+{
+
+    int iPlane, iStrike, iDownDip;
+    double xLocal, yLocal;
+    vector3D_t origin, pointLocal, pointGlobal;
+    octant_t *octant;
+    int onstrip ;
+
+    planes_LocalLargestStripCount = 0;
+
+    for ( iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++ ){
+	thePlanes[ iPlane ].numberofstripsthisplane = 0;
+	/* Compute the coordinates of the nodes of the plane */
+	origin.x[0] = thePlanes[ iPlane ].origincoords.x[0];
+	origin.x[1] = thePlanes[ iPlane ].origincoords.x[1];
+	origin.x[2] = thePlanes[ iPlane ].origincoords.x[2];
+
+	/*Find limits of consecutive strips*/
+	onstrip = 0;
+	for ( iStrike = 0;
+	      iStrike < thePlanes[iPlane].numberofstepsalongstrike;
+	      iStrike++ )
+	    {
+		xLocal = iStrike*thePlanes[iPlane].stepalongstrike;
+		for ( iDownDip = 0;
+		      iDownDip < thePlanes[iPlane].numberofstepsdowndip;
+		      iDownDip++ )
+		    {
+			yLocal = iDownDip*thePlanes[ iPlane ].stepdowndip;
+			pointLocal.x[0] = xLocal;
+			pointLocal.x[1] = yLocal;
+			pointLocal.x[2] = 0;
+			pointGlobal
+			    = compute_global_coords( origin, pointLocal,
+						     thePlanes[ iPlane ].dip, 0,
+						     thePlanes[ iPlane ].strike );
+
+			if (search_point( pointGlobal, &octant ) == 1) {
+			    if (!onstrip) { /* start new strip */
+				thePlanes[iPlane].stripstart[thePlanes[iPlane].numberofstripsthisplane]
+				    = (iStrike * thePlanes[iPlane].numberofstepsdowndip
+				       + iDownDip);
+				onstrip = 1;
+			    }
+
+			}
+
+			else {
+			    if (onstrip) { /* close strip */
+				onstrip = 0;
+				thePlanes[iPlane].stripend[thePlanes[iPlane]
+							   .numberofstripsthisplane]
+				    = (iStrike * thePlanes[iPlane].numberofstepsdowndip
+				       + iDownDip - 1);
+				thePlanes[ iPlane ].numberofstripsthisplane++;
+				if (thePlanes[ iPlane ].numberofstripsthisplane
+				    > MAX_STRIPS_PER_PLANE)
+				    {
+					fprintf( stderr,
+						 "Number of strips on plane exceeds "
+						 "MAX_STRIPS_PER_PLANE\n");
+					exit(1);
+				    }
+			    }
+			}
+		    }
+	    }
+
+	if (onstrip){  /*if on a strip at end of loop, close strip */
+            thePlanes[iPlane].stripend[thePlanes[iPlane].numberofstripsthisplane]
+		= (thePlanes[iPlane].numberofstepsdowndip
+		   * thePlanes[iPlane].numberofstepsalongstrike) - 1;
+            thePlanes[ iPlane ].numberofstripsthisplane++;
+	}
+
+	/* get strip counts to IO PEs */
+	MPI_Reduce( &thePlanes[ iPlane ].numberofstripsthisplane,
+		    &thePlanes[iPlane].globalnumberofstripsthisplane,
+		    1, MPI_INT, MPI_SUM, 0, comm_solver );
+	MPI_Bcast( &thePlanes[iPlane].globalnumberofstripsthisplane, 1, MPI_INT, 0, comm_IO );
+
+	/* allocate strips */
+	int stripnum, stripLength;
+
+	for (stripnum = 0;
+	     stripnum < thePlanes[ iPlane ].numberofstripsthisplane;
+	     stripnum++)
+	    {
+		stripLength = thePlanes[iPlane].stripend[stripnum]
+		    - thePlanes[iPlane].stripstart[stripnum] + 1;
+
+		thePlanes[iPlane].strip[stripnum]
+		    = (plane_strip_element_t*)malloc( sizeof(plane_strip_element_t)
+						      * stripLength );
+		if (thePlanes[ iPlane ].strip[stripnum] == NULL) {
+		    fprintf( stderr,
+			     "Error malloc'ing array strips for plane output\n"
+			     "PE: %d  Plane: %d  Strip: %d  Size: %zu\n",
+			     myID, iPlane, stripnum,
+			     sizeof(plane_strip_element_t) * stripLength );
+		    exit(1);
+		}
+
+		if (stripLength>planes_LocalLargestStripCount) {
+		    planes_LocalLargestStripCount = stripLength;
+		}
+	    }
+
+	/* fill strips */
+	origin.x[0] = thePlanes[ iPlane ].origincoords.x[0];
+	origin.x[1] = thePlanes[ iPlane ].origincoords.x[1];
+	origin.x[2] = thePlanes[ iPlane ].origincoords.x[2];
+
+	int elemnum;
+	for (stripnum = 0;
+	     stripnum < thePlanes[ iPlane ].numberofstripsthisplane;
+	     stripnum++)
+	    {
+		for (elemnum = 0;
+		     elemnum < (thePlanes[iPlane].stripend[stripnum]
+				-thePlanes[iPlane].stripstart[stripnum] + 1);
+		     elemnum++)
+		    {
+			iStrike  = (elemnum+thePlanes[iPlane].stripstart[stripnum])
+			    / thePlanes[iPlane].numberofstepsdowndip;
+			iDownDip = (elemnum+thePlanes[iPlane].stripstart[stripnum])
+			    % thePlanes[iPlane].numberofstepsdowndip;
+			xLocal = iStrike*thePlanes[iPlane].stepalongstrike;
+			yLocal = iDownDip*thePlanes[ iPlane ].stepdowndip;
+			pointLocal.x[0] = xLocal;
+			pointLocal.x[1] = yLocal;
+			pointLocal.x[2] = 0;
+			pointGlobal
+			    =  compute_global_coords( origin, pointLocal,
+						      thePlanes[ iPlane ].dip, 0,
+						      thePlanes[ iPlane ].strike );
+			if (search_point( pointGlobal, &octant) == 1) {
+			    compute_csi_eta_dzeta( octant, pointGlobal,
+						   &(thePlanes[ iPlane ].strip[stripnum][elemnum].localcoords),
+						   thePlanes[ iPlane ].strip[stripnum][elemnum].nodestointerpolate);
+			}
+		    }
+	    }
+    } /* end of plane loop: for (stripnum = 0; ...) */
+
+    MPI_Reduce( &planes_LocalLargestStripCount,
+		&planes_GlobalLargestStripCount,
+		1, MPI_INT, MPI_MAX, 0, comm_solver );
+    MPI_Bcast( &planes_GlobalLargestStripCount, 1, MPI_INT, 0, comm_IO );
+
+    /* allocate MPI send buffers for all PEs */
+    int buf_len = (3 * planes_LocalLargestStripCount) + 1;
+    planes_stripMPISendBuffer = (double*)malloc( sizeof(double) * buf_len );
+
+    /* This is large enough for 3 double componants of biggest strip plus
+       location number */
+    if (planes_stripMPISendBuffer == NULL) {
+	fprintf(stderr,
+		"Error creating MPI send buffer strip for plane output\n");
+	exit(1);
+    }
+}
+
+/**
+ * Interpolate the displacenents and communicate strips to printing PE.
+ * Bigben version has no control flow, just chugs through planes.
+ */
+int New_planes_print(int32_t PENum, mysolver_t* mySolver, int theNumberOfPlanes)
+{
+    int iPlane, iPhi;
+    int stripLength;
+    int iStrip, elemnum;
+
+    /* Auxiliar array to handle shapefunctions in a loop */
+    double  xi[3][8]={ {-1,  1, -1,  1, -1,  1, -1, 1} ,
+		       {-1, -1,  1,  1, -1, -1,  1, 1} ,
+		       {-1, -1, -1, -1,  1,  1,  1, 1} };
+
+    double      phi[8];
+    double      displacementsX, displacementsY, displacementsZ;
+
+    for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++) {
+	for (iStrip = 0; iStrip < thePlanes[iPlane].numberofstripsthisplane;
+	     iStrip++) {
+
+	    /* interpolate points directly into send buffer for this strip */
+	    for (elemnum = 0;
+		 elemnum < (thePlanes[iPlane].stripend[iStrip]
+			    -thePlanes[iPlane].stripstart[iStrip]+1);
+		 elemnum++){
+		displacementsX = 0;displacementsY = 0;displacementsZ = 0;
+
+		/* Interpolate the element */
+		for (iPhi = 0; iPhi < 8; iPhi++){
+		    phi[iPhi] = ( 1 + (xi[0][iPhi]) *
+				  (thePlanes[iPlane].strip[iStrip][elemnum].localcoords.x[0]) )
+			* ( 1 + (xi[1][iPhi]) *
+			    (thePlanes[iPlane].strip[iStrip][elemnum].localcoords.x[1]) )
+			* ( 1 + (xi[2][iPhi]) *
+			    (thePlanes[iPlane].strip[iStrip][elemnum].localcoords.x[2]) ) /8;
+
+		    displacementsX += phi[iPhi]*
+			(mySolver->tm1[ thePlanes[iPlane].strip[iStrip][elemnum].nodestointerpolate[iPhi] ].f[0]);
+		    displacementsY += phi[iPhi]*
+			(mySolver->tm1[ thePlanes[iPlane].strip[iStrip][elemnum].nodestointerpolate[iPhi] ].f[1]);
+		    displacementsZ += phi[iPhi]*
+			(mySolver->tm1[ thePlanes[iPlane].strip[iStrip][elemnum].nodestointerpolate[iPhi] ].f[2]);
+		}
+
+		planes_stripMPISendBuffer[elemnum*3]     = (double) (displacementsX);
+		planes_stripMPISendBuffer[elemnum*3 + 1] = (double) (displacementsY);
+		planes_stripMPISendBuffer[elemnum*3 + 2] = (double) (displacementsZ);
+
+	    } /*for elemnum*/
+
+	    /* add start location as last element, add .1 to insure int-float conversion (yes, bad form)*/
+	    stripLength = thePlanes[iPlane].stripend[iStrip]
+		- thePlanes[iPlane].stripstart[iStrip] + 1;
+
+	    planes_stripMPISendBuffer[stripLength*3]
+		= (double) (thePlanes[iPlane].stripstart[iStrip] + 0.1);
+
+	    MPI_Send( planes_stripMPISendBuffer, (stripLength*3)+1,
+		      MPI_DOUBLE, thePlanes[iPlane].IO_PE_num, iPlane, comm_IO );
+
+	} /*for iStrips*/
+
+
+	MPI_Barrier( comm_solver ); /* may not be required */
+
+
+    } /* for iPlane */
+
+    return 1;
+}
+
+
+/** Close planes files. */
+void New_planes_close(int32_t PEnum, int theNumberOfPlanes){
+
+    int IO_Server_PE, iPlane;
+
+    if (PEnum==0){
+	/* Simplest possible scheme, do loop for multiple server PEs later */
+	MPI_Comm_size(comm_IO, &IO_Server_PE);
+	IO_Server_PE--;
+	planes_stripMPISendBuffer[0]= (STOP_SERVER + 0.1);
+	for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++)
+	    MPI_Send( planes_stripMPISendBuffer, 1, MPI_DOUBLE, IO_Server_PE, iPlane, comm_IO );
+    }
+}
+
+
+
+/* Server IO PEs Main Loop */
+void planes_IO_PES_main(int32_t PEnum){
+
+    int        largestplanesize, comm_size, iPlane;
+    MPI_Status status;
+    char       thePlaneDirOut[256], planedisplacementsout[1024];
+    FILE*      fp0;
+    int32_t    thePlanePrintRate;
+    int        theNumberOfPlanes;
+
+    /* Get basic planes parameters */
+    MPI_Bcast( &theNumberOfPlanes, 1, MPI_INT, 0, comm_IO );
+    MPI_Bcast( &thePlanePrintRate, 1, MPI_INT, 0, comm_IO );
+    MPI_Bcast( &largestplanesize, 1, MPI_INT, 0, comm_IO );
+    MPI_Bcast( thePlaneDirOut, 256, MPI_CHAR, 0, comm_IO );
+
+    if(theNumberOfPlanes==0) return;
+
+    /* Create Planes info structure */
+    thePlanes = (plane_t*)malloc( sizeof( plane_t ) * theNumberOfPlanes );
+    if (thePlanes == NULL) {
+	solver_abort( "broadcast_planeinfo", NULL,
+		      "Error: Unable to create plane information arrays" );
+    }
+
+    /* Get plane params */
+    for ( iPlane = 0; iPlane < theNumberOfPlanes; iPlane++ ) {
+	MPI_Bcast( &(thePlanes[iPlane].numberofstepsalongstrike), 1, MPI_INT, 0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].numberofstepsdowndip), 1, MPI_INT, 0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].stepalongstrike), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].stepdowndip), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].strike), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].dip), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].rake), 1, MPI_DOUBLE,0, comm_IO);
+	MPI_Bcast( &(thePlanes[iPlane].origincoords.x[0]), 3, MPI_DOUBLE,0, comm_IO);
+	MPI_Barrier(comm_IO);
+    }
+
+    /* Get strip count for each plane */
+    for (iPlane = 0; iPlane < theNumberOfPlanes; iPlane++)
+	MPI_Bcast( &thePlanes[iPlane].globalnumberofstripsthisplane, 1, MPI_INT, 0, comm_IO );
+
+    /* Find size of largest strip */
+    MPI_Bcast( &planes_GlobalLargestStripCount, 1, MPI_INT, 0, comm_IO );
+
+    /* Idle IO Pool PEs can leave, don't use collectives past here! */
+    MPI_Comm_size(comm_IO, &comm_size);
+    if (PEnum < (comm_size-1)) return;
+
+    /* Allocate largest required strip recieve buffer */
+    int buf_len0 = (3 * planes_GlobalLargestStripCount) + 1;
+    planes_stripMPIRecvBuffer = (double*)malloc(sizeof(double) * buf_len0);
+    /* large enough for 3 double of biggest strip plus location number */
+    if (planes_stripMPIRecvBuffer == NULL) {
+	perror("Error creating MPI master buffer strip for plane output\n");
+	exit(1);
+    }
+
+    /* Allocate largest plane output buffer */
+    planes_output_buffer = (double*)malloc( 3 * sizeof(double)
+					    * largestplanesize );
+    if (planes_output_buffer == NULL) {
+	fprintf(stderr, "Error creating buffer for plane output\n");
+	exit(1);
+    }
+
+    /* open displacement output files */
+    /* for multiple IO server PEs, will need to make sure these are handled on each one */
+    for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++){
+	sprintf( planedisplacementsout, "%s/planedisplacements.%d",
+		 thePlaneDirOut, iPlane );
+	fp0 = fopen( planedisplacementsout, "w" );
+	thePlanes[iPlane].fpoutputfile = fp0;
+	/* Not activating planecoored files yet
+	   sprintf (planecoordsfile, "%s/planecoords.%d",
+	   thePlaneDirOut, iPlane);
+	   fp1 = fopen (planecoordsfile, "w");
+	   thePlanes[iPlane].fpplanecoordsfile = fp1;
+	   Turn this on when and if it is needed */
+    }
+
+    while(1){
+
+	int StartLocation, recvStripCount, rStrip;
+
+	/* Get any message from anywhere */
+	MPI_Recv( planes_stripMPIRecvBuffer, planes_GlobalLargestStripCount * 3 + 1, MPI_DOUBLE,
+		  MPI_ANY_SOURCE, MPI_ANY_TAG, comm_IO, &status );
+	MPI_Get_count(&status, MPI_DOUBLE, &recvStripCount);
+
+	/* Check for a stop message */
+	if( recvStripCount == 1){
+	    if( (int)planes_stripMPIRecvBuffer[0] == STOP_SERVER)
+		break;
+	}
+	/* else pick this plane and fill in first strip */
+	else{
+	    iPlane = status.MPI_TAG;
+	    StartLocation = (int)planes_stripMPIRecvBuffer[recvStripCount-1];
+	    memcpy( &(planes_output_buffer[StartLocation * 3]),
+		    planes_stripMPIRecvBuffer,
+		    (recvStripCount-1)*sizeof(double) );
+	}
+
+	/* Fill in rest of this plane until full */
+	for (rStrip = 0; rStrip < (thePlanes[iPlane].globalnumberofstripsthisplane - 1); rStrip++) {
+	    MPI_Recv( planes_stripMPIRecvBuffer,
+		      planes_GlobalLargestStripCount * 3 + 1, MPI_DOUBLE,
+		      MPI_ANY_SOURCE, iPlane, comm_IO, &status );
+	    MPI_Get_count(&status, MPI_DOUBLE, &recvStripCount);
+	    StartLocation = (int)planes_stripMPIRecvBuffer[recvStripCount-1];
+	    memcpy( &(planes_output_buffer[StartLocation * 3]),
+		    planes_stripMPIRecvBuffer,
+		    (recvStripCount-1)*sizeof(double) );
+	}
+
+	/* Print just this one plane */
+	int ret, items_to_write;
+	items_to_write = 3 * thePlanes[iPlane].numberofstepsalongstrike * thePlanes[iPlane].numberofstepsdowndip;
+	ret = fwrite( planes_output_buffer, sizeof(double), items_to_write, thePlanes[iPlane].fpoutputfile );
+	if (ret != items_to_write)
+	    solver_abort( "IO_Server_Main_Loop", NULL, "Error: Unable to output displacement file to disk" );
+
+    }/*while*/
+
+    /* Close all planes.  Will need to make sure these are seperated on multiple PEs*/
+    int ret;
+    for (iPlane = 0; iPlane < theNumberOfPlanes ;iPlane++){
+	ret = fclose( thePlanes[iPlane].fpoutputfile );
+	/* if (!ret) printf("Error closing plane file %d!!!\n", iPlane);  Sort this out later*/
+    }
+
+    return;
+
+}

--- a/quake/forward_gpu/io_planes.h
+++ b/quake/forward_gpu/io_planes.h
@@ -1,0 +1,30 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include "psolve.h"
+
+extern int planes_print(int32_t myID, int IO_pool_pe_count, int theNumberOfPlanes, 
+			mysolver_t* mySolver);
+extern void planes_setup(int32_t myID, int32_t *thePlanePrintRate, int IO_pool_pe_count,
+			 int theNumberOfPlanes, const char *numericalin, double surfaceShift,
+			 double *theSurfaceCornersLong, double *theSurfaceCornersLat,
+			 double theDomainX, double theDomainY, double theDomainZ,
+			 char* planes_input_file);
+extern void planes_close(int32_t myID, int IO_pool_pe_count, int theNumberOfPlanes);
+extern void planes_IO_PES_main(int32_t myID);

--- a/quake/forward_gpu/kernel.cu
+++ b/quake/forward_gpu/kernel.cu
@@ -1,0 +1,355 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "psolve.h"
+#include "kernel.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+
+/**
+ * For regular simulations use 1e-20.  For performance and scalability,
+ * uncomment the immediate return in vector_is_zero() and vector_is_all_zero().
+ * Alternatives with each platform underflow precision limit for 'double'
+ * may also work, though this have not been thoroughly tested.
+ *
+ * Known underflow limits:
+ * - NICS' Kraken: Limit is ~2.2e-308 --> use 1e-200
+ *
+ */
+#define UNDERFLOW_CAP_STIFFNESS 1e-20
+
+
+/* Stiffness Calc-Force Kernel */
+__global__  void kernelStiffnessCalcLocal(int32_t   myLinearElementsCount,
+					 int32_t*  myLinearElementsMapperDevice,
+					 elem_t*   elemTableDevice,
+					 e_t*      eTableDevice,
+					 fvector_t* tm1Device,
+					 fvector_t* localForceDevice) 
+{
+    fvector_t *localForce;
+    fvector_t curDisp[8];
+    int       i;
+    int32_t   eindex;
+    int32_t   lin_eindex = (blockIdx.x * blockDim.x) + threadIdx.x; 
+
+    elem_t* elemp;
+    e_t*    ep;
+
+    /* Since number of elements may not be exactly divisible by block size,
+       check that we are not off the end of the element array */
+    if (lin_eindex >= myLinearElementsCount) {
+      return;
+    }
+
+    localForce = &(localForceDevice[lin_eindex*8]);
+
+    eindex = myLinearElementsMapperDevice[lin_eindex];
+    elemp  = &(elemTableDevice[eindex]);
+    ep     = &(eTableDevice[eindex]);
+  
+    memset( localForce, 0, 8 * sizeof(fvector_t) );
+  
+    for (i = 0; i < 8; i++) {
+      int32_t    lnid = elemp->lnid[i];
+      fvector_t* tm1Disp = tm1Device + lnid;
+      //	    fvector_t* tm2Disp = tm2Device + lnid;
+      
+      curDisp[i].f[0] = tm1Disp->f[0];
+      curDisp[i].f[1] = tm1Disp->f[1];
+      curDisp[i].f[2] = tm1Disp->f[2];
+      
+    }
+    
+    /* Coefficients for new stiffness matrix calculation */
+    if (vector_is_zero( curDisp ) != 0) {
+      
+      double first_coeff  = -0.5625 * (ep->c2 + 2 * ep->c1);
+      double second_coeff = -0.5625 * (ep->c2);
+      double third_coeff  = -0.5625 * (ep->c1);
+      
+      double atu[24];
+      double firstVec[24];
+      
+      aTransposeU( curDisp, atu );
+      firstVector( atu, firstVec, first_coeff, second_coeff, third_coeff );
+      au( localForce, firstVec );
+    }
+}
+
+
+/* Stiffness Add-force Kernel */
+__global__  void kernelStiffnessAddLocal(int32_t nharbored,
+					 rev_entry_t* reverseLookupDevice,
+					 fvector_t* localForceDevice,
+					 fvector_t* forceDevice)
+{
+    int i;
+    int32_t   noffset;
+    int32_t   lnid = (blockIdx.x * blockDim.x) + threadIdx.x; 
+
+    rev_entry_t* revp;
+    fvector_t*   nodalForce;
+    fvector_t* localForce;
+
+    /* Since number of nodes may not be exactly divisible by block size,
+       check that we are not off the end of the node array */
+    if (lnid >= nharbored) {
+      return;
+    }
+
+    revp       = reverseLookupDevice + lnid;
+    nodalForce = forceDevice + lnid;
+
+    for (i = 0; i < revp->count; i++) {
+      noffset = revp->elements[i].offset;
+      localForce = &(localForceDevice[(revp->elements[i].elemid)*8]);
+
+      nodalForce->f[0] += localForce[noffset].f[0];
+      nodalForce->f[1] += localForce[noffset].f[1];
+      nodalForce->f[2] += localForce[noffset].f[2];
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+/*                         Efficient Method Utilities                         */
+/* -------------------------------------------------------------------------- */
+
+
+/**
+ * For effective stiffness method:
+ *
+ * Check whether all components of a 3D vector are close to zero,
+ * i.e., less than a small threshold.
+ *
+ * \return 1 when there is at least one "non-zero" component;
+ *         0 when all the components are "zero".
+ */
+__host__ __device__ int vector_is_zero( const fvector_t* v )
+{
+    /*
+     * For scalability studies, uncomment the immediate return.
+     */
+
+    /* return 1; */
+
+    int i,j;
+
+    for (i = 0; i < 8; i++) {
+        for(j = 0; j < 3; j++){
+            if (fabs( v[i].f[j] ) > UNDERFLOW_CAP_STIFFNESS) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+
+__host__ __device__ void aTransposeU( fvector_t* un, double* atu )
+{
+    double temp[24];
+    double u[24];
+    int    i, j;
+
+    /* arrange displacement values in an array */
+    for (i=0; i<8; i++) {
+        for(j=0; j<3; j++) {
+            temp[i*3 + j] = un[i].f[j];     /* u1 u2 u3 .... v1 v2 v3 ... z1 z2 z3 */
+	}
+    }
+
+    reformU( temp, u );
+
+    /* atu[0] = u[0] + u[1] + u[2] + u[3] + u[4] + u[5] + u[6] + u[7]; */
+    atu[0]  = 0;
+    atu[1]  = -u[0] - u[1] - u[2] - u[3] + u[4] + u[5] + u[6] + u[7];
+    atu[2]  = -u[0] - u[1] + u[2] + u[3] - u[4] - u[5] + u[6] + u[7];
+    atu[3]  = -u[0] + u[1] - u[2] + u[3] - u[4] + u[5] - u[6] + u[7];
+    atu[4]  =  u[0] + u[1] - u[2] - u[3] - u[4] - u[5] + u[6] + u[7];
+    atu[5]  =  u[0] - u[1] + u[2] - u[3] - u[4] + u[5] - u[6] + u[7];
+    atu[6]  =  u[0] - u[1] - u[2] + u[3] + u[4] - u[5] - u[6] + u[7];
+    atu[7]  = -u[0] + u[1] + u[2] - u[3] + u[4] - u[5] - u[6] + u[7];
+
+    /* atu[8] = u[8] + u[9] + u[10] + u[11] + u[12] + u[13] + u[14] + u[15]; */
+    atu[8]  = 0;
+    atu[9]  = -u[8] - u[9] - u[10] - u[11] + u[12] + u[13] + u[14] + u[15];
+    atu[10] = -u[8] - u[9] + u[10] + u[11] - u[12] - u[13] + u[14] + u[15];
+    atu[11] = -u[8] + u[9] - u[10] + u[11] - u[12] + u[13] - u[14] + u[15];
+    atu[12] =  u[8] + u[9] - u[10] - u[11] - u[12] - u[13] + u[14] + u[15];
+    atu[13] =  u[8] - u[9] + u[10] - u[11] - u[12] + u[13] - u[14] + u[15];
+    atu[14] =  u[8] - u[9] - u[10] + u[11] + u[12] - u[13] - u[14] + u[15];
+    atu[15] = -u[8] + u[9] + u[10] - u[11] + u[12] - u[13] - u[14] + u[15];
+
+    /* atu[16] = u[16] + u[17] + u[18] + u[19] + u[20] + u[21] + u[22] + u[23]; */
+    atu[16] = 0;
+    atu[17] = -u[16] - u[17] - u[18] - u[19] + u[20] + u[21] + u[22] + u[23];
+    atu[18] = -u[16] - u[17] + u[18] + u[19] - u[20] - u[21] + u[22] + u[23];
+    atu[19] = -u[16] + u[17] - u[18] + u[19] - u[20] + u[21] - u[22] + u[23];
+    atu[20] =  u[16] + u[17] - u[18] - u[19] - u[20] - u[21] + u[22] + u[23];
+    atu[21] =  u[16] - u[17] + u[18] - u[19] - u[20] + u[21] - u[22] + u[23];
+    atu[22] =  u[16] - u[17] - u[18] + u[19] + u[20] - u[21] - u[22] + u[23];
+    atu[23] = -u[16] + u[17] + u[18] - u[19] + u[20] - u[21] - u[22] + u[23];
+}
+
+__host__ __device__ void firstVector( const double* atu, 
+				      double* finalVector, 
+				      double a, 
+				      double c, 
+				      double b )
+{
+    finalVector[0] = 0;
+    finalVector[1] = b * (atu[19] + atu[1]);
+    finalVector[2] = b * (atu[11] + atu[2]);
+    finalVector[3] = a * atu[3] + c * (atu[10] + atu[17]);
+    finalVector[4] = b * (atu[13] + atu[22] + 2. * atu[4]) / 3.;
+    finalVector[5] = ( (a + b) * atu[5] + c * atu[12] ) /3.;
+    finalVector[6] = ( (a + b) * atu[6] + c * atu[20] ) /3.;
+    finalVector[7] = ( (a + 2.*b) * atu[7] ) / 9.;
+
+    finalVector[8] = 0;
+    finalVector[9] = b * (atu[18] + atu[9]);
+    finalVector[10] = a * atu[10] + c * (atu[3] + atu[17]);
+    finalVector[11] = b * (atu[11] + atu[2]);
+    finalVector[12] = ( (a + b) * atu[12] + c * atu[5] ) / 3.;
+    finalVector[13] = b * (atu[4] + atu[22] + 2. * atu[13]) / 3.;
+    finalVector[14] = ( (a + b) * atu[14] + c * atu[21] ) /3.;
+    finalVector[15] = (a + 2. * b) * atu[15] / 9.;
+
+    finalVector[16] = 0;
+    finalVector[17] = a * atu[17] + c * (atu[3] + atu[10]);
+    finalVector[18] = b * (atu[18] + atu[9]);
+    finalVector[19] = b * (atu[19] + atu[1]);
+    finalVector[20] = ( (a + b) * atu[20] + c * atu[6] ) / 3.;
+    finalVector[21] = ( (a + b) * atu[21] + c * atu[14] ) / 3.;
+    finalVector[22] = b * ( atu[4] + atu[13] + 2. * atu[22]) / 3.;
+    finalVector[23] = (a + 2. * b) * atu[23] / 9.;
+}
+
+
+__host__ __device__ void au( fvector_t* resVec, const double* u )
+{
+    int    i, j;
+    double finVec[24];
+    double temp[24];
+
+
+    finVec[0]  = u[0]  - u[1] - u[2] - u[3] + u[4] + u[5] + u[6] - u[7];
+    finVec[1]  = u[0]  - u[1] - u[2] + u[3] + u[4] - u[5] - u[6] + u[7];
+    finVec[2]  = u[0]  - u[1] + u[2] - u[3] - u[4] + u[5] - u[6] + u[7];
+    finVec[3]  = u[0]  - u[1] + u[2] + u[3] - u[4] - u[5] + u[6] - u[7];
+    finVec[4]  = u[0]  + u[1] - u[2] - u[3] - u[4] - u[5] + u[6] + u[7];
+    finVec[5]  = u[0]  + u[1] - u[2] + u[3] - u[4] + u[5] - u[6] - u[7];
+    finVec[6]  = u[0]  + u[1] + u[2] - u[3] + u[4] - u[5] - u[6] - u[7];
+    finVec[7]  = u[0]  + u[1] + u[2] + u[3] + u[4] + u[5] + u[6] + u[7];
+
+    finVec[8]  = u[8]  - u[9] - u[10] - u[11] + u[12] + u[13] + u[14] - u[15];
+    finVec[9]  = u[8]  - u[9] - u[10] + u[11] + u[12] - u[13] - u[14] + u[15];
+    finVec[10] = u[8]  - u[9] + u[10] - u[11] - u[12] + u[13] - u[14] + u[15];
+    finVec[11] = u[8]  - u[9] + u[10] + u[11] - u[12] - u[13] + u[14] - u[15];
+    finVec[12] = u[8]  + u[9] - u[10] - u[11] - u[12] - u[13] + u[14] + u[15];
+    finVec[13] = u[8]  + u[9] - u[10] + u[11] - u[12] + u[13] - u[14] - u[15];
+    finVec[14] = u[8]  + u[9] + u[10] - u[11] + u[12] - u[13] - u[14] - u[15];
+    finVec[15] = u[8]  + u[9] + u[10] + u[11] + u[12] + u[13] + u[14] + u[15];
+
+    finVec[16] = u[16] - u[17] - u[18] - u[19] + u[20] + u[21] + u[22] - u[23];
+    finVec[17] = u[16] - u[17] - u[18] + u[19] + u[20] - u[21] - u[22] + u[23];
+    finVec[18] = u[16] - u[17] + u[18] - u[19] - u[20] + u[21] - u[22] + u[23];
+    finVec[19] = u[16] - u[17] + u[18] + u[19] - u[20] - u[21] + u[22] - u[23];
+    finVec[20] = u[16] + u[17] - u[18] - u[19] - u[20] - u[21] + u[22] + u[23];
+    finVec[21] = u[16] + u[17] - u[18] + u[19] - u[20] + u[21] - u[22] - u[23];
+    finVec[22] = u[16] + u[17] + u[18] - u[19] + u[20] - u[21] - u[22] - u[23];
+    finVec[23] = u[16] + u[17] + u[18] + u[19] + u[20] + u[21] + u[22] + u[23];
+
+    reformF( finVec, temp );
+
+    for (j = 0; j<8; j++)
+    {
+        for (i = 0; i<3; i++)
+        {
+            resVec[j].f[i] += temp[j*3 + i];
+        }
+    }
+}
+
+
+__host__ __device__ void reformF( const double* u, double* newU )
+{
+    newU[0]  = u[0];
+    newU[1]  = u[8];
+    newU[2]  = u[16];
+    newU[3]  = u[1];
+    newU[4]  = u[9];
+    newU[5]  = u[17];
+    newU[6]  = u[2];
+    newU[7]  = u[10];
+    newU[8]  = u[18];
+    newU[9]  = u[3];
+    newU[10] = u[11];
+    newU[11] = u[19];
+    newU[12] = u[4];
+    newU[13] = u[12];
+    newU[14] = u[20];
+    newU[15] = u[5];
+    newU[16] = u[13];
+    newU[17] = u[21];
+    newU[18] = u[6];
+    newU[19] = u[14];
+    newU[20] = u[22];
+    newU[21] = u[7];
+    newU[22] = u[15];
+    newU[23] = u[23];
+}
+
+__host__ __device__ void reformU( const double* u, double* newU )
+{
+    newU[0]  = u[0];
+    newU[1]  = u[3];
+    newU[2]  = u[6];
+    newU[3]  = u[9];
+    newU[4]  = u[12];
+    newU[5]  = u[15];
+    newU[6]  = u[18];
+    newU[7]  = u[21];
+    newU[8]  = u[1];
+    newU[9]  = u[4];
+    newU[10] = u[7];
+    newU[11] = u[10];
+    newU[12] = u[13];
+    newU[13] = u[16];
+    newU[14] = u[19];
+    newU[15] = u[22];
+    newU[16] = u[2];
+    newU[17] = u[5];
+    newU[18] = u[8];
+    newU[19] = u[11];
+    newU[20] = u[14];
+    newU[21] = u[17];
+    newU[22] = u[20];
+    newU[23] = u[23];
+}

--- a/quake/forward_gpu/kernel.h
+++ b/quake/forward_gpu/kernel.h
@@ -1,0 +1,46 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef KERNEL_H_
+#define KERNEL_H_
+
+#include "psolve.h"
+
+#include <cuda_runtime.h>
+
+__global__  void kernelStiffnessCalcLocal(int32_t    myLinearElementsCount,
+				int32_t*   myLinearElementsMapperDevice,
+				elem_t*    elemTableDevice,
+				e_t*       eTableDevice,
+				fvector_t* tm1Device,
+				fvector_t* localForceDevice);
+
+__global__  void kernelStiffnessAddLocal(int32_t nharbored,
+					 rev_entry_t* reverseLookupDevice,
+					 fvector_t* localForceDevice,
+					 fvector_t* forceDevice);
+
+__host__ __device__ int vector_is_zero( const fvector_t* v );
+__host__ __device__ void aTransposeU( fvector_t* un, double* atu );
+__host__ __device__ void firstVector( const double* atu, double* finalVector, double a, double c, double b );
+__host__ __device__ void au( fvector_t* resVec, const double* u );
+__host__ __device__ void reformF( const double* u, double* newU );
+__host__ __device__ void reformU( const double* u, double* newU );
+
+#endif /* KERNEL_H_ */

--- a/quake/forward_gpu/meshformatlab.cu
+++ b/quake/forward_gpu/meshformatlab.cu
@@ -1,0 +1,250 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cvm.h"
+#include "psolve.h"
+#include "commutil.h"
+#include "util.h"
+#include "quake_util.h"
+#include "damping.h"
+#include "buildings.h"
+#include "meshformatlab.h"
+
+
+/* -------------------------------------------------------------------------- */
+/*                             Global Variables                               */
+/* -------------------------------------------------------------------------- */
+
+static char      theMeshDirMatlab[256];
+
+
+static double 	 theMatlabXMax,   theMatlabXMin,
+theMatlabYMax,   theMatlabYMin,
+theMatlabZMax,   theMatlabZMin;
+
+/* -------------------------------------------------------------------------- */
+/*                                 Utilities                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Saves coordinates and data of specified elements as an output binary file
+ * for MATLAB. also print damping ratios for rayleigh
+ */
+void saveMeshCoordinatesForMatlab( mesh_t      *myMesh,       int32_t myID,
+		const char  *parametersin, double  ticksize,
+		damping_type_t theTypeOfDamping, double xoriginm, double yoriginm,
+		double zoriginm, noyesflag_t includeBuildings)
+{
+
+	int      i, j, k, counter = 0;
+
+	double   double_message[6];
+	double   *auxiliar;
+	double   x_coord, y_coord, z_coord;
+
+	edata_t  *edata_temp;
+
+	FILE     *meshcoordinates;
+	FILE     *meshdata;
+	FILE     *fp;
+
+	static char    filename_coord [256];
+	static char    filename_data  [256];
+
+
+	/*Allocate memory to temporarily store coordinates of region to be plotted*/
+
+	auxiliar = (double*)malloc( sizeof(double) * 6 );
+
+	if ( auxiliar == NULL ) {
+		fprintf( stderr, "Err allocing mem in saveMeshCoordinatesForMatlab" );
+	}
+
+	/**
+	 * Parsing the name of the directory of mesh coordinates and corners of
+	 * region to be plotted for Matlab .
+	 */
+	if ( myID == 0 ) {
+
+		if ( (fp = fopen ( parametersin, "r")) == NULL ) {
+			solver_abort ("saveMeshCoordinatesForMatlab", parametersin,
+					"Error opening parameters.in configuration file");
+		}
+
+		if ( parsetext ( fp, "mesh_coordinates_directory_for_matlab",'s',
+				theMeshDirMatlab )!= 0 ) {
+			solver_abort ( "saveMeshCoordinatesForMatlab", NULL,
+					"Error parsing fields from %s\n", parametersin); }
+
+		if ( parsedarray( fp, "mesh_corners_matlab", 6 , auxiliar ) != 0)
+		{
+			fprintf(stderr, "Error parsing mesh_corners_matlab list from %s\n",
+					parametersin);
+		}
+
+		/**
+		 *We convert physical coordinates into etree coordinates
+		 *(divide by ticksize)
+		 *
+		 */
+		theMatlabXMin  =  auxiliar[0] / ticksize;
+		theMatlabYMin  =  auxiliar[1] / ticksize;
+		theMatlabXMax  =  auxiliar[2] / ticksize;
+		theMatlabYMax  =  auxiliar[3] / ticksize;
+		theMatlabZMin  =  auxiliar[4] / ticksize;
+		theMatlabZMax  =  auxiliar[5] / ticksize;
+
+		free( auxiliar );
+
+		hu_fclose( fp );
+
+	}
+
+	/* Broadcasting data */
+
+	double_message[0]  = theMatlabXMin;
+	double_message[1]  = theMatlabYMin;
+	double_message[2]  = theMatlabXMax;
+	double_message[3]  = theMatlabYMax;
+	double_message[4]  = theMatlabZMin;
+	double_message[5]  = theMatlabZMax;
+
+	MPI_Bcast( double_message , 6 , MPI_DOUBLE , 0 , comm_solver);
+
+	theMatlabXMin  = double_message[0] ;
+	theMatlabYMin  = double_message[1] ;
+	theMatlabXMax  = double_message[2] ;
+	theMatlabYMax  = double_message[3] ;
+	theMatlabZMin  = double_message[4] ;
+	theMatlabZMax  = double_message[5] ;
+
+	broadcast_char_array( theMeshDirMatlab, sizeof(theMeshDirMatlab), 0,
+			comm_solver );
+
+	/**
+	 *Coordinates and data in the specified region are written to a binary file
+	 *within each processor
+	 */
+
+	for ( i = 0; i < ( myMesh->lenum ); ++i ) {
+
+		/* j is like a node id here */
+		j = myMesh->elemTable[i].lnid[0]; /* looking at first node of the element(at top) */
+
+		edata_temp = (edata_t *)myMesh->elemTable[i].data;
+
+		/* these are  lower left  coordinates */
+		x_coord = myMesh->nodeTable[j].x;
+		y_coord = myMesh->nodeTable[j].y;
+		z_coord = myMesh->nodeTable[j].z;
+
+
+		if ( (z_coord >= theMatlabZMin) && (z_coord < theMatlabZMax) )
+		{
+			if ( (y_coord >= theMatlabYMin) && (y_coord < theMatlabYMax) )
+			{
+				if ( (x_coord >= theMatlabXMin) && (x_coord <  theMatlabXMax))
+				{
+
+					if ( counter == 0 ) {
+						/* In order to open file just once and not creating any
+						 * empty files */
+						sprintf(filename_coord, "%s/mesh_coordinates.%d",
+								theMeshDirMatlab, myID);
+						sprintf(filename_data,  "%s/mesh_data.%d",
+								theMeshDirMatlab, myID);
+
+						meshcoordinates = hu_fopen ( filename_coord, "wb" );
+						meshdata        = hu_fopen ( filename_data,  "wb" );
+
+					}
+
+					counter++;
+
+					for ( k = 0 ; k < 8 ; ++k ) {
+						/* j is like a node id here */
+						j = myMesh->elemTable[i].lnid[k];
+
+						fwrite( &(myMesh->nodeTable[j].x), sizeof(myMesh->nodeTable[j].x),
+								1,meshcoordinates);
+						fwrite( &(myMesh->nodeTable[j].y), sizeof(myMesh->nodeTable[j].y),
+								1,meshcoordinates);
+						fwrite( &(myMesh->nodeTable[j].z), sizeof(myMesh->nodeTable[j].z),
+								1,meshcoordinates);
+					}
+
+					fwrite( &(edata_temp->Vs),  sizeof(edata_temp->Vs),  1, meshdata );
+					fwrite( &(edata_temp->Vp),  sizeof(edata_temp->Vp),  1, meshdata );
+					fwrite( &(edata_temp->rho), sizeof(edata_temp->rho), 1, meshdata );
+
+					/**
+					 * If you want to have damping ratios, change the 0.
+					 */
+					if (theTypeOfDamping == RAYLEIGH && 0) {
+
+						int32_t   n_0;
+						double    x_m,y_m,z_m;
+						float     zeta;
+
+						n_0 = myMesh->elemTable[i].lnid[0];
+						z_m = zoriginm + (ticksize)*myMesh->nodeTable[n_0].z;
+						x_m = xoriginm + (ticksize)*myMesh->nodeTable[n_0].x;
+						y_m = yoriginm + (ticksize)*myMesh->nodeTable[n_0].y;
+
+						/* Shift the domain if buildings are considered */
+						if ( includeBuildings == YES ) {
+							z_m -= get_surface_shift();
+						}
+
+						//if ( softerSoil == YES ) {
+						/* Get it from the damping vs strain curves */
+						//		zeta = get_damping_ratio(x_m,y_m,z_m,xoriginm,yoriginm,zoriginm);
+						//	}
+						//	else {
+						/* New formula for damping according to Graves */
+						//		zeta = 10 / edata_temp->Vs;
+						//	}
+
+						//If element is not in the soft-soil box, use the Graves damping formula
+						if (zeta == -1) {
+							zeta = 10 / edata_temp->Vs;
+						}
+
+						//If element is in the building, use 5% damping.
+						if (z_m < 0) {
+							zeta = 0.05;
+						}
+
+						fwrite( &(zeta), sizeof(zeta), 1, meshdata );
+
+					}
+
+				}
+			}
+		}
+	}
+
+	if ( counter != 0 ) {
+		hu_fclose( meshcoordinates );
+		hu_fclose( meshdata );
+	}
+}

--- a/quake/forward_gpu/meshformatlab.h
+++ b/quake/forward_gpu/meshformatlab.h
@@ -1,0 +1,29 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef MESHFORMATLAB_H_
+#define MESHFORMATLAB_H_
+
+void saveMeshCoordinatesForMatlab( mesh_t      *myMesh,       int32_t myID,
+                                   const char  *parametersin, double  ticksize,
+                                   damping_type_t theTypeOfDamping, double xoriginm, double yoriginm,
+                                   double zoriginm, noyesflag_t includeBuildings );
+
+#endif /* MESHFORMATLAB_H_ */
+

--- a/quake/forward_gpu/nonlinear.cu
+++ b/quake/forward_gpu/nonlinear.cu
@@ -1,0 +1,2230 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "geometrics.h"
+#include "nonlinear.h"
+#include "octor.h"
+#include "psolve.h"
+#include "quake_util.h"
+#include "util.h"
+
+#define  QC  qc = 0.577350269189 /* sqrt(3.0)/3.0; */
+
+#define  XI  xi[3][8] = { {-1,  1, -1,  1, -1,  1, -1, 1} , \
+                          {-1, -1,  1,  1, -1, -1,  1, 1} , \
+                          {-1, -1, -1, -1,  1,  1,  1, 1} }
+
+static int superflag = 0;
+
+/* -------------------------------------------------------------------------- */
+/*                             Global Variables                               */
+/* -------------------------------------------------------------------------- */
+
+static nlsolver_t           *myNonlinSolver;
+static double                theNonLinVsCut = 0;
+static double                theNonLinVsMin = 0;
+static int32_t               thePropertiesCount;
+static materialmodel_t       theMaterialModel;
+static plasticitytype_t      thePlasticityModel;
+static materialproperties_t  thePropertiesType;
+static double               *theVsLimits;
+static double               *theAlphaCohes;
+static double               *theKayPhis;
+static double               *theStrainRates;
+static double               *theSensitivities;
+static double               *theHardeningModulus;
+static double                theGeostaticLoadingT = 0;
+static double                theGeostaticCushionT = 0;
+static int                   theGeostaticFinalStep;
+static int32_t              *myStationsElementIndices;
+static nlstation_t          *myNonlinStations;
+static int32_t              *myNonlinStationsMapping;
+static int32_t               myNumberOfNonlinStations;
+static int32_t               myNonlinElementsCount;
+static int32_t              *myNonlinElementsMapping;
+static int32_t               myBottomElementsCount = 0;
+static bottomelement_t      *myBottomElements;
+
+static double totalWeight = 0;
+
+/* -------------------------------------------------------------------------- */
+/*                                 Utilities                                  */
+/* -------------------------------------------------------------------------- */
+
+double get_geostatic_total_time() {
+    return theGeostaticLoadingT + theGeostaticCushionT;
+}
+
+/*
+ * Return YES if an element is to be considered nonlinear, NO otherwise.
+ */
+int isThisElementNonLinear(mesh_t *myMesh, int32_t eindex) {
+
+    elem_t  *elemp;
+    edata_t *edata;
+
+    elemp = &myMesh->elemTable[eindex];
+    edata = (edata_t *)elemp->data;
+
+    if ( ( edata->Vs <= theNonLinVsCut ) && ( edata->Vs >= theNonLinVsMin ) )  {
+        return YES;
+    }
+
+    return NO;
+}
+
+/*
+ * Performs linear interpolation between to given vectors for a given value
+ * and gives back the corresponding pair for the requested Vs.
+ *
+ */
+double interpolate_property_value(double vsRequest, double *propVector)
+{
+    int i;
+    double vs0, vs1;
+    double prop0, prop1;
+
+    /* below floor case */
+    if ( vsRequest <= theVsLimits[0] ) {
+        return propVector[0];
+    }
+
+    /* above ceiling case */
+    if ( vsRequest > theVsLimits[thePropertiesCount-1] ) {
+        return propVector[thePropertiesCount-1];
+    }
+
+    /* in between cases */
+
+    for ( i = 0; i < thePropertiesCount-1; i++ ) {
+
+        if ( ( vsRequest >  theVsLimits[i]   ) &&
+             ( vsRequest <= theVsLimits[i+1] ) ) {
+
+            vs0 = theVsLimits[i];
+            vs1 = theVsLimits[i+1];
+
+            prop0 = propVector[i];
+            prop1 = propVector[i+1];
+        }
+    }
+
+    double result = prop0 + (vsRequest - vs0)*( (prop1 - prop0)/(vs1 - vs0) );
+
+    return result;
+}
+
+/*
+ * Returns the value of the constant alpha for Drucker-Prager's material
+ * model
+ */
+double get_alpha(double vs) {
+
+    double alpha;
+    double phi;
+
+    switch ( thePropertiesType ) {
+
+        case ALPHAKAY:
+            alpha = interpolate_property_value(vs, theAlphaCohes);
+            break;
+
+        case COHEFRICTION:
+            phi   = interpolate_property_value(vs, theKayPhis) * PI / 180.0;
+            alpha = 2 * sin(phi) / ( sqrt(3.0) * ( 3 - sin(phi) ) );
+            break;
+
+        default:
+            alpha = 0;
+    }
+
+    return alpha;
+}
+
+/*
+ * Returns the value of the constant kay for in Drucker-Prager's material
+ * model
+ */
+double get_kay(double vs) {
+
+    double k;
+    double c, phi;
+
+    switch ( thePropertiesType ) {
+
+        case ALPHAKAY:
+            k     = interpolate_property_value(vs, theKayPhis);
+            break;
+
+        case COHEFRICTION:
+            c     = interpolate_property_value(vs, theAlphaCohes);
+            phi   = interpolate_property_value(vs, theKayPhis) * PI / 180.0;
+            k     = 6 * c * cos(phi) / ( sqrt(3.0) * ( 3 - sin(phi) ) );
+            break;
+
+        default:
+            k     = 0;
+    }
+
+    return k;
+}
+
+/* -------------------------------------------------------------------------- */
+/*       Initialization of parameters, structures and memory allocations      */
+/* -------------------------------------------------------------------------- */
+
+void nonlinear_init( int32_t     myID,
+                     const char *parametersin,
+                     double      theDeltaT,
+                     double      theEndT )
+{
+    double  double_message[4];
+    int     int_message[5];
+
+    /* Capturing data from file --- only done by PE0 */
+    if (myID == 0) {
+        if (nonlinear_initparameters(parametersin, theDeltaT, theEndT) != 0) {
+            fprintf(stderr,"Thread 0: nonlinear_local_init: "
+                    "nonlinear_initparameters error\n");
+            MPI_Abort(MPI_COMM_WORLD, ERROR);
+            exit(1);
+        }
+    }
+
+    /* Broadcasting data */
+
+    double_message[0] = theNonLinVsCut;
+    double_message[1] = theGeostaticLoadingT;
+    double_message[2] = theGeostaticCushionT;
+    double_message[3] = theNonLinVsMin;
+
+    int_message[0] = (int)theMaterialModel;
+    int_message[1] = (int)thePropertiesType;
+    int_message[2] = thePropertiesCount;
+    int_message[3] = theGeostaticFinalStep;
+    int_message[4] = thePlasticityModel;
+
+
+    MPI_Bcast(double_message, 4, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(int_message,    5, MPI_INT,    0, comm_solver);
+
+    theNonLinVsCut        = double_message[0];
+    theGeostaticLoadingT  = double_message[1];
+    theGeostaticCushionT  = double_message[2];
+    theNonLinVsMin        = double_message[3];
+
+    theMaterialModel      = (materialmodel_t)int_message[0];
+    thePropertiesType     = (materialproperties_t)int_message[1];
+    thePropertiesCount    = int_message[2];
+    theGeostaticFinalStep = int_message[3];
+    thePlasticityModel    = (plasticitytype_t)int_message[4];
+
+    /* allocate table of properties for all other PEs */
+
+    if (myID != 0) {
+        theVsLimits         = (double*)malloc(sizeof(double) * thePropertiesCount);
+        theAlphaCohes       = (double*)malloc(sizeof(double) * thePropertiesCount);
+        theKayPhis          = (double*)malloc(sizeof(double) * thePropertiesCount);
+        theStrainRates      = (double*)malloc(sizeof(double) * thePropertiesCount);
+        theSensitivities    = (double*)malloc(sizeof(double) * thePropertiesCount);
+        theHardeningModulus = (double*)malloc(sizeof(double) * thePropertiesCount);
+    }
+
+    /* Broadcast table of properties */
+    MPI_Bcast(theVsLimits,         thePropertiesCount, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theAlphaCohes,       thePropertiesCount, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theKayPhis,          thePropertiesCount, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theStrainRates,      thePropertiesCount, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theSensitivities,    thePropertiesCount, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(theHardeningModulus, thePropertiesCount, MPI_DOUBLE, 0, comm_solver);
+}
+
+/*
+ * Reads from parameters.in and stores in PE0 globals.
+ */
+int32_t nonlinear_initparameters ( const char *parametersin,
+                                   double      theDeltaT,
+                                   double      theEndT )
+{
+    FILE    *fp;
+    int32_t  properties_count;
+    int      row;
+    double   nonlin_vscut, nonlin_vsbott, geostatic_loading_t, geostatic_cushion_t,
+            *auxiliar;
+    char     material_model[64],
+             material_properties[64],
+             plasticity_type[64];
+
+    materialmodel_t      materialmodel;
+    materialproperties_t materialproperties;
+    plasticitytype_t     plasticitytype;
+
+
+    /* Opens numericalin file */
+    if ((fp = fopen(parametersin, "r")) == NULL) {
+        fprintf(stderr, "Error opening %s\n at nl_init_parameters", parametersin);
+        return -1;
+    }
+
+    /* Parses parameters.in to capture nonlinear single-value parameters */
+
+    if ( (parsetext(fp, "nonlinear_shear_velocity_cut", 'd', &nonlin_vscut        ) != 0) ||
+         (parsetext(fp, "nonlinear_shear_velocity_min", 'd', &nonlin_vsbott        ) != 0) ||
+         (parsetext(fp, "geostatic_loading_time_sec",   'd', &geostatic_loading_t ) != 0) ||
+         (parsetext(fp, "geostatic_cushion_time_sec",   'd', &geostatic_cushion_t ) != 0) ||
+         (parsetext(fp, "material_model",               's', &material_model      ) != 0) ||
+         (parsetext(fp, "material_properties_type",     's', &material_properties ) != 0) ||
+         (parsetext(fp, "material_plasticity_type",     's', &plasticity_type     ) != 0) ||
+         (parsetext(fp, "material_properties_count",    'i', &properties_count    ) != 0) )
+    {
+        fprintf(stderr, "Error parsing nonlinear parameters from %s\n", parametersin);
+        return -1;
+    }
+
+    /* Performs sanity checks */
+
+    if (nonlin_vscut < 0) {
+        fprintf(stderr, "Illegal Vs cut value for nonlinear analysis %f\n", nonlin_vscut);
+        return -1;
+    }
+
+    if (nonlin_vsbott < 0) {
+        fprintf(stderr, "Illegal Vs min value for nonlinear analysis %f\n", nonlin_vsbott);
+        return -1;
+    }
+
+
+    if ( (geostatic_loading_t < 0) || (geostatic_cushion_t < 0) ||
+         (geostatic_loading_t + geostatic_cushion_t > theEndT) ) {
+        fprintf(stderr, "Illegal geostatic loading/cushion time %f/%f\n",
+                geostatic_loading_t, geostatic_cushion_t);
+        return -1;
+    }
+
+    if ( strcasecmp(material_model, "linear") == 0 ) {
+        materialmodel = LINEAR;
+    } else if ( strcasecmp(material_model, "vonMises") == 0 ) {
+        materialmodel = VONMISES;
+    } else if ( strcasecmp(material_model, "DruckerPrager") == 0 ) {
+        materialmodel = DRUCKERPRAGER;
+    } else {
+        fprintf(stderr,
+                "Illegal material model for nonlinear analysis"
+                "(linear, vonMises, DruckerPrager): %s\n", material_model);
+        return -1;
+    }
+
+    if ( strcasecmp(material_properties, "cohefriction") == 0 ) {
+        materialproperties = COHEFRICTION;
+    } else if ( strcasecmp(material_properties, "alphakay") == 0 ) {
+        materialproperties = ALPHAKAY;
+    } else {
+        fprintf(stderr,
+                "Illegal material properties type for nonlinear "
+                "analysis (cohefriction, alphakay): %s\n",
+                material_properties);
+        return -1;
+    }
+
+    if (properties_count < 1) {
+        fprintf(stderr, "Illegal material properties count %d\n", properties_count);
+        return -1;
+    }
+
+    if ( strcasecmp(plasticity_type, "rate_dependant") == 0 ) {
+        plasticitytype = RATE_DEPENDANT;
+    } else if ( strcasecmp(plasticity_type, "rate_independant") == 0 ) {
+        plasticitytype = RATE_INDEPENDANT;
+    } else {
+        fprintf(stderr,
+                "Illegal material plasticity type for nonlinear "
+                "analysis (rate_dependant, rate_independant): %s\n",
+                plasticity_type);
+        return -1;
+    }
+
+
+    /* Initialize the static global variables */
+
+    theNonLinVsCut        = nonlin_vscut;
+    theNonLinVsMin        = nonlin_vsbott;
+    theGeostaticLoadingT  = geostatic_loading_t;
+    theGeostaticCushionT  = geostatic_cushion_t;
+    theGeostaticFinalStep = (int)( (geostatic_loading_t + geostatic_cushion_t) / theDeltaT );
+    theMaterialModel      = materialmodel;
+    thePropertiesType     = materialproperties;
+    thePropertiesCount    = properties_count;
+    thePlasticityModel    = plasticitytype;
+
+    auxiliar             = (double*)malloc( sizeof(double) * thePropertiesCount * 6 );
+    theVsLimits          = (double*)malloc( sizeof(double) * thePropertiesCount );
+    theAlphaCohes        = (double*)malloc( sizeof(double) * thePropertiesCount );
+    theKayPhis           = (double*)malloc( sizeof(double) * thePropertiesCount );
+    theStrainRates       = (double*)malloc( sizeof(double) * thePropertiesCount );
+    theSensitivities     = (double*)malloc( sizeof(double) * thePropertiesCount );
+    theHardeningModulus  = (double*)malloc( sizeof(double) * thePropertiesCount );
+
+
+    if ( parsedarray( fp, "material_properties_list", thePropertiesCount * 6, auxiliar ) != 0) {
+        fprintf(stderr, "Error parsing nonlinear material properties list from %s\n", parametersin);
+        return -1;
+    }
+
+    for ( row = 0; row < thePropertiesCount; row++) {
+        theVsLimits[row]          = auxiliar[ row * 6     ];
+        theAlphaCohes[row]        = auxiliar[ row * 6 + 1 ];
+        theKayPhis[row]           = auxiliar[ row * 6 + 2 ];
+        theStrainRates[row]       = auxiliar[ row * 6 + 3 ];
+        theSensitivities[row]     = auxiliar[ row * 6 + 4 ];
+        theHardeningModulus[row]  = auxiliar[ row * 6 + 5 ];
+    }
+
+    return 0;
+}
+
+/*
+ * Counts the number of nonlinear elements in my local mesh
+ */
+void nonlinear_elements_count(int32_t myID, mesh_t *myMesh) {
+
+    int32_t eindex;
+    int32_t count = 0;
+
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+        if ( isThisElementNonLinear(myMesh, eindex) == YES ) {
+            count++;
+        }
+    }
+
+    if ( count > myMesh-> lenum ) {
+        fprintf(stderr,"Thread %d: nl_elements_count: "
+                "more elements than expected\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    myNonlinElementsCount = count;
+
+    return;
+}
+
+/*
+ * Re-counts and stores the nonlinear element indices to a static local array
+ * that will serve as mapping tool to the local mesh elements table.
+ */
+void nonlinear_elements_mapping(int32_t myID, mesh_t *myMesh) {
+
+    int32_t eindex;
+    int32_t count = 0;
+
+    XMALLOC_VAR_N(myNonlinElementsMapping, int32_t, myNonlinElementsCount);
+
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+        if ( isThisElementNonLinear(myMesh, eindex) == YES ) {
+            myNonlinElementsMapping[count] = eindex;
+            count++;
+        }
+    }
+
+    if ( count != myNonlinElementsCount ) {
+        fprintf(stderr,"Thread %d: nl_elements_mapping: "
+                "more elements than the count\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    return;
+}
+
+noyesflag_t isThisElementsAtTheBottom( mesh_t  *myMesh,
+                                       int32_t  eindex,
+                                       double   depth )
+{
+    elem_t  *elemp;
+    int32_t  nindex;
+    double   z_m;
+
+    /* Capture the element's last node at the bottom */
+    elemp  = &myMesh->elemTable[eindex];
+    nindex = elemp->lnid[7];
+
+    z_m = (myMesh->ticksize)*(double)myMesh->nodeTable[nindex].z;
+
+    if ( z_m == depth ) {
+        return YES;
+    }
+
+    return NO;
+}
+
+void bottom_elements_count(int32_t myID, mesh_t *myMesh, double depth ) {
+
+    int32_t eindex;
+    int32_t count = 0;
+
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+        if ( isThisElementsAtTheBottom(myMesh, eindex, depth) == YES ) {
+            count++;
+        }
+    }
+
+    if ( count > myMesh-> lenum ) {
+        fprintf(stderr,"Thread %d: bottom_elements_count: "
+                "more elements than expected\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    myBottomElementsCount = count;
+
+    return;
+}
+
+void bottom_elements_mapping(int32_t myID, mesh_t *myMesh, double depth) {
+
+    int32_t eindex;
+    int32_t count = 0;
+
+    XMALLOC_VAR_N(myBottomElements, bottomelement_t, myBottomElementsCount);
+
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+        if ( isThisElementsAtTheBottom(myMesh, eindex, depth) == YES ) {
+            myBottomElements[count].element_id = eindex;
+            count++;
+        }
+    }
+
+    if ( count != myBottomElementsCount ) {
+        fprintf(stderr,"Thread %d: bottom_elements_mapping: "
+                "more elements than expected\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    return;
+}
+
+/*
+ * Prints statistics about number of nonlinear elements and stations in nonlinear
+ * elements.
+ */
+void nonlinear_print_stats(int32_t *nonlinElementsCount,
+                           int32_t *nonlinStationsCount,
+                           int32_t *bottomElementsCount,
+                           int32_t  theGroupSize)
+{
+
+    int pid;
+    global_id_t totalElements = 0;
+    global_id_t totalStations = 0;
+    global_id_t totalBottom   = 0;
+
+    FILE *fp = hu_fopen( "stat-nonlin.txt", "w" );
+
+    fputs( "\n"
+           "# ---------------------------------------- \n"
+           "# Nonlinear elements and stations count:   \n"
+           "# ---------------------------------------- \n"
+           "# Rank    Elements    Stations      Bottom \n"
+           "# ---------------------------------------- \n", fp );
+
+    for ( pid = 0; pid < theGroupSize; pid++ ) {
+
+        fprintf( fp, "%06d %11d %11d %11d\n", pid,
+                 nonlinElementsCount[pid],
+                 nonlinStationsCount[pid],
+                 bottomElementsCount[pid] );
+
+        totalElements += nonlinElementsCount[pid];
+        totalStations += nonlinStationsCount[pid];
+        totalBottom   += bottomElementsCount[pid];
+    }
+
+    fprintf( fp,
+             "# ---------------------------------------- \n"
+             "# Total%11"INT64_FMT" %11"INT64_FMT" %11"INT64_FMT" \n"
+             "# ---------------------------------------- \n\n",
+             totalElements, totalStations, totalBottom );
+
+    hu_fclosep( &fp );
+
+    /* output aggregate information to the monitor file / stdout */
+    fprintf( stdout,
+             "\nNonlinear mesh information\n"
+             "Total number of nonlinear elements: %11"INT64_FMT"\n"
+             "Total number of nonlinear stations: %11"INT64_FMT"\n"
+             "Total number of bottom elements:    %11"INT64_FMT"\n\n",
+             totalElements, totalStations, totalBottom );
+
+    fflush( stdout );
+
+}
+
+/*
+ * Collects statistics about number of nonlinear elements and stations in
+ * nonlinear elements.
+ */
+void nonlinear_stats(int32_t myID, int32_t theGroupSize) {
+
+    int32_t *nonlinElementsCount = NULL;
+    int32_t *nonlinStationsCount = NULL;
+    int32_t *bottomElementsCount = NULL;
+
+    if ( myID == 0 ) {
+        XMALLOC_VAR_N( nonlinElementsCount, int32_t, theGroupSize);
+        XMALLOC_VAR_N( nonlinStationsCount, int32_t, theGroupSize);
+        XMALLOC_VAR_N( bottomElementsCount, int32_t, theGroupSize);
+    }
+
+    MPI_Gather( &myNonlinElementsCount,    1, MPI_INT,
+                nonlinElementsCount,       1, MPI_INT, 0, comm_solver );
+    MPI_Gather( &myNumberOfNonlinStations, 1, MPI_INT,
+                nonlinStationsCount,       1, MPI_INT, 0, comm_solver );
+    MPI_Gather( &myBottomElementsCount,    1, MPI_INT,
+                bottomElementsCount,       1, MPI_INT, 0, comm_solver );
+
+    if ( myID == 0 ) {
+
+        nonlinear_print_stats( nonlinElementsCount, nonlinStationsCount,
+                               bottomElementsCount, theGroupSize);
+
+        xfree_int32_t( &nonlinElementsCount );
+    }
+
+    return;
+}
+
+/*
+ * nonlinear_solver_init: Initialize all the structures needed for nonlinear
+ *                        analysis and the material/element constants.
+ */
+void nonlinear_solver_init(int32_t myID, mesh_t *myMesh, double depth) {
+
+    int     i;
+    int32_t eindex, nl_eindex;
+
+    nonlinear_elements_count(myID, myMesh);
+    nonlinear_elements_mapping(myID, myMesh);
+
+    if ( theGeostaticLoadingT > 0 ) {
+        bottom_elements_count(myID, myMesh, depth);
+        bottom_elements_mapping(myID, myMesh, depth);
+    }
+
+    /* Memory allocation for mother structure */
+
+    myNonlinSolver = (nlsolver_t *)malloc(sizeof(nlsolver_t));
+
+    if (myNonlinSolver == NULL) {
+        fprintf(stderr, "Thread %d: nonlinear_init: out of memory\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    /* Memory allocation for internal structures */
+
+    myNonlinSolver->constants =
+        (nlconstants_t *)calloc(myNonlinElementsCount, sizeof(nlconstants_t));
+    myNonlinSolver->stresses =
+        (qptensors_t *)calloc(myNonlinElementsCount, sizeof(qptensors_t));
+    myNonlinSolver->strains =
+        (qptensors_t *)calloc(myNonlinElementsCount, sizeof(qptensors_t));
+    myNonlinSolver->pstrains1 =
+        (qptensors_t *)calloc(myNonlinElementsCount, sizeof(qptensors_t));
+    myNonlinSolver->pstrains2 =
+        (qptensors_t *)calloc(myNonlinElementsCount, sizeof(qptensors_t));
+    myNonlinSolver->ep1 =
+        (qpvectors_t *)calloc(myNonlinElementsCount, sizeof(qpvectors_t));
+    myNonlinSolver->ep2 =
+        (qpvectors_t *)calloc(myNonlinElementsCount, sizeof(qpvectors_t));
+
+    if ( (myNonlinSolver->constants  == NULL) ||
+         (myNonlinSolver->stresses   == NULL) ||
+         (myNonlinSolver->strains    == NULL) ||
+         (myNonlinSolver->ep1        == NULL) ||
+         (myNonlinSolver->ep2        == NULL) ||
+         (myNonlinSolver->pstrains1  == NULL) ||
+         (myNonlinSolver->pstrains2  == NULL) ) {
+
+        fprintf(stderr, "Thread %d: nonlinear_init: out of memory\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    /* Initialization of element constants
+     * Tensors have been initialized to 0 by calloc
+     */
+
+    for (nl_eindex = 0; nl_eindex < myNonlinElementsCount; nl_eindex++) {
+
+        elem_t     *elemp;
+        edata_t    *edata;
+        nlconstants_t *ecp;
+        double      mu, lambda;
+        double      elementVs;
+
+        eindex = myNonlinElementsMapping[nl_eindex];
+
+        elemp = &myMesh->elemTable[eindex];
+        edata = (edata_t *)elemp->data;
+        ecp   = myNonlinSolver->constants + nl_eindex;
+
+        /* get element Vs */
+
+        elementVs = (double)edata->Vs;
+
+        /* Calculate the lame constants and store in element */
+
+        mu_and_lambda(&mu, &lambda, edata, eindex);
+        ecp->lambda = lambda;
+        ecp->mu     = mu;
+
+        /* Calculate the yield function constants */
+
+        switch (theMaterialModel) {
+
+            case LINEAR:
+                ecp->alpha = 0;
+                ecp->k     = 0;
+                break;
+
+            case VONMISES:
+                ecp->alpha = 0;
+                ecp->k     = get_kay(elementVs);
+                break;
+
+            case DRUCKERPRAGER:
+                ecp->alpha = get_alpha(elementVs);
+                ecp->k     = get_kay(elementVs);
+                break;
+
+            default:
+                fprintf(stderr, "Thread %d: nonlinear_solver_init:\n"
+                        "\tUnexpected error with the material model\n", myID);
+                MPI_Abort(MPI_COMM_WORLD, ERROR);
+                exit(1);
+                break;
+        }
+
+        for (i = 0; i < 8; i++) {
+            ecp->fs[i]     = 0;
+            ecp->dLambda[i] = 0;
+        }
+
+        ecp->strainrate  =
+            interpolate_property_value(elementVs, theStrainRates  );
+        ecp->sensitivity =
+            interpolate_property_value(elementVs, theSensitivities );
+        ecp->hardmodulus =
+            interpolate_property_value(elementVs, theHardeningModulus );
+
+
+    } /* for all elements */
+
+}
+
+/* -------------------------------------------------------------------------- */
+/*                   Auxiliary tensor manipulation methods                    */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * tensor_I1: Returns the invariant I1 of a tensor.
+ */
+double tensor_I1(tensor_t tensor) {
+
+    return tensor.xx + tensor.yy + tensor.zz;
+}
+
+/*
+ * Returns the octahedral of a tensor given its first invariant I1
+ */
+double tensor_octahedral(double I1) {
+
+    return I1/3.0;
+}
+
+/*
+ * Returns the deviator of a tensor given the tensor and its octahedral.
+ */
+tensor_t tensor_deviator(tensor_t tensor, double oct) {
+
+    tensor_t deviator;
+
+    deviator.xx = tensor.xx - oct;
+    deviator.yy = tensor.yy - oct;
+    deviator.zz = tensor.zz - oct;
+    deviator.xy = tensor.xy;
+    deviator.yz = tensor.yz;
+    deviator.xz = tensor.xz;
+
+    return deviator;
+}
+
+/*
+ * tensos_J2: Returns the second invariant of a tensor given its deviator.
+ */
+double tensor_J2(tensor_t dev) {
+
+    return ( (dev.xx * dev.xx) + (dev.yy * dev.yy) + (dev.zz * dev.zz) ) * 0.5
+           + (dev.xy * dev.xy) + (dev.yz * dev.yz) + (dev.xz * dev.xz);
+}
+
+/*
+ * Computes the contribution of the i-th node to the three derivatives
+ * dx, dy, dz of the shape functions evaluated at local coordinates
+ * lx, ly, lz.
+ */
+void point_dxi ( double *dx, double *dy, double *dz,
+                 double  lx, double  ly, double  lz, double h, int i )
+{
+    double XI;
+    double Jij = 0.25 / h; /* Jacobian 1/(4h) */
+
+    *dx = Jij * (       xi[0][i]      )
+              * ( 1.0 + xi[1][i] * ly )
+              * ( 1.0 + xi[2][i] * lz );
+
+    *dy = Jij * ( 1.0 + xi[0][i] * lx )
+              * (       xi[1][i]      )
+              * ( 1.0 + xi[2][i] * lz );
+
+    *dz = Jij * ( 1.0 + xi[0][i] * lx )
+              * ( 1.0 + xi[1][i] * ly )
+              * (       xi[2][i]      );
+
+    return;
+}
+
+/*
+ * Computes the three derivatives of the shape functions evaluated at
+ * coordinates j-th quadrature point.
+ */
+void compute_qp_dxi (double *dx, double *dy, double *dz, int i, int j, double h)
+{
+    double XI, QC;
+
+    /* quadrature point local coordinates */
+    double lx = xi[0][j] * qc ;
+    double ly = xi[1][j] * qc ;
+    double lz = xi[2][j] * qc ;
+
+    point_dxi(dx, dy, dz, lx, ly, lz, h, i);
+
+    return;
+}
+
+/*
+ * Resets a tensor to zero in all its components.
+ */
+tensor_t init_tensor() {
+
+    tensor_t tensor;
+
+    tensor.xx = 0;
+    tensor.yy = 0;
+    tensor.zz = 0;
+    tensor.xy = 0;
+    tensor.yz = 0;
+    tensor.xz = 0;
+
+    return tensor;
+}
+
+void init_tensorptr(tensor_t *tensor) {
+
+    tensor->xx = 0;
+    tensor->yy = 0;
+    tensor->zz = 0;
+    tensor->xy = 0;
+    tensor->yz = 0;
+    tensor->xz = 0;
+
+    return;
+}
+
+/*
+ * Compute strain tensor of a given point in the element.
+ */
+tensor_t point_strain (fvector_t *u, double lx, double ly, double lz, double h) {
+
+    int i;
+
+    tensor_t strain = init_tensor();
+
+    /* Contribution of each node */
+    for (i = 0; i < 8; i++) {
+
+        double dx, dy, dz;
+
+        point_dxi(&dx, &dy, &dz, lx, ly, lz, h, i);
+
+        strain.xx += dx * u[i].f[0];
+        strain.yy += dy * u[i].f[1];
+        strain.zz += dz * u[i].f[2];
+
+        strain.xy += 0.5 * ( dy * u[i].f[0] + dx * u[i].f[1] );
+        strain.yz += 0.5 * ( dz * u[i].f[1] + dy * u[i].f[2] );
+        strain.xz += 0.5 * ( dz * u[i].f[0] + dx * u[i].f[2] );
+
+    } /* nodes contribution */
+
+    return strain;
+}
+
+/*
+ * Computes the stress tensor in a given point in the element from the point's
+ * strain tensor and the element properties according to the linear elastic
+ * stress-strain relationship.
+ */
+tensor_t point_stress (tensor_t strain, double mu, double lambda) {
+
+    double mu2, lkk;
+    double strain_kk;
+    tensor_t stress;
+
+    /* calculate strtain_kk */
+    strain_kk = tensor_I1(strain);
+
+    mu2 = 2.0 * mu;
+    lkk = lambda * strain_kk;
+
+    stress.xx = mu2 * strain.xx + lkk;
+    stress.yy = mu2 * strain.yy + lkk;
+    stress.zz = mu2 * strain.zz + lkk;
+
+    stress.xy = mu2 * strain.xy;
+    stress.yz = mu2 * strain.yz;
+    stress.xz = mu2 * strain.xz;
+
+    return stress;
+}
+
+/*
+ * Computes the stress tensors for the quadrature points of an element given
+ * the strain tensors.
+ */
+qptensors_t compute_qp_stresses (qptensors_t strains, double mu, double lambda)
+{
+    int i;
+    qptensors_t stresses;
+
+    /* Loop over the quadrature points */
+    for ( i = 0; i < 8; i++ ) {
+        stresses.qp[i] = point_stress(strains.qp[i], mu, lambda);
+    }
+
+    return stresses;
+}
+
+/*
+ * Returns the subtraction between two tensors.
+ */
+tensor_t subtrac_tensors(tensor_t A, tensor_t B) {
+
+    tensor_t C;
+
+    C.xx = A.xx - B.xx;
+    C.yy = A.yy - B.yy;
+    C.zz = A.zz - B.zz;
+    C.xy = A.xy - B.xy;
+    C.yz = A.yz - B.yz;
+    C.xz = A.xz - B.xz;
+
+    return C;
+}
+
+/*
+ * Returns the subtraction between two tensors for all quadrature points.
+ */
+qptensors_t subtrac_qptensors(qptensors_t A, qptensors_t B) {
+
+    int i;
+    qptensors_t C;
+
+    /* Loop over quadrature points */
+    for (i = 0; i < 8; i++) {
+        C.qp[i] = subtrac_tensors(A.qp[i], B.qp[i]);
+    }
+
+    return C;
+}
+
+tensor_t copy_tensor (tensor_t original) {
+
+    tensor_t copy;
+
+    copy.xx = original.xx;
+    copy.yy = original.yy;
+    copy.zz = original.zz;
+    copy.xy = original.xy;
+    copy.yz = original.yz;
+    copy.xz = original.xz;
+
+    return copy;
+}
+
+double compute_yield_surface_state ( double J2, double I1, double alpha ) {
+
+//    if ( theMaterialModel == VONMISES ) {
+//        return sqrt(J2);
+//    }
+//
+//    if ( theMaterialModel == DRUCKERPRAGER ) {
+        return alpha * I1 + sqrt(J2);
+//    }
+//
+//    return 0;
+}
+
+double compute_dLambda ( nlconstants_t constants, double fs, double eff_ps, double J2, double I1 ) {
+
+	/* This function is no longer used and was updated by compute_dLambdaII */
+	double phi_pt, eta_pt, psi_pt, s, c, kappa, A1, B1, C1; /*  variables needed for the plastic strain update*/
+
+	if ( thePlasticityModel == RATE_DEPENDANT ) {
+		double factor      = fs / constants.k;
+		double strainRate  = constants.strainrate;
+		double sensitivity = constants.sensitivity;
+		double oneOverM    = 1.0 / sensitivity;
+
+		return strainRate * pow(factor, oneOverM);
+	}
+
+	/* Dorian: Rate independent plastic multiplier computation stage. */
+	/* This expression is exact for the Drucker-Prager material model with Linear hardening Rule */
+
+	s      = constants.hardmodulus;
+	c      = constants.k;
+	kappa  = ( constants.lambda + 2 * constants.mu / 3 );
+
+	phi_pt = sqrt ( 1/2. + 3 * constants.alpha * constants.alpha );
+	eta_pt = s * phi_pt + 9 * kappa * constants.alpha *  constants.alpha;
+	psi_pt = s * eff_ps + c - constants.alpha * I1;
+
+	A1 = constants.mu * constants.mu - eta_pt * eta_pt;
+	B1 = 2 * eta_pt * psi_pt + 2 * sqrt( J2 ) * constants.mu;
+	C1 = J2 - psi_pt * psi_pt;
+
+
+	if ( fs > c + s * eff_ps ) {
+
+		if ( ( B1*B1 - 4 * A1 * C1 ) < 0 ) {
+        fprintf(stderr, "Thread compute_dLambda:\n"
+                "\t Illegal value computing plastic strain multiplier\n" );
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+
+		}
+
+		return ( B1 - sqrt ( B1 * B1 - 4 * A1 * C1 ) ) / ( 2 * A1 );
+	}
+	else
+		return 0;
+
+}
+
+
+double compute_dLambdaII ( nlconstants_t constants, double fs, double eff_ps, double J2, double I1 ) {
+
+	double phi_pt, s, c, kappa, FsT; /*  variables needed for the plastic strain update*/
+
+	if ( thePlasticityModel == RATE_DEPENDANT ) {
+		double factor      = fs / constants.k;
+		double strainRate  = constants.strainrate;
+		double sensitivity = constants.sensitivity;
+		double oneOverM    = 1.0 / sensitivity;
+
+		return strainRate * pow(factor, oneOverM);
+	}
+
+	/* Dorian: Rate independent plastic multiplier computation stage. */
+	/* This expression is exact for the Drucker-Prager material model with Linear hardening Rule */
+
+	s      = constants.hardmodulus;
+	c      = constants.k;
+	kappa  = ( constants.lambda + 2 * constants.mu / 3 );
+	phi_pt = sqrt ( 1/2. + 3 * constants.alpha * constants.alpha );
+
+	FsT = fs - c - s * eff_ps;
+
+	if (  FsT > 0 )
+		return FsT / ( constants.mu + 9 * kappa * constants.alpha * constants.alpha + s * phi_pt );
+
+	return 0;
+}
+
+
+
+
+
+tensor_t compute_dfds (tensor_t dev, double J2, double alpha) {
+
+    tensor_t dfds;
+
+    dfds.xx = dev.xx / ( 2.0 * sqrt(J2) ) + alpha;
+    dfds.yy = dev.yy / ( 2.0 * sqrt(J2) ) + alpha;
+    dfds.zz = dev.zz / ( 2.0 * sqrt(J2) ) + alpha;
+    dfds.xy = dev.xy / ( 2.0 * sqrt(J2) );
+    dfds.yz = dev.yz / ( 2.0 * sqrt(J2) );
+    dfds.xz = dev.xz / ( 2.0 * sqrt(J2) );
+
+    return dfds;
+
+}
+
+tensor_t compute_pstrain2 (tensor_t pstrain1, tensor_t dfds, double dLambda,
+                           double dt) {
+
+    tensor_t pstrain2;
+
+    if ( thePlasticityModel == RATE_DEPENDANT ) {
+    	pstrain2.xx = pstrain1.xx + dt * dLambda * dfds.xx;
+    	pstrain2.yy = pstrain1.yy + dt * dLambda * dfds.yy;
+    	pstrain2.zz = pstrain1.zz + dt * dLambda * dfds.zz;
+    	pstrain2.xy = pstrain1.xy + dt * dLambda * dfds.xy;
+    	pstrain2.yz = pstrain1.yz + dt * dLambda * dfds.yz;
+    	pstrain2.xz = pstrain1.xz + dt * dLambda * dfds.xz;
+    }
+    else {
+    pstrain2.xx = pstrain1.xx +  dLambda * dfds.xx;
+    pstrain2.yy = pstrain1.yy +  dLambda * dfds.yy;
+    pstrain2.zz = pstrain1.zz +  dLambda * dfds.zz;
+    pstrain2.xy = pstrain1.xy +  dLambda * dfds.xy;
+    pstrain2.yz = pstrain1.yz +  dLambda * dfds.yz;
+    pstrain2.xz = pstrain1.xz +  dLambda * dfds.xz;
+
+    }
+
+    return pstrain2;
+}
+
+int get_displacements(mysolver_t *solver, elem_t *elemp, fvector_t *u) {
+
+    int i;
+    int res = 0;
+
+    /* Capture displacements for each node */
+    for (i = 0; i < 8; i++) {
+
+        int32_t    lnid;
+        fvector_t *dis;
+
+        lnid = elemp->lnid[i];
+        dis  = solver->tm1 + lnid;
+
+        res += vector_is_all_zero( dis );
+
+        u[i].f[0] = dis->f[0];
+        u[i].f[1] = dis->f[1];
+        u[i].f[2] = dis->f[2];
+
+    }
+
+    return res;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              Stability methods                             */
+/* -------------------------------------------------------------------------- */
+
+void check_yield_limit(mesh_t *myMesh, int32_t eindex, double vs, double fs,
+                       double k, int qp)
+{
+    if ( fs > 1.5 * k ) {
+
+        if ( superflag > 0 ) {
+
+            double  north_m, east_m, depth_m;
+            int32_t lnid0;
+
+            lnid0 = myMesh->elemTable[eindex].lnid[0];
+
+            north_m = (myMesh->ticksize)*(double)myMesh->nodeTable[lnid0].x;
+            east_m  = (myMesh->ticksize)*(double)myMesh->nodeTable[lnid0].y;
+            depth_m = (myMesh->ticksize)*(double)myMesh->nodeTable[lnid0].z;
+
+            fprintf(stderr, "\n\n\tcompute_nonlinear_entities:"
+                    "\n\tAn element exceeded the yield surface."
+                    "\n\tThe element origin is at:\n"
+                    "\n\tnorth (m) = %f"
+                    "\n\teast  (m) = %f"
+                    "\n\tdepth (m) = %f"
+                    "\n\tVs  (m/s) = %f"
+                    "\n\tFs        = %f"
+                    "\n\tk         = %f"
+                    "\n\tqp        = %d\n"
+                    "\n\tA smaller dt or coarser mesh is required.\n",
+                    north_m, east_m, depth_m, vs, fs, k, qp);
+
+            MPI_Abort(MPI_COMM_WORLD, ERROR);
+            exit(1);
+
+        } else {
+
+            superflag++;
+        }
+    }
+
+    return;
+}
+
+void check_strain_stability ( double dLambda, double dt, mesh_t *myMesh,
+                              int32_t eindex, double vs, double fs,
+                              double k, int qp)
+{
+    double STRAINRATELIMIT = 0.002;
+
+    if ( dLambda > STRAINRATELIMIT / dt ) {
+
+        if ( superflag > 0 ) {
+
+            double  north_m, east_m, depth_m;
+            int32_t lnid0;
+
+            lnid0 = myMesh->elemTable[eindex].lnid[0];
+
+            north_m = (myMesh->ticksize)*(double)myMesh->nodeTable[lnid0].x;
+            east_m  = (myMesh->ticksize)*(double)myMesh->nodeTable[lnid0].y;
+            depth_m = (myMesh->ticksize)*(double)myMesh->nodeTable[lnid0].z;
+
+            fprintf(stderr, "\n\n\tcompute_nonlinear_entities:"
+                    "\n\tAn element violated dlambda condition"
+                    "\n\tThe element origin is at:\n"
+                    "\n\tnorth (m) = %f"
+                    "\n\teast  (m) = %f"
+                    "\n\tdepth (m) = %f"
+                    "\n\tVs  (m/s) = %f"
+                    "\n\tFs        = %f"
+                    "\n\tk         = %f"
+                    "\n\tqp        = %d\n"
+                    "\n\tdLambda   = % 8e\n",
+                    north_m, east_m, depth_m, vs, fs, k, qp, dLambda);
+
+            MPI_Abort(MPI_COMM_WORLD, ERROR);
+            exit(1);
+
+        } else {
+
+            superflag++;
+        }
+    }
+
+    return;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                   Nonlinear core computational methods                     */
+/* -------------------------------------------------------------------------- */
+
+double smooth_rise_factor(int32_t step, double dt) {
+
+    /* TODO: Consider to eliminate t1, i.e. t1 = 0 */
+
+    static noyesflag_t preloaded = NO;
+    static double n1, n2, n3, n22, n31;
+    static double C1, C2, B1, B2;
+    static int    N;
+
+    /* Pre-load constants, executed only once */
+    if ( preloaded == NO ) {
+
+        N = (int)(theGeostaticLoadingT / dt);
+
+        n1 = (int)( 0.1 * N );
+        n2 = (int)( 0.5 * N );
+        n3 = (int)( 0.9 * N );
+
+        n31 = n3 - n1;
+
+        C1 = 2.0 / ( n31 * (n2 - n1) ) ;
+        C2 = 2.0 / ( n31 * (n2 - n3) ) ;
+
+        B1 = 0.5 * n1 * n1;
+        B2 = 0.5 * ( n31*(n2-n3) + n3*n3 );
+
+        preloaded = YES;
+    }
+
+    /* Started dynamic simulation (the most common case) */
+    if ( step > n3 ) {
+        return 1.0;
+    }
+
+    /* Has not even really started (a zeros-buffer zone) */
+    if ( step <= n1 ) {
+        return 0.0;
+    }
+
+    /* The actual geostatic loading cases */
+
+    n22 = 0.5 * step * step;
+
+    if ( (step > n1) && (step <= n2) ) {
+
+        return C1 * (n22 - step*n1 + B1);
+
+    } else if ( (step > n2) && (step <= n3) ) {
+
+        return C2 * (n22 - step*n3 + B2);
+    }
+
+    /* The code should never get here */
+    fprintf(stderr, "Smooth Rise Error %d %d\n", N, step);
+    MPI_Abort(MPI_COMM_WORLD, ERROR);
+    exit(1);
+}
+
+void add_force_reactions ( mesh_t     *myMesh,
+                           mysolver_t *mySolver )
+{
+
+    int       i;
+    int32_t   beindex, eindex;
+
+    /* Loop on the number of elements */
+    for (beindex = 0; beindex < myBottomElementsCount; beindex++) {
+
+        elem_t    *elemp;
+
+        eindex = myBottomElements[beindex].element_id;
+        elemp  = &myMesh->elemTable[eindex];
+
+        for (i = 4; i < 8; i++) {
+
+            int32_t    lnid;
+            fvector_t *nodalForce;
+
+            lnid = elemp->lnid[i];
+            nodalForce = mySolver->force + lnid;
+
+            nodalForce->f[2] += myBottomElements[beindex].nodal_force[i-4];
+
+        } /* element nodes */
+    }
+
+    return;
+}
+
+void check_balance( int32_t myID ) {
+
+    double totalReaction = 0;
+    int i;
+    int32_t   beindex;
+
+    for (beindex = 0; beindex < myBottomElementsCount; beindex++) {
+        for ( i = 0; i < 4; i++ ) {
+            totalReaction += myBottomElements[beindex].nodal_force[i];
+        }
+    }
+
+    double theTotalWeight;
+    double theTotalReaction;
+
+    MPI_Reduce( &totalWeight, &theTotalWeight, 1,
+                MPI_DOUBLE, MPI_SUM, 0, comm_solver );
+    MPI_Reduce( &totalReaction, &theTotalReaction, 1,
+                MPI_DOUBLE, MPI_SUM, 0, comm_solver );
+
+    if ( myID == 0 ) {
+        fprintf( stdout,
+                 "\tTotal Weight   = %20.6f\n"
+                 "\tTotal Reaction = %20.6f\n"
+                 "\tDifference     = %20.6f\n\n",
+                 theTotalWeight, theTotalReaction,
+                 theTotalWeight+theTotalReaction );
+    }
+
+    return;
+}
+
+void compute_addforce_gravity( mesh_t     *myMesh,
+                               mysolver_t *mySolver,
+                               int         step,
+                               double      dt )
+{
+    /*
+     * Some gravity values:
+     *
+     * Los Angeles    9.796 m/s2      Athens    9.800 m/s2
+     * Mexico City    9.779 m/s2      Auckland  9.799 m/s2
+     * San Francisco  9.800 m/s2      Rome      9.803 m/s2
+     * Istanbul       9.808 m/s2      Tokyo     9.798 m/s2
+     * Vancouver      9.809 m/s2      Ottawa    9.806 m/s2
+     *
+     */
+
+    #define G 9.8
+
+    int32_t   eindex;
+
+    /* Loop on the number of elements */
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+        int      i;
+        elem_t  *elemp;
+        edata_t *edata;
+        double   h, h3;
+        double   rho, W;
+
+        /* Capture element data structure */
+        elemp = &myMesh->elemTable[eindex];
+        edata = (edata_t *)elemp->data;
+
+        /* capture element data */
+        h   = (double)edata->edgesize;
+        rho = (double)edata->rho;
+
+        /* Compute nodal total weight contribution */
+        h3 = h * h * h;
+        W  = h3 * rho * G * 0.125; /* volume x density x gravity / 8 */
+
+        if ( step == theGeostaticFinalStep+10 ) {
+            totalWeight += W*dt*dt*8;
+        }
+
+        /* Loop over the 8 element nodes:
+         * Add the gravitational force contribution calculated with respect
+         * to the current time-step to the nodal force vector.
+         */
+        for (i = 0; i < 8; i++) {
+
+            int32_t    lnid;
+            fvector_t *nodalForce;
+
+            lnid       = elemp->lnid[i];
+            nodalForce = mySolver->force + lnid;
+
+            /* Force due to gravity is positive in Z-axis */
+            nodalForce->f[2] += W * smooth_rise_factor(step, dt) * dt * dt;
+
+        } /* element nodes */
+
+    }
+
+    if ( step > theGeostaticFinalStep ) {
+        add_force_reactions(myMesh, mySolver);
+    }
+
+    return;
+}
+
+void compute_bottom_reactions ( mesh_t     *myMesh,
+                                mysolver_t *mySolver,
+                                fmatrix_t (*theK1)[8],
+                                fmatrix_t (*theK2)[8],
+                                int         step,
+                                double      dt )
+{
+    if ( step != theGeostaticFinalStep ) {
+        return;
+    }
+
+    int32_t   beindex;
+    int32_t   eindex;
+    fvector_t localForce[8];
+
+    for ( beindex = 0; beindex < myBottomElementsCount; beindex++ ) {
+
+        int        i, j;
+        elem_t    *elemp;
+        e_t*       ep;
+
+        eindex = myBottomElements[beindex].element_id;
+        elemp  = &myMesh->elemTable[eindex];
+        ep     = &mySolver->eTable[eindex];
+
+        /* -------------------------------
+         * Ku DONE IN THE CONVENTIONAL WAY
+         * ------------------------------- */
+
+        /* step 1: calculate the force due to the element stiffness */
+        memset( localForce, 0, 8 * sizeof(fvector_t) );
+
+        /* contribution by node j to node i (only for nodes at the bottom) */
+        for (i = 4; i < 8; i++) {
+
+            fvector_t* toForce = &localForce[i];
+
+            for (j = 0; j < 8; j++) {
+
+                int32_t    nodeJ  = elemp->lnid[j];
+                fvector_t *myDisp = mySolver->tm1 + nodeJ;
+
+                MultAddMatVec( &theK1[i][j], myDisp, ep->c1, toForce );
+                MultAddMatVec( &theK2[i][j], myDisp, ep->c2, toForce );
+            }
+        }
+
+        /* step 2: store the forces */
+        for (i = 4; i < 8; i++) {
+            myBottomElements[beindex].nodal_force[i-4] = localForce[i].f[2];
+        }
+
+        edata_t *edata;
+        double   h, h3;
+        double   rho, W;
+
+        edata = (edata_t *)elemp->data;
+        h     = (double)edata->edgesize;
+        rho   = (double)edata->rho;
+        h3    = h * h * h;
+        W     = h3 * rho * G * 0.125;
+
+        for (i = 0; i < 4; i++) {
+            myBottomElements[beindex].nodal_force[i] -= W * dt * dt;
+        }
+    }
+
+    return;
+}
+
+void geostatic_displacements_fix( mesh_t     *myMesh,
+                                  mysolver_t *mySolver,
+                                  double      totalDomainDepth,
+                                  double      dt,
+                                  int         step )
+{
+
+    if ( step > theGeostaticFinalStep ) {
+        return;
+    }
+
+    int32_t nindex;
+
+    for ( nindex = 0; nindex < myMesh->nharbored; nindex++ ) {
+
+        double z_m = (myMesh->ticksize)*(double)myMesh->nodeTable[nindex].z;
+
+        if ( z_m == totalDomainDepth ) {
+            fvector_t *tm2Disp;
+            tm2Disp = mySolver->tm2 + nindex;
+            tm2Disp->f[2] = 0;
+        }
+    }
+
+    return;
+}
+
+/*
+ * compute_addforce_nl: Adds a fictitious force that accounts for
+ *                      nonlinearity in the soil --- a correction
+ *                      to the 'trial' stress within K-elastic
+ *
+ * The computation done here corresponds to calculate the last expression
+ * in the manuscript prepared by Ricardo (part I) for the implementation of
+ * nonlinear soil into the program.
+ *
+ *      Integral(grad(Phi) * Cijkl * PlasticStrain) * delta_t^2
+ */
+void compute_addforce_nl (mesh_t     *myMesh,
+                          mysolver_t *mySolver,
+                          double      theDeltaTSquared)
+{
+
+    int       i, j;
+    int32_t   eindex;
+    int32_t   nl_eindex;
+    fvector_t localForce[8];
+
+    /* Loop on the number of elements */
+    for (nl_eindex = 0; nl_eindex < myNonlinElementsCount; nl_eindex++) {
+
+        elem_t  *elemp;
+        edata_t *edata;
+        double   h, h3, WiJi;
+        double   mu, lambda;
+
+        eindex = myNonlinElementsMapping[nl_eindex];
+
+        qptensors_t stresses;
+
+        /* Capture the table of elements from the mesh and the size
+         * This is what gives me the connectivity to nodes */
+        elemp = &myMesh->elemTable[eindex];
+        edata = (edata_t *)elemp->data;
+
+        h    = (double)edata->edgesize;
+        h3   = h * h * h;
+        WiJi = h3 * 0.125; /* (h^3)/8 */
+
+        nlconstants_t ec = myNonlinSolver->constants[nl_eindex];
+
+        mu     = ec.mu;
+        lambda = ec.lambda;
+
+        if ( theMaterialModel == LINEAR ) {
+
+            stresses = myNonlinSolver->stresses[nl_eindex];
+
+        } else {
+
+            qptensors_t tstrains, pstrains, estrains;
+
+            tstrains = myNonlinSolver->strains   [nl_eindex];
+            pstrains = myNonlinSolver->pstrains1[nl_eindex];
+
+            /* compute total strain - plastic strain */
+            estrains = subtrac_qptensors(tstrains, pstrains);
+
+            /* compute the corresponding stress */
+            stresses = compute_qp_stresses(estrains, mu, lambda);
+        }
+
+        /* Clean memory for the local force vector */
+        memset(localForce, 0, 8 * sizeof(fvector_t));
+
+        /* Loop over the 8 element nodes:
+         * Calculates the forces on each vertex */
+        for (i = 0; i < 8; i++) {
+
+            fvector_t *toForce;
+
+            /* Points the loop force to the element force */
+            toForce = &localForce[i];
+
+            /* Loop over the 8 quadrature points */
+            for (j = 0; j < 8; j++) {
+
+                double dx, dy, dz;
+
+                compute_qp_dxi (&dx, &dy, &dz, i, j, h);
+
+                /* Gauss integration: Sum(DeltaPsi * Sigma * wi * Ji) */
+
+                toForce->f[0] += ( ( dx * stresses.qp[j].xx )
+                                 + ( dy * stresses.qp[j].xy )
+                                 + ( dz * stresses.qp[j].xz ) ) * WiJi;
+
+                toForce->f[1] += ( ( dy * stresses.qp[j].yy )
+                                 + ( dx * stresses.qp[j].xy )
+                                 + ( dz * stresses.qp[j].yz ) ) * WiJi;
+
+                toForce->f[2] += ( ( dz * stresses.qp[j].zz )
+                                 + ( dy * stresses.qp[j].yz )
+                                 + ( dx * stresses.qp[j].xz ) ) * WiJi;
+
+            } /* quadrature points */
+
+        } /* element nodes */
+
+        /* Loop over the 8 element nodes:
+         * Add the contribution calculated above to the node
+         * forces carried from the source and stiffness.
+         */
+        for (i = 0; i < 8; i++) {
+
+            int32_t    lnid;
+            fvector_t *nodalForce;
+
+            lnid = elemp->lnid[i];
+
+            nodalForce = mySolver->force + lnid;
+
+            nodalForce->f[0] -= localForce[i].f[0] * theDeltaTSquared;
+            nodalForce->f[1] -= localForce[i].f[1] * theDeltaTSquared;
+            nodalForce->f[2] -= localForce[i].f[2] * theDeltaTSquared;
+
+        } /* element nodes */
+
+    } /* all elements */
+
+    return;
+}
+
+/*
+ * compute_nonlinear_state: Compute the necessary quantities to determine
+ *                             if an element has undergone plastic deformation.
+ *
+ * The steps described in this method are in reference to the manuscript
+ * prepared by Ricardo about the implementation of nonlinear soil in the
+ * program (Part III).
+ *
+ * The convention for the strain and stress tensors is:
+ *
+ *      T[6] = {Txx, Tyy, Tzz, Txy, Tyz, Txz}
+ */
+void compute_nonlinear_state ( mesh_t     *myMesh,
+                               mysolver_t *mySolver,
+                               int32_t     theNumberOfStations,
+                               int32_t     myNumberOfStations,
+                               station_t  *myStations,
+                               double      theDeltaT)
+{
+    /* In general, j-index refers to the quadrature point in a loop (0 to 7 for
+     * eight points), and i-index refers to the tensor component (0 to 5), with
+     * the following order xx[0], yy[1], zz[2], xy[3], yz[4], xz[5]. i-index is
+     * also some times used for the number of nodes (8, 0 to 7).
+     */
+
+    int     i;
+    int32_t eindex, nl_eindex;
+
+    /* Loop over the number of local elements */
+    for (nl_eindex = 0; nl_eindex < myNonlinElementsCount; nl_eindex++) {
+
+        elem_t        *elemp;
+        edata_t       *edata;
+        nlconstants_t *enlcons;
+
+        double         h;          /* Element edge-size in meters   */
+        double         alpha, k;   /* Drucker-Prager constants      */
+        double         mu, lambda; /* Elasticity material constants */
+        double		   hrd;        /* Hardening Modulus  */
+        double         XI, QC;
+        double         Fs, I1, oct, J2, Fs2, ept=0;
+        fvector_t      u[8];
+        qptensors_t   *stresses, *tstrains, *pstrains1, *pstrains2;
+        qpvectors_t   *epstr1, *epstr2;
+
+        /* Capture data from the element and mesh */
+
+        eindex = myNonlinElementsMapping[nl_eindex];
+
+        elemp = &myMesh->elemTable[eindex];
+        edata = (edata_t *)elemp->data;
+        h     = edata->edgesize;
+
+        /* Capture data from the nonlinear element structure */
+
+        enlcons = myNonlinSolver->constants + nl_eindex;
+
+        mu     = enlcons->mu;
+        lambda = enlcons->lambda;
+        alpha  = enlcons->alpha;
+        k      = enlcons->k;
+        hrd    = enlcons->hardmodulus;
+
+        /* Capture the current state in the element */
+        tstrains  = myNonlinSolver->strains   + nl_eindex;
+        stresses  = myNonlinSolver->stresses  + nl_eindex;
+        pstrains1 = myNonlinSolver->pstrains1 + nl_eindex;
+        pstrains2 = myNonlinSolver->pstrains2 + nl_eindex;
+        epstr1    = myNonlinSolver->ep1       + nl_eindex;
+        epstr2    = myNonlinSolver->ep2       + nl_eindex;
+
+
+        /* Capture displacements */
+        if ( get_displacements(mySolver, elemp, u) == 0 ) {
+            /* If all displacements are zero go for next element */
+            continue;
+        }
+
+        /* Loop over the quadrature points */
+        for (i = 0; i < 8; i++) {
+
+            tensor_t    estrain, dev;
+
+            /* Quadrature point local coordinates */
+            double lx = xi[0][i] * qc ;
+            double ly = xi[1][i] * qc ;
+            double lz = xi[2][i] * qc ;
+
+            /* Calculate strains */
+            tstrains->qp[i] = point_strain(u, lx, ly, lz, h);
+
+            /* Calculate stresses */
+            if ( theMaterialModel == LINEAR ) {
+                stresses->qp[i]  = point_stress ( tstrains->qp[i], mu, lambda );
+            } else {
+                pstrains1->qp[i] = copy_tensor ( pstrains2->qp[i] );     /* strain predictor: equal to the previous strain tens   */
+                estrain          = subtrac_tensors ( tstrains->qp[i], pstrains1->qp[i] ); /* stress predictor   */
+                stresses->qp[i]  = point_stress ( estrain, mu, lambda );
+                ept              = epstr2->qv[i];
+
+            }
+
+
+            /* Stress invariants */
+            I1  = tensor_I1 ( stresses->qp[i] );
+            oct = tensor_octahedral ( I1 );
+            dev = tensor_deviator ( stresses->qp[i], oct );
+            J2  = tensor_J2 ( dev );
+            Fs  = compute_yield_surface_state ( J2, I1, alpha ); /* Fs predictor */
+
+
+            enlcons->avgFs += Fs * 0.125; /* 1/8 = 0.125 is qp contribution */
+            if ( Fs > enlcons->maxFs ) {
+                enlcons->maxFs = Fs;
+            }
+
+            /* Do not compute plasticity for the linear case */
+//            if ( ( theMaterialModel == LINEAR ) || ( J2 == 0 ) ) {
+            if ( ( theMaterialModel == LINEAR ) ) {
+            	continue;
+            }
+
+            /* Next plastic strain correction */
+            enlcons->dLambda[i] = compute_dLambdaII ( *enlcons, Fs, ept , J2, I1 );
+            tensor_t dfds       = compute_dfds ( dev, J2, alpha );
+            pstrains2->qp[i]    = compute_pstrain2 ( pstrains1->qp[i], dfds, enlcons->dLambda[i], theDeltaT ); /* real plastic strain */
+        	epstr2->qv[i]       = ept + enlcons->dLambda[i] * sqrt ( 1/2. + 3 * alpha * alpha);
+
+//            if ( hrd != 0)
+//            	epstr2->qv[i]   = ept + enlcons->dLambda[i] * sqrt ( 1/2. + 3 * alpha * alpha);
+//            else
+//            	epstr2->qv[i]   = 0;
+
+            /* if fs > k the stress and strain tensors must be corrected. Dorian*/
+            if ( thePlasticityModel != RATE_DEPENDANT ) {
+            	if ( enlcons->dLambda[i] > 0 ){
+            		estrain          = subtrac_tensors ( tstrains->qp[i], pstrains2->qp[i] );
+            		stresses->qp[i]  = point_stress ( estrain, mu, lambda ); /* real stress tensor */
+            		I1               = tensor_I1 ( stresses->qp[i] );
+            		oct              = tensor_octahedral ( I1 );
+            		dev              = tensor_deviator ( stresses->qp[i], oct );
+            		J2               = tensor_J2 ( dev );
+            		Fs2              = compute_yield_surface_state ( J2, I1, alpha );  /* final Fs value, must be equal to the value from the hardening function */
+            	}
+            }
+
+            /* Storing and checking */
+            if ( thePlasticityModel == RATE_DEPENDANT ) {
+            	enlcons->fs[i] = Fs;
+            	check_yield_limit ( myMesh, eindex, edata->Vs, Fs, k, i);
+            }
+//            check_strain_stability ( enlcons->dLambda[i], theDeltaT, myMesh, eindex, edata->Vs, Fs, k, i );
+
+
+
+        } /* for all quadrature points */
+
+    } /* for all nonlinear elements */
+
+}
+
+/* -------------------------------------------------------------------------- */
+/*                        Nonlinear Finalize and Stats                        */
+/* -------------------------------------------------------------------------- */
+
+void nonlinear_yield_stats(mesh_t *myMesh, int32_t myID, int32_t theTotalSteps, int32_t theGroupSize) {
+
+    static double VSMIN = 0;
+    static double VSMAX = 10000;
+
+    int32_t  nl_eindex, eindex;
+    int      r;
+    int      ranges = thePropertiesCount+1;
+    double  *myFsMaxs;
+    double  *myFsAvgs;
+    double   vs, vs0, vs1;
+    int32_t *myFsAvgCount;
+
+    myFsMaxs     =  (double *)calloc(ranges, sizeof(double));
+    myFsAvgs     =  (double *)calloc(ranges, sizeof(double));
+    myFsAvgCount = (int32_t *)calloc(ranges, sizeof(int32_t));
+
+    for ( nl_eindex = 0; nl_eindex < myNonlinElementsCount; nl_eindex++ ) {
+
+        elem_t        *elemp;
+        edata_t       *edata;
+        nlconstants_t  ec;
+
+        eindex = myNonlinElementsMapping[nl_eindex];
+        elemp  = &myMesh->elemTable[eindex];
+        edata  = (edata_t *)elemp->data;
+        ec     = myNonlinSolver->constants[nl_eindex];
+        vs     = edata->Vs;
+
+        for ( r = 0; r < ranges; r++ ) {
+
+            /* set bottom vs limit */
+            if ( r == 0 ) {
+                vs0 = VSMIN;
+            } else {
+                vs0 = theVsLimits[r-1];
+            }
+
+            /* set top vs limit */
+            if ( r == ranges-1 ) {
+                vs1 = VSMAX;
+            } else {
+                vs1 = theVsLimits[r];
+            }
+
+            if ( (vs > vs0) && (vs <= vs1) ) {
+                myFsAvgs[r] += ec.avgFs;
+                myFsAvgCount[r]++;
+                if ( ec.maxFs > myFsMaxs[r] ) {
+                    myFsMaxs[r] = ec.maxFs;
+                }
+            }
+        }
+    }
+
+    if ( myNonlinElementsCount > 0 ) {
+        for ( r = 0; r < ranges; r++ ) {
+            myFsAvgs[r] /= theTotalSteps;
+        }
+    }
+
+
+    double  *theFsMaxs     = NULL;
+    double  *theFsAvgs     = NULL;
+    int32_t *theFsAvgCount = NULL;
+
+    theFsMaxs     =  (double *)calloc(ranges, sizeof(double));
+    theFsAvgs     =  (double *)calloc(ranges, sizeof(double));
+    theFsAvgCount = (int32_t *)calloc(ranges, sizeof(int32_t));
+
+    MPI_Reduce(myFsMaxs, theFsMaxs, ranges, MPI_DOUBLE, MPI_MAX, 0, comm_solver );
+    MPI_Reduce(myFsAvgs, theFsAvgs, ranges, MPI_DOUBLE, MPI_SUM, 0, comm_solver );
+    MPI_Reduce(myFsAvgCount, theFsAvgCount, ranges, MPI_INT, MPI_SUM, 0, comm_solver );
+
+    if ( myID == 0 ) {
+
+        for ( r = 0; r < ranges; r++ ) {
+            if ( theFsAvgCount[r] > 0 ) {
+                theFsAvgs[r] /= theFsAvgCount[r];
+            }
+        }
+
+        FILE *fp = hu_fopen( "stat-fs-yield.txt", "w" );
+
+        fputs( "\n"
+               "# ------------------------------------------- \n"
+               "# Nonlinear Fs maximum and average values:    \n"
+               "# ------------------------------------------- \n"
+               "#   Vs >    Vs <=           Avg           Max \n"
+               "# ------------------------------------------- \n", fp );
+
+        for ( r = 0; r < ranges; r++ ) {
+
+            /* set bottom vs limit */
+            if ( r == 0 ) {
+                vs0 = VSMIN;
+            } else {
+                vs0 = theVsLimits[r-1];
+            }
+
+            /* set top vs limit */
+            if ( r == ranges-1 ) {
+                vs1 = VSMAX;
+            } else {
+                vs1 = theVsLimits[r];
+            }
+
+            fprintf( fp, "%8.0f %8.0f % 10e % 10e\n",
+                     vs0, vs1, theFsAvgs[r], theFsMaxs[r]);
+
+        }
+
+        fprintf( fp, "# ------------------------------------------- \n\n");
+
+        hu_fclosep( &fp );
+
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/*                        Nonlinear Output to Stations                        */
+/* -------------------------------------------------------------------------- */
+
+void nonlinear_stations_init(mesh_t    *myMesh,
+                             station_t *myStations,
+                             int32_t    myNumberOfStations)
+{
+
+    if ( myNumberOfStations == 0 ) {
+        return;
+    }
+
+    int32_t     eindex, nl_eindex;
+    int32_t     iStation=0;
+    vector3D_t  point;
+    octant_t   *octant;
+    int32_t     lnid0;
+
+    myNumberOfNonlinStations = 0;
+    for (iStation = 0; iStation < myNumberOfStations; iStation++) {
+
+        for ( nl_eindex = 0; nl_eindex < myNonlinElementsCount; nl_eindex++ ) {
+
+            /* capture the stations coordinates */
+            point = myStations[iStation].coords;
+
+            /* search the octant */
+            if ( search_point(point, &octant) != 1 ) {
+                fprintf(stderr,
+                        "nonlinear_stations_init: "
+                        "No octant with station coords\n");
+                MPI_Abort(MPI_COMM_WORLD, ERROR);
+                exit(1);
+            }
+
+            eindex = myNonlinElementsMapping[nl_eindex];
+
+            lnid0 = myMesh->elemTable[eindex].lnid[0];
+
+            if ( (myMesh->nodeTable[lnid0].x == octant->lx) &&
+                 (myMesh->nodeTable[lnid0].y == octant->ly) &&
+                 (myMesh->nodeTable[lnid0].z == octant->lz) ) {
+
+                /* I have a match for the element's origin */
+
+                /* Now, perform level sanity check */
+                if (myMesh->elemTable[eindex].level != octant->level) {
+                    fprintf(stderr,
+                            "nonlinear_stations_init: First pass: "
+                            "Wrong level of octant\n");
+                    MPI_Abort(MPI_COMM_WORLD, ERROR);
+                    exit(1);
+                }
+
+                myNumberOfNonlinStations++;
+
+                break;
+            }
+        }
+    }
+
+    XMALLOC_VAR_N( myStationsElementIndices, int32_t, myNumberOfNonlinStations);
+    XMALLOC_VAR_N( myNonlinStationsMapping, int32_t, myNumberOfNonlinStations);
+    XMALLOC_VAR_N( myNonlinStations, nlstation_t, myNumberOfNonlinStations);
+
+    int32_t nlStationsCount = 0;
+    for (iStation = 0; iStation < myNumberOfStations; iStation++) {
+
+        for ( nl_eindex = 0; nl_eindex < myNonlinElementsCount; nl_eindex++ ) {
+
+            /* capture the stations coordinates */
+            point = myStations[iStation].coords;
+
+            /* search the octant */
+            if ( search_point(point, &octant) != 1 ) {
+                fprintf(stderr,
+                        "nonlinear_stations_init: "
+                        "No octant with station coords\n");
+                MPI_Abort(MPI_COMM_WORLD, ERROR);
+                exit(1);
+            }
+
+            eindex = myNonlinElementsMapping[nl_eindex];
+
+            lnid0 = myMesh->elemTable[eindex].lnid[0];
+
+            if ( (myMesh->nodeTable[lnid0].x == octant->lx) &&
+                 (myMesh->nodeTable[lnid0].y == octant->ly) &&
+                 (myMesh->nodeTable[lnid0].z == octant->lz) ) {
+
+                /* I have a match for the element's origin */
+
+                /* Now, perform level sanity check */
+                if (myMesh->elemTable[eindex].level != octant->level) {
+                    fprintf(stderr,
+                            "nonlinear_stations_init: Second pass: "
+                            "Wrong level of octant\n");
+                    MPI_Abort(MPI_COMM_WORLD, ERROR);
+                    exit(1);
+                }
+
+                if ( nlStationsCount >= myNumberOfNonlinStations ) {
+                    fprintf(stderr,
+                            "nonlinear_stations_init: Second pass: "
+                            "More stations than initially counted\n");
+                    MPI_Abort(MPI_COMM_WORLD, ERROR);
+                    exit(1);
+                }
+
+                /* Store the element index and mapping to stations */
+                myStationsElementIndices[nlStationsCount] = nl_eindex;
+                myNonlinStationsMapping[nlStationsCount] = iStation;
+
+                nlStationsCount++;
+
+                break;
+            }
+
+        } /* for all my elements */
+
+    } /* for all my stations */
+
+    for ( iStation = 0; iStation < myNumberOfNonlinStations; iStation++ ) {
+
+        tensor_t *stress, *strain, *pstrain1, *pstrain2;
+        double   *ep1;
+
+        strain   = &(myNonlinStations[iStation].strain);
+        stress   = &(myNonlinStations[iStation].stress);
+        pstrain1 = &(myNonlinStations[iStation].pstrain1);
+        pstrain2 = &(myNonlinStations[iStation].pstrain2);
+        ep1      = &(myNonlinStations[iStation].ep );
+        *ep1     = 0;
+
+        init_tensorptr(strain);
+        init_tensorptr(stress);
+        init_tensorptr(pstrain1);
+        init_tensorptr(pstrain2);
+
+    }
+
+}
+
+void print_nonlinear_stations(mesh_t     *myMesh,
+                              mysolver_t *mySolver,
+                              station_t  *myStations,
+                              int32_t     myNumberOfStations,
+                              double      dt,
+                              int         step,
+                              int         rate)
+{
+
+    int32_t eindex;
+    int32_t nl_eindex;
+    int32_t iStation;
+    int32_t mappingIndex;
+
+    for ( iStation = 0; iStation < myNumberOfNonlinStations; iStation++ ) {
+
+        vector3D_t     localcoords;
+        tensor_t      *stress, *tstrain, *pstrain1, *pstrain2, estrain, dev;
+        elem_t        *elemp;
+        edata_t       *edata;
+        nlconstants_t *constants;
+        fvector_t      u[8];
+        double         alpha, lambda, dLambda = 0, mu, k, hrd,  Fs = 0, J2, I1, h, oct;
+        double         bStrain = 0, bStress = 0, *ept, ep=0;
+        double         lx, ly, lz;
+
+        nl_eindex    = myStationsElementIndices[iStation];
+        eindex       = myNonlinElementsMapping[nl_eindex];
+        mappingIndex = myNonlinStationsMapping[iStation];
+
+        elemp = &myMesh->elemTable[eindex];
+        edata = (edata_t *)elemp->data;
+        h     = edata->edgesize;
+
+        /* Capture data from the nonlinear element structure */
+        constants = myNonlinSolver->constants + nl_eindex;
+
+        mu     = constants->mu;
+        lambda = constants->lambda;
+        alpha  = constants->alpha;
+        k      = constants->k;
+        hrd    = constants->hardmodulus;
+
+        /* Capture the current state in the station */
+        tstrain  = &(myNonlinStations[iStation].strain);
+        stress   = &(myNonlinStations[iStation].stress);
+        pstrain1 = &(myNonlinStations[iStation].pstrain1);
+        pstrain2 = &(myNonlinStations[iStation].pstrain2);
+        ept      = &(myNonlinStations[iStation].ep);
+        ep       = *ept;
+
+        /* Capture displacements */
+        if ( get_displacements(mySolver, elemp, u) == 0 ) {
+            /* If all displacements are zero go directly to printing */
+            goto NLPRINT;
+        }
+
+        /* Capture local coordinates */
+        localcoords = myStations[mappingIndex].localcoords;
+
+        localcoords.x[0] = -1/sqrt(3.);
+        localcoords.x[1] = -1/sqrt(3.);
+        localcoords.x[2] = -1/sqrt(3.);
+
+        lx = localcoords.x[0];
+        ly = localcoords.x[1];
+        lz = localcoords.x[2];
+
+        /* Calculate strains */
+        *tstrain = point_strain(u, lx, ly, lz, h);
+
+        /* Calculate stresses */
+        if ( theMaterialModel == LINEAR ) {
+            *stress = point_stress ( *tstrain, mu, lambda);
+        } else {
+            *pstrain1 = copy_tensor ( *pstrain2 );
+            estrain   = subtrac_tensors ( *tstrain, *pstrain1 );
+            *stress   = point_stress ( estrain, mu, lambda );
+        }
+
+        /* Stress invariants */
+        I1  = tensor_I1 ( *stress );
+        oct = tensor_octahedral ( I1 );
+        dev = tensor_deviator ( *stress, oct );
+        J2  = tensor_J2 ( dev );
+
+        Fs  = compute_yield_surface_state ( J2, I1, alpha );
+
+
+        /* Do not compute plasticity for the linear case */
+        if ( theMaterialModel != LINEAR ) {
+//            if ( J2 != 0 ) {
+                /* Next plastic strain correction */
+                dLambda       = compute_dLambdaII ( *constants, Fs, *ept, J2, I1 );
+                tensor_t dfds = compute_dfds ( dev, J2, alpha );
+                *pstrain2     = compute_pstrain2 ( *pstrain1, dfds, dLambda, dt );
+                *ept          = ep +  dLambda * sqrt (1/2. + 3 * alpha * alpha );
+
+
+                if ( thePlasticityModel != RATE_DEPENDANT ) {
+                	if ( dLambda > 0) {
+
+                		estrain   = subtrac_tensors ( *tstrain, *pstrain2 );
+                		*stress   = point_stress ( estrain, mu, lambda );
+                		I1  = tensor_I1 ( *stress );
+                		oct = tensor_octahedral ( I1 );
+                		dev = tensor_deviator ( *stress, oct );
+                		J2  = tensor_J2 ( dev );
+                		Fs  = compute_yield_surface_state ( J2, I1, alpha );  /* final Fs value, must be equal to the value from the hardening function */
+                	}
+
+                }
+
+//            }
+        }
+
+        bStrain = tstrain->xx + tstrain->yy + tstrain->zz;
+        bStress = stress->xx + stress->yy + stress->zz;
+
+NLPRINT:
+        if (step % rate == 0) {
+            fprintf( myStations[mappingIndex].fpoutputfile,
+
+                    " % 8e % 8e"
+                    " % 8e % 8e"
+                    " % 8e % 8e"
+                    " % 8e % 8e"
+                    " % 8e % 8e"
+                    " % 8e % 8e"
+                    " % 8e % 8e"
+                    " % 8e % 8e % 8e",
+
+                    tstrain->xx, stress->xx, // 11 12
+                    tstrain->yy, stress->yy, // 13 14
+                    tstrain->zz, stress->zz, // 15 16
+                    bStrain,     bStress,    // 17 18
+                    tstrain->xy, stress->xy, // 19 20
+                    tstrain->yz, stress->yz, // 21 22
+                    tstrain->xz, stress->xz, // 23 24
+                    dLambda, Fs, k + hrd * (*ept) ); // 25 26 27
+        }
+    } /* for all my stations */
+
+}

--- a/quake/forward_gpu/nonlinear.h
+++ b/quake/forward_gpu/nonlinear.h
@@ -1,0 +1,279 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef Q_NONLINEAR_H
+#define Q_NONLINEAR_H
+
+/* -------------------------------------------------------------------------- */
+/*                        Structures and definitions                          */
+/* -------------------------------------------------------------------------- */
+
+typedef enum {
+
+    RATE_DEPENDANT = 0, RATE_INDEPENDANT
+
+} plasticitytype_t;
+
+
+typedef enum {
+    /*
+     * The Linear option is intended for calculating nonlinear associated
+     * entities (e.g., strains, stresses, k, J2) while keeping all elements
+     * elastic. No operation is performed at compute_addforce_nl. This option
+     * allows one to initially evaluate the levels of deformation and serves
+     * for comparisons with the corresponding elastoplastic runs.
+     */
+    LINEAR = 0, VONMISES, DRUCKERPRAGER
+
+} materialmodel_t;
+
+typedef enum {
+    /*
+     * The options for vonMises and DruckerPrager to decide in how to input
+     * the material properties for nonlinear analysis may be in the form of
+     * data for cohesion and friction angle, or data for the coefficients
+     * alpha and k.
+     */
+    COHEFRICTION = 0, ALPHAKAY
+} materialproperties_t;
+
+typedef struct vector_t {
+
+	double ep;
+
+} vector_t;
+
+
+typedef struct tensor_t {
+
+    double xx;
+    double yy;
+    double zz;
+    double xy;
+    double yz;
+    double xz;
+
+} tensor_t;
+
+typedef struct qpvectors_t {
+
+    double qv[8];
+
+} qpvectors_t;
+
+typedef struct qptensors_t {
+
+    tensor_t qp[8];
+
+} qptensors_t;
+
+typedef struct nlconstants_t {
+
+    double lambda;
+    double mu;
+    double alpha;      /* yield function constants */
+    double k;
+    double fs[8];      /* F(sigma) */
+    double dLambda[8]; /* yield control */
+    double strainrate;
+    double sensitivity;
+    double hardmodulus; /* the effective yield stress is defined as : ( k + hardmodulus*ep ) */
+
+    double maxFs;
+    double avgFs;
+
+} nlconstants_t;
+
+typedef struct nlsolver_t {
+
+    nlconstants_t *constants;
+    qptensors_t   *stresses;
+    qptensors_t   *strains;
+    qptensors_t   *pstrains1;
+    qptensors_t   *pstrains2;
+    qpvectors_t   *ep1;         /* effective plastic strains */
+    qpvectors_t   *ep2;
+
+
+} nlsolver_t;
+
+typedef struct nlstation_t {
+
+    tensor_t stress;
+    tensor_t strain;
+    tensor_t pstrain1;
+    tensor_t pstrain2;
+    double   ep;
+
+} nlstation_t;
+
+typedef struct bottomelement_t {
+
+    int32_t element_id;
+    double  nodal_force[4];
+
+} bottomelement_t;
+
+/* -------------------------------------------------------------------------- */
+/*                                 Utilities                                  */
+/* -------------------------------------------------------------------------- */
+
+double get_geostatic_total_time();
+
+int isThisElementNonLinear(mesh_t *myMesh, int32_t eindex);
+
+double interpolate_property_value(double vsRequest, double *propVector);
+double get_alpha(double vs);
+double get_kay(double vs);
+
+/* -------------------------------------------------------------------------- */
+/*       Initialization of parameters, structures and memory allocations      */
+/* -------------------------------------------------------------------------- */
+
+void nonlinear_init ( int32_t     myID,
+                      const char *parametersin,
+                      double      theDeltaT,
+                      double      theEndT );
+
+int32_t nonlinear_initparameters ( const char *parametersin,
+                                   double      theDeltaT,
+                                   double      theEndT );
+
+void nonlinear_elements_count(int32_t myID, mesh_t *myMesh);
+void nonlinear_elements_mapping(int32_t myID, mesh_t *myMesh);
+void bottom_elements_count(int32_t myID, mesh_t *myMesh, double depth);
+void bottom_elements_mapping(int32_t myID, mesh_t *myMesh, double depth);
+void nonlinear_print_stats(int32_t *nonlinElementsCount,
+                           int32_t *nonlinStationsCount,
+                           int32_t *bottomElementsCount,
+                           int32_t  theGroupSize);
+
+void nonlinear_stats(int32_t myID, int32_t theGroupSize);
+void nonlinear_solver_init(int32_t myID, mesh_t *myMesh, double depth);
+
+/* -------------------------------------------------------------------------- */
+/*                   Auxiliary tensor manipulation methods                    */
+/* -------------------------------------------------------------------------- */
+
+double   tensor_I1(tensor_t tensor);
+double   tensor_octahedral(double I1);
+tensor_t tensor_deviator(tensor_t tensor, double oct);
+double   tensor_J2(tensor_t dev);
+
+void point_dxi      ( double *dx, double *dy, double *dz,
+                      double  lx, double  ly, double  lz,
+                      double h, int i );
+void compute_qp_dxi ( double *dx, double *dy, double *dz,
+                      int i, int j, double h);
+
+tensor_t init_tensor     ( );
+void     init_tensorptr  ( tensor_t *tensor );
+
+tensor_t point_strain    ( fvector_t *u, double lx, double ly, double lz,
+                           double h);
+tensor_t point_stress    ( tensor_t strain, double mu, double lambda);
+tensor_t subtrac_tensors ( tensor_t A, tensor_t B);
+tensor_t copy_tensor     ( tensor_t original);
+
+qptensors_t compute_qp_stresses ( qptensors_t strains, double mu, double lambda);
+qptensors_t subtrac_qptensors   ( qptensors_t A, qptensors_t B);
+
+double   compute_yield_surface_state ( double J2, double I1, double alpha );
+double   compute_dLambdaII           ( nlconstants_t constants, double fs, double eff_ps, double J2, double I1 );
+tensor_t compute_dfds                ( tensor_t dev, double J2, double alpha);
+tensor_t compute_pstrain2            ( tensor_t pstrain1, tensor_t dfds,
+                                       double dLambda, double dt);
+
+int get_displacements ( mysolver_t *solver, elem_t *elemp, fvector_t *u );
+
+/* -------------------------------------------------------------------------- */
+/*                              Stability methods                             */
+/* -------------------------------------------------------------------------- */
+
+void check_yield_limit      ( mesh_t *myMesh, int32_t eindex, double vs,
+                              double fs, double k, int qp);
+void check_strain_stability ( double dLambda, double dt, mesh_t *myMesh,
+                              int32_t eindex, double vs, double fs,
+                              double k, int qp);
+
+/* -------------------------------------------------------------------------- */
+/*                   Nonlinear core computational methods                     */
+/* -------------------------------------------------------------------------- */
+
+void compute_addforce_gravity( mesh_t     *myMesh,
+                               mysolver_t *mySolver,
+                               int         step,
+                               double      dt );
+
+void compute_bottom_reactions ( mesh_t     *myMesh,
+                                mysolver_t *mySolver,
+                                fmatrix_t (*theK1)[8],
+                                fmatrix_t (*theK2)[8],
+                                int         step,
+                                double      dt );
+
+void geostatic_displacements_fix( mesh_t     *myMesh,
+                                  mysolver_t *mySolver,
+                                  double      totalDomainDepth,
+                                  double      dt,
+                                  int         step );
+
+
+void compute_addforce_nl ( mesh_t     *myMesh,
+                           mysolver_t *mySolver,
+                           double      theDeltaTSquared );
+
+void compute_nonlinear_state ( mesh_t     *myMesh,
+                               mysolver_t *mySolver,
+                               int32_t     theNumberOfStations,
+                               int32_t     myNumberOfStations,
+                               station_t  *myStations,
+                               double      theDeltaT );
+
+/* -------------------------------------------------------------------------- */
+/*                        Nonlinear Output to Stations                        */
+/* -------------------------------------------------------------------------- */
+
+void nonlinear_stations_init ( mesh_t    *myMesh,
+                               station_t *myStations,
+                               int32_t    myNumberOfStations );
+
+void print_nonlinear_stations ( mesh_t     *myMesh,
+                                mysolver_t *mySolver,
+                                station_t  *myStations,
+                                int32_t     myNumberOfStations,
+                                double      dt,
+                                int         step,
+                                int         rate);
+
+/* -------------------------------------------------------------------------- */
+
+void nonlinear_yield_stats(mesh_t *myMesh, int32_t myID, int32_t theTotalSteps, int32_t theGroupSize);
+
+void check_balance( int32_t myID );
+
+#endif /* Q_NONLINEAR_H */
+
+
+
+
+
+
+
+

--- a/quake/forward_gpu/nrutila.cu
+++ b/quake/forward_gpu/nrutila.cu
@@ -1,0 +1,316 @@
+/* -*- C -*- */
+
+/* CAUTION: This is the ANSI C (only) version of the Numerical Recipes
+   utility file nrutil.c.  Do not confuse this file with the same-named
+   file nrutil.c that is supplied in the same subdirectory or archive
+   as the header file nrutil.h.  *That* file contains both ANSI and
+   traditional K&R versions, along with #ifdef macros to select the
+   correct version.  *This* file contains only ANSI C.               */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#define NR_END 1
+#define FREE_ARG char*
+
+void nrerror(char error_text[])
+/* Numerical Recipes standard error handler */
+{
+	fprintf(stderr,"Numerical Recipes run-time error...\n");
+	fprintf(stderr,"%s\n",error_text);
+	fprintf(stderr,"...now exiting to system...\n");
+	exit(1);
+}
+
+float *vector(long nl, long nh)
+/* allocate a float vector with subscript range v[nl..nh] */
+{
+	float *v;
+
+	v=(float *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(float)));
+	if (!v) nrerror("allocation failure in vector()");
+	return v-nl+NR_END;
+}
+
+int *ivector(long nl, long nh)
+/* allocate an int vector with subscript range v[nl..nh] */
+{
+	int *v;
+
+	v=(int *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(int)));
+	if (!v) nrerror("allocation failure in ivector()");
+	return v-nl+NR_END;
+}
+
+unsigned char *cvector(long nl, long nh)
+/* allocate an unsigned char vector with subscript range v[nl..nh] */
+{
+	unsigned char *v;
+
+	v=(unsigned char *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(unsigned char)));
+	if (!v) nrerror("allocation failure in cvector()");
+	return v-nl+NR_END;
+}
+
+unsigned long *lvector(long nl, long nh)
+/* allocate an unsigned long vector with subscript range v[nl..nh] */
+{
+	unsigned long *v;
+
+	v=(unsigned long *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(long)));
+	if (!v) nrerror("allocation failure in lvector()");
+	return v-nl+NR_END;
+}
+
+double *dvector(long nl, long nh)
+/* allocate a double vector with subscript range v[nl..nh] */
+{
+	double *v;
+
+	v=(double *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(double)));
+	if (!v) nrerror("allocation failure in dvector()");
+	return v-nl+NR_END;
+}
+
+float **matrix(long nrl, long nrh, long ncl, long nch)
+/* allocate a float matrix with subscript range m[nrl..nrh][ncl..nch] */
+{
+	long i, nrow=nrh-nrl+1,ncol=nch-ncl+1;
+	float **m;
+
+	/* allocate pointers to rows */
+	m=(float **) malloc((size_t)((nrow+NR_END)*sizeof(float*)));
+	if (!m) nrerror("allocation failure 1 in matrix()");
+	m += NR_END;
+	m -= nrl;
+
+	/* allocate rows and set pointers to them */
+	m[nrl]=(float *) malloc((size_t)((nrow*ncol+NR_END)*sizeof(float)));
+	if (!m[nrl]) nrerror("allocation failure 2 in matrix()");
+	m[nrl] += NR_END;
+	m[nrl] -= ncl;
+
+	for(i=nrl+1;i<=nrh;i++) m[i]=m[i-1]+ncol;
+
+	/* return pointer to array of pointers to rows */
+	return m;
+}
+
+double **dmatrix(long nrl, long nrh, long ncl, long nch)
+/* allocate a double matrix with subscript range m[nrl..nrh][ncl..nch] */
+{
+	long i, nrow=nrh-nrl+1,ncol=nch-ncl+1;
+	double **m;
+
+	/* allocate pointers to rows */
+	m=(double **) malloc((size_t)((nrow+NR_END)*sizeof(double*)));
+	if (!m) nrerror("allocation failure 1 in matrix()");
+	m += NR_END;
+	m -= nrl;
+
+	/* allocate rows and set pointers to them */
+	m[nrl]=(double *) malloc((size_t)((nrow*ncol+NR_END)*sizeof(double)));
+	if (!m[nrl]) nrerror("allocation failure 2 in matrix()");
+	m[nrl] += NR_END;
+	m[nrl] -= ncl;
+
+	for(i=nrl+1;i<=nrh;i++) m[i]=m[i-1]+ncol;
+
+	/* return pointer to array of pointers to rows */
+	return m;
+}
+
+int **imatrix(long nrl, long nrh, long ncl, long nch)
+/* allocate a int matrix with subscript range m[nrl..nrh][ncl..nch] */
+{
+	long i, nrow=nrh-nrl+1,ncol=nch-ncl+1;
+	int **m;
+
+	/* allocate pointers to rows */
+	m=(int **) malloc((size_t)((nrow+NR_END)*sizeof(int*)));
+	if (!m) nrerror("allocation failure 1 in matrix()");
+	m += NR_END;
+	m -= nrl;
+
+
+	/* allocate rows and set pointers to them */
+	m[nrl]=(int *) malloc((size_t)((nrow*ncol+NR_END)*sizeof(int)));
+	if (!m[nrl]) nrerror("allocation failure 2 in matrix()");
+	m[nrl] += NR_END;
+	m[nrl] -= ncl;
+
+	for(i=nrl+1;i<=nrh;i++) m[i]=m[i-1]+ncol;
+
+	/* return pointer to array of pointers to rows */
+	return m;
+}
+
+float **submatrix(float **a, long oldrl, long oldrh, long oldcl, long oldch,
+	long newrl, long newcl)
+/* point a submatrix [newrl..][newcl..] to a[oldrl..oldrh][oldcl..oldch] */
+{
+	long i,j,nrow=oldrh-oldrl+1,ncol=oldcl-newcl;
+	float **m;
+
+	/* allocate array of pointers to rows */
+	m=(float **) malloc((size_t) ((nrow+NR_END)*sizeof(float*)));
+	if (!m) nrerror("allocation failure in submatrix()");
+	m += NR_END;
+	m -= newrl;
+
+	/* set pointers to rows */
+	for(i=oldrl,j=newrl;i<=oldrh;i++,j++) m[j]=a[i]+ncol;
+
+	/* return pointer to array of pointers to rows */
+	return m;
+}
+
+float **convert_matrix(float *a, long nrl, long nrh, long ncl, long nch)
+/* allocate a float matrix m[nrl..nrh][ncl..nch] that points to the matrix
+declared in the standard C manner as a[nrow][ncol], where nrow=nrh-nrl+1
+and ncol=nch-ncl+1. The routine should be called with the address
+&a[0][0] as the first argument. */
+{
+	long i,j,nrow=nrh-nrl+1,ncol=nch-ncl+1;
+	float **m;
+
+	/* allocate pointers to rows */
+	m=(float **) malloc((size_t) ((nrow+NR_END)*sizeof(float*)));
+	if (!m) nrerror("allocation failure in convert_matrix()");
+	m += NR_END;
+	m -= nrl;
+
+	/* set pointers to rows */
+	m[nrl]=a-ncl;
+	for(i=1,j=nrl+1;i<nrow;i++,j++) m[j]=m[j-1]+ncol;
+	/* return pointer to array of pointers to rows */
+	return m;
+}
+
+float ***f3tensor(long nrl, long nrh, long ncl, long nch, long ndl, long ndh)
+/* allocate a float 3tensor with range t[nrl..nrh][ncl..nch][ndl..ndh] */
+{
+	long i,j,nrow=nrh-nrl+1,ncol=nch-ncl+1,ndep=ndh-ndl+1;
+	float ***t;
+
+	/* allocate pointers to pointers to rows */
+	t=(float ***) malloc((size_t)((nrow+NR_END)*sizeof(float**)));
+	if (!t) nrerror("allocation failure 1 in f3tensor()");
+	t += NR_END;
+	t -= nrl;
+
+	/* allocate pointers to rows and set pointers to them */
+	t[nrl]=(float **) malloc((size_t)((nrow*ncol+NR_END)*sizeof(float*)));
+	if (!t[nrl]) nrerror("allocation failure 2 in f3tensor()");
+	t[nrl] += NR_END;
+	t[nrl] -= ncl;
+
+	/* allocate rows and set pointers to them */
+	t[nrl][ncl]=(float *) malloc((size_t)((nrow*ncol*ndep+NR_END)*sizeof(float)));
+	if (!t[nrl][ncl]) nrerror("allocation failure 3 in f3tensor()");
+	t[nrl][ncl] += NR_END;
+	t[nrl][ncl] -= ndl;
+
+	for(j=ncl+1;j<=nch;j++) t[nrl][j]=t[nrl][j-1]+ndep;
+	for(i=nrl+1;i<=nrh;i++) {
+		t[i]=t[i-1]+ncol;
+		t[i][ncl]=t[i-1][ncl]+ncol*ndep;
+		for(j=ncl+1;j<=nch;j++) t[i][j]=t[i][j-1]+ndep;
+	}
+
+	/* return pointer to array of pointers to rows */
+	return t;
+}
+
+void free_vector(float *v, long nl, long nh)
+/* free a float vector allocated with vector() */
+{
+	free((FREE_ARG) (v+nl-NR_END));
+}
+
+void free_ivector(int *v, long nl, long nh)
+/* free an int vector allocated with ivector() */
+{
+	free((FREE_ARG) (v+nl-NR_END));
+}
+
+void free_cvector(unsigned char *v, long nl, long nh)
+/* free an unsigned char vector allocated with cvector() */
+{
+	free((FREE_ARG) (v+nl-NR_END));
+}
+
+void free_lvector(unsigned long *v, long nl, long nh)
+/* free an unsigned long vector allocated with lvector() */
+{
+	free((FREE_ARG) (v+nl-NR_END));
+}
+
+void free_dvector(double *v, long nl, long nh)
+/* free a double vector allocated with dvector() */
+{
+	free((FREE_ARG) (v+nl-NR_END));
+}
+
+void free_matrix(float **m, long nrl, long nrh, long ncl, long nch)
+/* free a float matrix allocated by matrix() */
+{
+	free((FREE_ARG) (m[nrl]+ncl-NR_END));
+	free((FREE_ARG) (m+nrl-NR_END));
+}
+
+void free_dmatrix(double **m, long nrl, long nrh, long ncl, long nch)
+/* free a double matrix allocated by dmatrix() */
+{
+	free((FREE_ARG) (m[nrl]+ncl-NR_END));
+	free((FREE_ARG) (m+nrl-NR_END));
+}
+
+void free_imatrix(int **m, long nrl, long nrh, long ncl, long nch)
+/* free an int matrix allocated by imatrix() */
+{
+	free((FREE_ARG) (m[nrl]+ncl-NR_END));
+	free((FREE_ARG) (m+nrl-NR_END));
+}
+
+void free_submatrix(float **b, long nrl, long nrh, long ncl, long nch)
+/* free a submatrix allocated by submatrix() */
+{
+	free((FREE_ARG) (b+nrl-NR_END));
+}
+
+void free_convert_matrix(float **b, long nrl, long nrh, long ncl, long nch)
+/* free a matrix allocated by convert_matrix() */
+{
+	free((FREE_ARG) (b+nrl-NR_END));
+}
+
+void free_f3tensor(float ***t, long nrl, long nrh, long ncl, long nch,
+	long ndl, long ndh)
+/* free a float f3tensor allocated by f3tensor() */
+{
+	free((FREE_ARG) (t[nrl][ncl]+ndl-NR_END));
+	free((FREE_ARG) (t[nrl]+ncl-NR_END));
+	free((FREE_ARG) (t+nrl-NR_END));
+}
+
+
+
+
+/*
+ * ReadFormat1: 
+ *              [rows][columns] files 
+ */
+
+void read_double_matrix_from_file(FILE *fp,
+                                  double **matrix, int rows, int columns){
+  
+  int i,j;
+  
+  for(i = 0; i < rows; i++)
+    for(j = 0; j < columns; j++)
+      if(fscanf(fp, "%lf ", &matrix[i][j]) != 1){
+	fprintf(stderr, "Error reading matrix from a file \n");
+	exit(1);
+      }  
+}

--- a/quake/forward_gpu/nrutila.h
+++ b/quake/forward_gpu/nrutila.h
@@ -1,0 +1,61 @@
+/* -*- C -*- */
+
+/*
+ * CAUTION: This is the ANSI C (only) version of the Numerical Recipes
+ * utility file nrutil.c.  Do not confuse this file with the same-named
+ * file nrutil.c that is supplied in the same subdirectory or archive as
+ * the header file nrutil.h.  *That* file contains both ANSI and
+ * traditional K&R versions, along with #ifdef macros to select the
+ * correct version.  *This* file contains only ANSI C.
+ */
+
+void nrerror(char error_text[]);
+
+float *vector(long nl, long nh);
+
+int *ivector(long nl, long nh);
+
+unsigned char *cvector(long nl, long nh);
+
+unsigned long *lvector(long nl, long nh);
+
+double *dvector(long nl, long nh);
+
+float **matrix(long nrl, long nrh, long ncl, long nch);
+
+double **dmatrix(long nrl, long nrh, long ncl, long nch);
+
+int **imatrix(long nrl, long nrh, long ncl, long nch);
+
+float **submatrix(float **a, long oldrl, long oldrh, long oldcl, long oldch,
+		  long newrl, long newcl);
+
+float **convert_matrix(float *a, long nrl, long nrh, long ncl, long nch);
+
+float ***f3tensor(long nrl, long nrh, long ncl, long nch, long ndl, long ndh);
+
+void free_vector(float *v, long nl, long nh);
+
+void free_ivector(int *v, long nl, long nh);
+
+void free_cvector(unsigned char *v, long nl, long nh);
+
+void free_lvector(unsigned long *v, long nl, long nh);
+
+void free_dvector(double *v, long nl, long nh);
+
+void free_matrix(float **m, long nrl, long nrh, long ncl, long nch);
+
+void free_dmatrix(double **m, long nrl, long nrh, long ncl, long nch);
+
+void free_imatrix(int **m, long nrl, long nrh, long ncl, long nch);
+
+void free_submatrix(float **b, long nrl, long nrh, long ncl, long nch);
+
+void free_convert_matrix(float **b, long nrl, long nrh, long ncl, long nch);
+
+void free_f3tensor(float ***t, long nrl, long nrh, long ncl, long nch,
+		   long ndl, long ndh);
+
+void read_double_matrix_from_file(FILE *fp,
+                                  double **matrix, int rows, int columns);

--- a/quake/forward_gpu/output.cu
+++ b/quake/forward_gpu/output.cu
@@ -1,0 +1,1719 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ * Description: 4D parallel output routines.
+ */
+
+/**
+ * \file
+ *
+ * Assumptions:
+ * - Three components of the desired property are saved, i.e., x,y,z.
+ * - Each output file has an output header: \see out_header_t.
+ * - Output is a double float per component.
+ *
+ * \todo Save job/run metadata as a text file.
+ * \todo Add the following field to the output metadata:
+ *       simulation code version.
+ * \todo Add print out function for (output) metadata header.
+ *
+ * \section perf-stats Performance stats
+ * Notes on overall performance stats for the parallel output code.
+ *
+ * - Avg throughput per PE serves as a rough estimate of the overall
+ *   throughput (avg_local_throughput * #PEs) as well as the realized
+ *   throughput per PE.
+ *
+ * - Min and Max throughput are the peak high and low throughput values
+ *   observed during an execution.  This provides a high-level idea of the
+ *   throughput variation among PEs and output time steps throught the
+ *   execution.
+ *
+ * - Min avg, max avg, var(avg) throughtput characterize how the throughput
+ *   varies across PEs, if the [min-max] range is close and var is low, this
+ *   indicates that PEs realize about the same local throughput throuout the
+ *   execution.
+ *
+ * - Min var, max var, avg (var) throughput shows what the PE local
+ * throughput variance is accross PEs.  A PE's variance of the local
+ * throughput shows how much the observed throughput varies for a PE
+ * during the execution.  Min (var), Avg (var), Max (var) shows how the
+ * variance behaves across PEs.  Do some PEs observe lower variance than others?
+ *
+ * Create an output stats file with the following contents:
+ *
+ * - Number of PEs.
+ * - Number of output time steps.
+ * - Expected output size.
+ * - High-level stats as described above for displacement and velocity output.
+ * - Detailed matrix with a row per PE with the following entries:
+ *   - PE id
+ *   - Number of nodes written
+ *   - Avg throughput.
+ *   - Stdev throughput.
+ *   - Min throughput.
+ *   - Max throughput.
+ *   - CV throughput.
+ *   - Avg latency.
+ *   - Stdev latency.
+ *   - CV latency.
+ *   - IOP count.
+ *   - IOPS (during actual I/O).
+ *   - IOPS (amortized, i.e., including I/O + compute + communication time).
+ * - Summary rows with min, max, median (with corresponding rank) and avg, std.
+ */
+
+#include <mpi.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <time.h>
+#include <float.h>
+#include <math.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <alloca.h>
+#include <stdarg.h>
+
+#include "output.h"
+#include "psolve.h"
+#include "util.h"
+
+
+/* ------------------------------------------------------------------------- *
+ * Macro definitions
+ * ------------------------------------------------------------------------- */
+#define HERCULES_4D_FORMAT_VERSION	0
+
+
+/* unfortunately vararg macros are not well supported by many compilers or
+ * on some platforms.
+ */
+#define DEBUG_MSG0(MSG)					\
+    do {						\
+        if (DO_DEBUG && po_debug_output_) {		\
+	   po_debug_msg(MSG);              		\
+        }				  		\
+    } while (0)
+
+
+#define DEBUG_MSG1(MSG,p1)				\
+    do {						\
+        if (DO_DEBUG && po_debug_output_) {		\
+	   po_debug_msg(MSG,p1);              		\
+        }				         	\
+    } while (0)
+
+
+#define DEBUG_MSG2(MSG,p1,p2)				\
+    do {						\
+        if (DO_DEBUG && po_debug_output_) {		\
+            po_debug_msg(MSG, p1, p2);                  \
+        }				                \
+    } while (0)
+
+#define DEBUG_MSG3(MSG,p1,p2,p3)			\
+    do {						\
+        if (DO_DEBUG && po_debug_output_) {		\
+            po_debug_msg(MSG, p1, p2, p3);              \
+        }				                \
+    } while (0)
+
+
+
+/* ------------------------------------------------------------------------- *
+ * Structure and type definitions
+ * ------------------------------------------------------------------------- */
+
+typedef int64_t global_node_id_t;
+typedef int32_t local_node_id_t;
+
+
+/**
+ * Output stat running counters.
+ */
+struct po_stat_counters_t {
+    double min;		/**< Minimum value seen so far */
+    double max;		/**< Maximum value seen so far */
+    double sum;		/**< Running sum	       */
+    double sum2;	/**< Running square sum	       */
+    double sum_inv;	/**< Sum (1/x)		       */
+    /**< Sum (1/x^2) needed to compute the variance of 1/x */
+    double sum_inv2;
+    int    count;	/**< Number of measurements    */
+    /* Number of I/O operations per time step per node */
+    unsigned int iop_per_out_step;
+};
+
+typedef struct po_stat_counters_t po_stat_counters_t;
+
+
+/**
+ * Information and parameters about the parallel output.
+ */
+struct par_output_t {
+    /** Flag indicating whether this struct has been initialized. */
+    int initialized;
+
+    /** Index of the first harbored noded that is locally owned */
+    int first_owned_idx;
+
+    int64_t local_node_count;
+    int64_t total_node_count;
+    int64_t local_base_node_id;
+
+    /** Relative offset seeked by a process (PE: processing element) */
+    off_t relative_offset;
+
+    /** Stride between timesteps, i.e., size of a given time step data */
+    off_t stride;
+
+    /** Base offset where to seek from, i.e., space for a file header */
+    off_t base_offset;
+
+    off_t local_time_step_chunk_size;
+
+    off_t expected_output_file_size;
+
+    /** File handle for the displacement output */
+    FILE* disp_fp;
+
+    /** File handle for the velocity output */
+    FILE* vel_fp;
+
+    /** Flag indicating whether or not the displacement should be saved */
+    int output_displacement;
+
+    /** Flag indicating whether or not the velocity field should be saved */
+    int output_velocity;
+
+    int output_steps;
+    int cur_output_time_step;
+
+    double delta_t;
+
+    /** Current offset */
+    off_t current_offset;
+
+    /** Pointer to the local mesh structure (in mesh.c) */
+    mesh_t* mesh;
+
+    /** Pointer to the local solver structure (in psolve.c) */
+    solver_t* solver;
+
+    /** Displacement output time stats */
+    output_stats_t disp_time;
+
+    /** Velocity output time stats */
+    output_stats_t vel_time;
+
+    int pe_id;		/**< Processing Element (PE) id / rank.	*/
+    int pe_count;	/**< Number of PEs (group size).	*/
+
+    po_stat_counters_t disp_stats;
+    po_stat_counters_t vel_stats;
+
+    off_t bytes_written;
+
+    /**
+     * Wall clock time from output open to close, it should be very close
+     * to the solver run time.  This is really an estimate, since we don't
+     * perform any synchronization to figure out the global time.
+     */
+    double output_elapsed_time;
+};
+
+typedef struct par_output_t par_output_t;
+
+
+/* ------------------------------------------------------------------------- *
+ * Global variables
+ * ------------------------------------------------------------------------- */
+
+/* These are static anyway, so only visible within this file's scope */
+
+static par_output_t po_;
+
+
+/** Flag indicating whether or not to perform parallel output */
+static int do_parallel_output_;
+
+
+/**
+ * Flag indicating whether or not to produce debug output.  This is global,
+ * so it can be easily accessed within this file/module.
+ */
+static int po_debug_output_ = 0;
+
+
+/**
+ * File handle to the debug output stream.  This is global,
+ * so it can be easily accessed within this file/module.
+ */
+static FILE* po_debug_fp_ = NULL;
+
+
+/* ------------------------------------------------------------------------- *
+ * Function definitions
+ * ------------------------------------------------------------------------- */
+
+static void
+output_stats_init (po_stat_counters_t* stats)
+{
+    assert (NULL != stats);
+
+    stats->min      = DBL_MAX;
+    stats->max      = -DBL_MAX;
+    stats->sum      = 0;
+    stats->sum2     = 0;
+    stats->sum_inv  = 0;
+    stats->sum_inv2 = 0;
+    stats->count    = 0;
+}
+
+
+/**
+ * Compute the sample variance as follows:
+ *
+ * E[x]   = avg(x)   = sum(xi)/n
+ * E[x^2] = avg(x^2) = sum(xi^2)/n
+ *
+ * Sample variance:
+ * S^2[x] = var(x)   = sum(xi^2)/(n-1) - n*(E[x]*E[x])/(n-1)
+ *
+ * \param sum	Sum of sample values.
+ * \param sum2  Sum of the square of sample values, i.e, Sum (x^2).
+ * \param n	Number of samples.
+ *
+ * \return the sample variance if n > 1, 0 otherwise.
+ */
+static double
+sample_variance (double sum, double sum2, unsigned int n)
+{
+    double var = 0;
+
+    if (n > 1) {
+	/* mean = sum / n ;
+	 * n * mean * mean == sum * sum / n 
+	 */
+
+	var = ( sum2 / (n - 1) ) - ( (sum * sum) / n / (n - 1) );
+    }
+
+    return var;
+}
+
+
+/**
+ * Compute population variance as:
+ *
+ * s^2[x] = var(x)   = sum(xi^2)/n - (sum(xi)/n)^2 = E[x^2] - E[x]^2
+ * E[x]   = avg(x)   = sum(xi)/n
+ * E[x^2] = avg(x^2) = sum(xi^2)/n
+ */
+static inline double
+population_variance (double mean, double sum2, unsigned int n)
+{
+    return (sum2 / n) - (mean * mean);
+}
+
+
+/**
+ * \return 0: on success
+ *	  -1: general error (fstat)
+ *	  -2: file is a fifo (cannot determine file size).
+ *        -3: not a regular file
+ */
+static int
+get_file_size (int fd, off_t* p_filesize)
+{
+    int ret = -1;
+    struct stat buf;
+
+    assert (fd >= 0);
+    assert (p_filesize);
+
+    ret = fstat (fd, &buf);
+
+    if (ret < 0){
+	perror ("fstat");
+	fprintf (stderr, "Error in po_get_file_size fstat (fd = %d) returned %d\n",
+		 fd, ret);
+	return -1;
+    }
+
+    if (S_ISREG (buf.st_mode)) {
+	*p_filesize = buf.st_size;
+	ret = 0;
+    }
+
+    else if (S_ISFIFO (buf.st_mode)) {
+	ret = -2;
+    }
+
+    else {
+	ret = -3;
+    }
+
+    return ret;
+}
+
+
+static void
+output_stats_update (po_stat_counters_t* stats, double val)
+{
+    double val2;
+
+    assert (NULL != stats);
+
+    if (val < stats->min) {
+	stats->min = val;
+    }
+
+    if (val > stats->max) {
+	stats->max = val;
+    }
+
+    stats->sum      += val;
+    stats->sum_inv  += 1/val;
+    val2             = val * val;
+    stats->sum2     += val2;
+    stats->sum_inv2 += 1/val2;
+    stats->count++;
+}
+
+
+static void inline
+po_debug_msg (const char* msg, ...)
+{
+    int ret;
+
+    if (po_debug_output_ && po_debug_fp_ != NULL) {
+        va_list ap;
+
+        va_start (ap, msg);
+        ret =  vfprintf (po_debug_fp_, msg, ap);
+	va_end (ap);
+    }
+
+    return;
+}
+
+
+/**
+ * Ramdomly generate a 128-bit identifier for a file.
+ *
+ * \note This function is not portable in the sense that it does not
+ *	 produce the same result in different platforms with the same seed,
+ *       but that's OK.
+ */
+static void
+generate_fileid (unsigned char ufid[16])
+{
+    static int initialized = 0;
+
+    int i;
+    int* ufid_ptr = (int*)ufid;
+
+
+    if (!initialized) {
+	time_t t;
+
+	srandom (time (&t));
+    }
+
+    for (i = 0; i < 4; i++) {
+	*ufid_ptr = random();
+	ufid_ptr++;
+    }
+}
+
+
+/**
+ * Check whether the parallel output parameters have been initialized.
+ */
+static int
+po_check_init (const par_output_t* po)
+{
+    if (NULL == po) {
+	/* programming error! */
+	solver_abort ("po_check_init()", NULL, "po is NULL\n");
+	return -1;
+    }
+
+    if (po->initialized == 0) {
+	/* programming error! */
+	solver_abort ("po_check_init()", NULL, "po has NOT been initialized\n");
+	return -1;
+    }
+
+    return 0;
+}
+
+
+static FILE*
+po_open_file (const char* filename, const char* mode)
+{
+    int ret = 0;
+
+    FILE* fhnd = fopen (filename, mode);
+
+    if (NULL == fhnd) {
+	solver_abort ("po_open_file", "fopen() failed", "filename = %s",
+		      filename);
+    }
+
+    /* fhnd must be unbuffered, otherwise we are in for big trouble, i.e.,
+     * output file corruption.  Using unbuffered output essentially converts
+     * stdio calls to wrappers around the system calls.
+     */
+    ret = setvbuf (fhnd, NULL, _IONBF, 0);
+    
+    if (0 != ret) {
+	fprintf (stderr, "\n\nWarning!: could not disable buffering on file handle (0x%p)\n", fhnd);
+	fclose (fhnd);
+	fhnd = NULL;
+    }
+
+    return fhnd;
+}
+
+
+static unsigned int
+get_output_time_step_count (int total_time_steps, int output_rate)
+{
+    return (total_time_steps - 1) / output_rate + 1;
+}
+
+
+/**
+ * Fill in metadata header.
+ *
+ * \todo Write a valid value for the following fields: endianness, platform_id.
+ * \todo Add a debug procedure to print the metadata header.
+ */
+static int
+po_init_output_header (out_hdr_t* out_hdr, const output_parameters_t* params)
+{
+    int ret;
+    time_t t;
+
+    if (NULL == out_hdr || NULL == params) {
+	/* programming error! */
+	solver_abort ("po_init_output_header()", NULL, "NULL parameter\n");
+	return -1;
+    }
+
+    memset (out_hdr, 0, sizeof (out_hdr_t));
+
+    ret = snprintf (out_hdr->file_type_str, sizeof (out_hdr->file_type_str),
+		    "Hercules 4D output v%03u", HERCULES_4D_FORMAT_VERSION);
+
+    if (ret <= 0 || ret >= sizeof (out_hdr->file_type_str)) {
+	solver_abort ("po_init_output_header()", NULL,
+		      "Could not generate 4D output header, string is too short\n");
+    }
+
+    out_hdr->format_version   = HERCULES_4D_FORMAT_VERSION;
+    out_hdr->endiannes	      = -1;
+    out_hdr->platform_id      = -1;
+    out_hdr->total_nodes      = params->total_nodes;
+    out_hdr->output_steps     = get_output_time_step_count (
+	    params->total_time_steps, params->output_rate);
+    out_hdr->scalar_count     = 3;
+    out_hdr->scalar_size      = sizeof (double);
+    out_hdr->scalar_type      = 2;	/* FLOAT64_T   */
+    out_hdr->scalar_class     = 1;	/* FLOAT_CLASS */
+    out_hdr->quantity_type    = 0;
+    out_hdr->domain_x         = params->domain_x;
+    out_hdr->domain_y         = params->domain_y;
+    out_hdr->domain_z         = params->domain_z;
+    out_hdr->mesh_ticksize    = params->mesh->ticksize;
+    out_hdr->delta_t	      = params->delta_t;
+    out_hdr->total_elements   = params->total_elements;
+    out_hdr->output_rate      = params->output_rate;
+    out_hdr->total_time_steps = params->total_time_steps;
+    out_hdr->generation_date  = time (&t);
+
+    generate_fileid (out_hdr->ufid);
+
+    return 0;
+}
+
+
+/**
+ * This function creates the 4D output file and writes the metadata header
+ * to it.
+ *
+ * \pre This function should be called only by the PE with rank 0.
+ * \pre This function reads the following global variables, thus they should
+ * be properly initialized:
+ * - myId
+ * - theDomainX
+ * - theDomainY
+ * - theDomainZ
+ * - theNTotal
+ * - theETotal
+ * - theDNTotal
+ * - myMesh->ticksize
+ * - theTotalSteps
+ *
+ * \return a FILE* handle for the newly created file.  On error the solver
+ *	execution is aborted by calling \c solver_abort().
+ */
+static FILE*
+po_create_file (const char* filename, out_hdr_t* out_hdr)
+{
+    /* Proc 0 creates the output file */
+    FILE*     fhnd;
+    int	      ret;
+    int	      my_rank;
+
+    /* this should only be executed by process 0 */
+    MPI_Comm_rank (comm_solver, &my_rank);
+    assert (my_rank == 0);
+
+    fhnd = po_open_file (filename, "w+");	/* this aborts on failure */
+
+    ret = fwrite (out_hdr, sizeof(out_hdr_t), 1, fhnd);
+
+    if (1 != ret) {
+	solver_abort ("po_create_file()", "fwrite() failed",
+		      "Failed to write 4D metadata header");
+	fclose (fhnd);  /* this won't get executed, but anyway! */
+	fhnd = NULL;
+    }
+
+    return fhnd;
+}
+
+
+static FILE*
+po_open_4d_file (const char* filename, out_hdr_t* out_hdr, int my_rank)
+{
+    char  tmp;
+    FILE* fhnd = NULL;
+
+    if (0 == my_rank) {		/* PE 0 creates the file */
+	fhnd = po_create_file (filename, out_hdr);
+    }
+
+    tmp = 'H';	/* a random value */
+
+    /* all PEs should wait for PE 0 to create the file before openning it */
+    MPI_Bcast (&tmp, 1, MPI_CHAR, 0, comm_solver);
+
+    if (my_rank != 0) {            /* all other processors open the file */
+	fhnd = po_open_file (filename, "r+");
+    }
+
+    return fhnd;
+}
+
+
+/**
+ * Find each PE's relative base offset for the output.
+ *
+ * \pre theGroupSize must be initialized.
+ * \pre theNTotal must be initialized.
+ *
+ * \todo update po structure
+ */
+static int
+po_gather_base_offset (par_output_t* po, const output_parameters_t* params)
+{
+    int32_t  procid;
+    int32_t* count_table;
+    int64_t  total_count;
+    mesh_t*  mesh;
+
+    if (NULL == po) {
+	solver_abort ("po_gather_base_offset", NULL, "po parameter is NULL");
+	return -1;
+    }
+
+    if (NULL == params) {
+	solver_abort ("po_gather_base_offset", NULL,"params parameter is NULL");
+	return -1;
+    }
+
+    mesh = params->mesh;
+
+    count_table = (int32_t*)malloc (sizeof(int32_t) * params->pe_count);
+
+    if (NULL == count_table) {		/* Out of memory */
+	solver_abort ("po_gather_base_offset", "count_table allocation",
+		      NULL);
+	return -1;
+    }
+
+    MPI_Allgather (&mesh->lnnum, 1, MPI_INT, count_table, 1, MPI_INT,
+		   comm_solver);
+
+    /* find my relative offset */
+    po->local_base_node_id = 0;
+
+    for (procid = 0; procid < params->pe_id; procid++) {
+	po->local_base_node_id += count_table[procid];
+    }
+
+    po->relative_offset = po->local_base_node_id * sizeof (fvector_t);
+    po->current_offset  = po->base_offset + po->relative_offset;
+
+    /* this is a consistency check, always enabled, done only once */
+    total_count = po->local_base_node_id;
+
+    for (; procid < params->pe_count; procid++) {
+	total_count += count_table[procid];
+    }
+
+    DEBUG_MSG2 ("po_gather_base_offset (...): rel_off=%" OFFT_FMT ", cur_off=%" OFFT_FMT,
+		po->relative_offset, po->current_offset);
+    DEBUG_MSG2 (" total_count=%" OFFT_FMT ", base_off=%" OFFT_FMT "\n",
+		total_count, po->base_offset);
+
+    po->total_node_count = total_count;
+
+    free (count_table);
+
+    if (total_count != params->total_nodes) {
+	solver_abort ("po_gather_base_offset", NULL, "count_table is corrupted"
+		      "\ntotal_count = %d, params->total_nodes = %d \n",
+		      total_count, params->total_nodes);
+	return -1;
+    }
+
+    return 0;
+}
+
+
+/**
+ * check whether the range of locally owned nodes are in a contiguous
+ * global node id range.
+ */
+static int
+po_check_local_node_id_range (
+	struct par_output_t* po,
+	const output_parameters_t* params
+	)
+{
+    global_node_id_t current_gid;
+    int i;
+    int is_contiguous = 1;
+    int own_count;
+    const mesh_t* mesh = params->mesh;
+
+    current_gid = -1;
+
+    po->first_owned_idx = -1;
+
+    /* look for the first node owned by this PE */
+    for (i = 0; i < mesh->nharbored && ! mesh->nodeTable[i].ismine; i++);
+
+    if (i < mesh->nharbored && mesh->nodeTable[i].ismine) {
+	current_gid = mesh->nodeTable[i].gnid;
+	po->first_owned_idx = i;
+    }
+
+    own_count = 0;
+
+    /* now check whether the range of owned nodes is contiguous */
+    while (i < mesh->nharbored) {
+
+	if (mesh->nodeTable[i].ismine) {
+	    if (mesh->nodeTable[i].gnid != current_gid) {
+		is_contiguous = 0;
+		/* report error */
+		fprintf (stderr, "Rank %d: Warning, uncontinuous global "
+			 "node id range\n"
+			 "expected global node id: %" INT64_FMT
+			 "actual global node id: %" INT64_FMT
+			 "node index: %d", params->pe_id, current_gid,
+			 mesh->nodeTable[i].gnid, i);
+		/* break out of loop and routine */
+		return -1;
+	    }
+
+	    current_gid++;	/* update the expected global node id */
+	    own_count++;
+	}
+
+	i++;
+    }
+
+    if (is_contiguous) {
+
+	if (own_count != mesh->lnnum) {
+	    solver_abort ("po_check_continuous_node_id_range()", NULL,
+			  "Number of local nodes does not match "
+			  "own_count = %d myMesh->lnnum = %d\n",
+			  own_count, mesh->lnnum);
+	    return -1;
+	}
+
+	if (mesh->nharbored != i) {
+	    solver_abort ("po_check_continuous_node_id_range()", NULL,
+			  "Number of harbored nodes does not match "
+			  "i = %d myMesh->nharbored = %d\n",
+			  i, mesh->nharbored);
+	    return -1;
+	}
+
+	po->local_node_count = own_count;
+    }
+
+    return (is_contiguous == 1) ? 0 : -1;
+}
+
+
+static char*
+generate_local_string (const char* tpl, int pe_id)
+{
+    static const int extra_length_default = 5;
+
+    int    digits;
+    char*  my_template;
+    char*  string;
+    int    extra_len;
+    size_t string_len;
+
+    assert (pe_id >= 0);
+
+    extra_len = extra_length_default;
+    digits    = log10 (pe_id);
+
+    /* adjust for pe_ids larger or equal to 100000 */
+    if (digits > extra_len) {
+	extra_len = digits;
+    }
+
+    /* 6 extra chars for "-%05d" + \0 if needed */
+    my_template = (char*)alloca (strlen (tpl) + 6);
+    strcpy (my_template, tpl);
+
+    /* does the template already have a "%d" */
+    if (strstr (tpl, "%d") == NULL) { /* it does not */
+	strcat (my_template, "-%05d");
+    }
+
+    string_len = strlen (my_template) - 2 + extra_len + 1;
+
+    string = (char*)malloc (string_len);
+
+    if (NULL != string) {     /* check memory allocation */
+	snprintf (string, string_len, my_template, pe_id);
+    }
+
+    return string;
+}
+
+
+static int
+po_init_debug (output_parameters_t* params)
+{
+    int ret = 0;
+    char* local_file_name;
+
+    assert (NULL != params);
+
+    po_debug_fp_     = NULL;
+    po_debug_output_ = 0;
+
+    if (params->output_debug) {
+	ret = -1;
+	/* generate per PE filenames */
+	local_file_name = generate_local_string (params->debug_filename, params->pe_id);
+
+	if (local_file_name != NULL) {
+	   po_debug_fp_ = po_open_file (local_file_name, "w");
+	   xfree_char( &local_file_name );
+
+	   if (NULL != po_debug_fp_) {
+	       ret = 0;
+	       po_debug_output_ = 1;
+	   }
+	}
+    }
+
+    return ret;
+}
+
+
+static int
+po_print (par_output_t* po, FILE* f)
+{
+    assert (NULL != po);
+    assert (NULL != f);
+
+    fputs ("\n------------------------------\n", f);
+    fprintf (f, "par_output_t p=%p\n", po);
+    fprintf (f, "  pe_id = %d, pe_count = %d\n", po->pe_id, po->pe_count);
+    fprintf (f, "  initialized=%d\n", po->initialized);
+    fprintf (f, "  first_owned_idx=%d\n", po->first_owned_idx);
+    fprintf (f, "  local_node_count=%" INT64_FMT "\n", po->local_node_count);
+    fprintf (f, "  total_node_count=%" INT64_FMT "\n", po->total_node_count);
+    fprintf (f, "  local_base_node_id=%" INT64_FMT "\n", po->total_node_count);
+    fprintf (f, "  relative_offset=%" OFFT_FMT "\n", po->relative_offset);
+    fprintf (f, "  stride=%" OFFT_FMT "\n", po->stride);
+    fprintf (f, "  base_offset=%" OFFT_FMT "\n", po->base_offset);
+    fprintf (f, "  local_time_step_chunk_size=%" OFFT_FMT "\n",
+	     po->local_time_step_chunk_size);
+    fprintf (f, "  expected_output_file_size=%" OFFT_FMT "\n",
+	     po->expected_output_file_size);
+    fprintf (f, "  output_displacement=%d\n", po->output_displacement);
+    fprintf (f, "  output_velocity=%d\n", po->output_velocity);
+    fprintf (f, "  output_steps=%d\n", po->output_steps);
+    fprintf (f, "  cur_output_time_step=%d\n", po->cur_output_time_step);
+    fprintf (f, "  current_offset=%" OFFT_FMT "\n", po->current_offset);
+    fprintf (f, "  bytes_written=%" OFFT_FMT "\n", po->bytes_written);
+    fprintf (f, "  delta_t=%f\n", po->delta_t);
+    fprintf (f, "  disp_fp=%p\n", po->disp_fp);
+    fprintf (f, "  vel_fp=%p\n", po->vel_fp);
+    fprintf (f, "  mesh=%p\n", po->mesh);
+    fprintf (f, "  solver=%p\n", po->solver);
+    fprintf (f, "  output_elapsed_time=%f\n", po->output_elapsed_time);
+    fputs ("------------------------------\n", f);
+
+    return 0;
+}
+
+
+static int inline
+po_print_debug (par_output_t* po)
+{
+    if (DO_DEBUG && po_debug_output_) {
+	return po_print (po, po_debug_fp_);
+    }
+
+    return 0;
+}
+
+
+/**
+ * Initialize a parallel output structure.
+ *
+ * High-level initialization steps:
+ * - gather i/o parameters
+ * - check whether we are actually performing I/O.
+ *   - what properties are to be saved.
+ *   - get output file names.
+ * - check range continuity.
+ * - obtain offsets.
+ *
+ */
+static int
+po_init (par_output_t* po, output_parameters_t* params)
+{
+    if (NULL == po) {
+	/* programming error! */
+	solver_abort ("po_init()", NULL, "po is NULL\n");
+	return -1;
+    }
+
+    if (po->initialized != 0) {
+	/* programming error! */
+	solver_abort ("po_init()", NULL, "po has already been initialized\n");
+	return -1;
+    }
+
+    if (NULL == params) {
+	solver_abort ("po_init()", NULL, "params is NULL\n");
+	return -1;
+    }
+
+    memset (po, 0, sizeof(*po));
+
+    DEBUG_MSG1 ("params->total_nodes=%d\n", params->total_nodes);
+
+    po->output_elapsed_time  = -MPI_Wtime();
+    po->pe_id                = params->pe_id;
+    po->pe_count	     = params->pe_count;
+    po->relative_offset      = 0;
+    po->base_offset          = sizeof (out_hdr_t);
+    po->disp_fp		     = NULL;
+    po->vel_fp		     = NULL;
+    po->output_velocity      = 0;
+    po->output_displacement  = 0;
+    po->first_owned_idx      = -1;
+    po->cur_output_time_step = -1;
+    po->stride		     = sizeof (fvector_t) * params->total_nodes;
+    po->mesh		     = params->mesh;
+    po->solver		     = params->solver;
+    po->delta_t		     = params->delta_t;
+    po->bytes_written	     = 0;
+
+
+    output_stats_init (&po->disp_stats);
+    output_stats_init (&po->vel_stats);
+
+    if (po_check_local_node_id_range (po, params) != 0) {
+	solver_abort ("po_init()", NULL, "global id range for locally owned "
+		      "nodes is not contiguous");
+	return -1;
+    }
+
+    /* gather i/o parameters */
+    if (po_gather_base_offset (po, params) != 0) {
+	return -1;
+    }
+
+    po->output_steps = get_output_time_step_count (params->total_time_steps,
+						   params->output_rate);
+
+    DEBUG_MSG2 ("po->output_steps=%d\nparams->total_time_steps=%d\n",
+		po->output_steps, params->total_time_steps);
+    DEBUG_MSG1 ("params->output_size=%" OFFT_FMT "\n", params->output_size);
+
+
+    po->expected_output_file_size  = params->output_size;
+    po->local_time_step_chunk_size = po->local_node_count * sizeof (fvector_t);
+
+    po->disp_stats.iop_per_out_step = 1;
+    po->vel_stats.iop_per_out_step = po->local_node_count;
+    po->total_node_count = params->total_nodes;
+
+    /* open files depending on whether we are saving displacement and/or
+     * velocity data
+     */
+    if (0 != params->output_displacement
+	&& NULL != params->displacement_filename)
+    {
+	out_hdr_t disp_hdr;
+
+	po_init_output_header (&disp_hdr, params);
+	disp_hdr.quantity_type = 1;
+	po->disp_fp = po_open_4d_file (params->displacement_filename,
+				       &disp_hdr, params->pe_id);
+
+	if (NULL == po->disp_fp) {
+	    return -1;
+	}
+
+	po->output_displacement = 1;
+    }
+
+    if (0 != params->output_velocity
+	&& NULL != params->velocity_filename)
+    {
+	out_hdr_t vel_hdr;
+
+	po_init_output_header (&vel_hdr, params);
+	vel_hdr.quantity_type = 2;
+	po->vel_fp = po_open_4d_file (params->velocity_filename,
+				      &vel_hdr, params->pe_id);
+
+	if (NULL == po->vel_fp) {
+	    return -1;
+	}
+
+	po->output_velocity = 1;
+    }
+
+    po->initialized = 1;
+
+    po_print_debug (po);
+
+    return 0;
+}
+
+
+static int
+po_check_file_size (FILE* file, off_t expected_size)
+{
+    int ret = -1;
+    int fd;
+    off_t actual_size;
+
+    assert (NULL != file);
+
+    fd = fileno (file);
+
+    if (-1 == fd) {
+	perror ("po_check_file_size: fileno(file)");
+	return -1;
+    }
+
+    ret = get_file_size (fd, &actual_size);
+
+    if (0 != ret) {
+	fprintf (stderr, "Could not get file size for file (d): FILE* (fd):"
+		 "0x%p (%d)\n",	file, fd);
+
+	return -3;
+    }
+
+    if (actual_size != expected_size) {
+	fprintf (stderr, "\n\nWarning!: File does not have expected size\n"
+		 "  FILE* (fd): 0x%p (%d)\n"
+		 "  Expected size: %" OFFT_FMT "\n"
+		 "  Actual size: %" OFFT_FMT "\n"
+		 "  Difference: %" OFFT_FMT "\n\n",
+		 file, fd, expected_size, actual_size,
+		 (expected_size - actual_size));
+	return -2;
+    }
+
+    return 0;
+}
+
+
+static int
+po_check_file_sizes (par_output_t* po)
+{
+    int ret = 0;
+    int ret2;
+
+    assert (NULL != po);
+
+    if (po->output_displacement && NULL != po->disp_fp) {
+	ret2 = po_check_file_size (po->disp_fp, po->expected_output_file_size);
+	if (ret2 != 0) {
+	    fprintf (stderr, "Displacement file size check failed!\n");
+	    ret = -1;
+	}
+    }
+
+    if (po->output_velocity && NULL != po->vel_fp) {
+	ret2 = po_check_file_size (po->vel_fp, po->expected_output_file_size);
+	if (ret2 != 0) {
+	    fprintf (stderr, "Velocity file size check failed!\n");
+	    ret += -2;
+	}
+    }
+
+    return ret;
+}
+
+
+static int
+po_fini (par_output_t* po)
+{
+    int ret = 0;
+    int recvval, sendval = 1;
+    assert (NULL != po);
+
+    if (!po->initialized) {
+	return -1;
+    }
+
+    if (0 != po->pe_id) {
+	/* delay closing files on PE 0 so we can check their file size */
+
+        if (NULL != po->disp_fp) {
+	   fflush (po->disp_fp);
+	   fclose (po->disp_fp);
+	   po->disp_fp = NULL;
+        }
+
+        if (NULL != po->vel_fp) {
+	   fflush (po->vel_fp);
+	   fclose (po->vel_fp);
+	   po->vel_fp = NULL;
+        }
+    }
+
+    /* PE0: wait until all processes have closed the files and then
+     * check the file size.
+     */
+    MPI_Reduce (&sendval, &recvval, 1, MPI_INT, MPI_SUM, 0, comm_solver);
+
+    po->output_elapsed_time  += MPI_Wtime();
+
+    if (0 == po->pe_id) {
+
+	if (NULL != po->disp_fp) {
+	   fflush (po->disp_fp);
+	}
+
+	if (NULL != po->vel_fp) {
+	    fflush (po->vel_fp);
+	}
+
+	ret = po_check_file_sizes (po);
+
+	/* close files on PE 0 now */
+	if (NULL != po->disp_fp) {
+	    fclose (po->disp_fp);
+	    po->disp_fp = NULL;
+	}
+
+	if (NULL != po->vel_fp) {
+	    fclose (po->vel_fp);
+	    po->vel_fp = NULL;
+	}
+    }
+
+    po->initialized = 0;
+
+    return ret;
+}
+
+
+/**
+ * Output initialization (Entry point function).
+ *
+ * \post Global variable do_parallel_output_c is initialized.
+ */
+int
+output_init_state (output_parameters_t* params)
+{
+    assert (NULL != params);
+
+    do_parallel_output_ = params->parallel_output;
+
+    po_init_debug (params);
+
+    if (0 != params->parallel_output) {
+	return po_init (&po_, params);
+    }
+
+    return 0;
+}
+
+
+static int
+po_fini_debug()
+{
+    int ret = 0;
+
+    /* close all local debug files */
+    if (NULL != po_debug_fp_) {
+	fflush (po_debug_fp_);
+	ret = fclose (po_debug_fp_);
+	po_debug_fp_ = NULL;
+    }
+
+    return ret;
+}
+
+
+/**
+ * Output finalization and cleanup (Entry point function).
+ */
+int
+output_fini()
+{
+    if (do_parallel_output_) {
+	return po_fini (&po_);
+    }
+
+    po_fini_debug();
+
+    return 0;
+}
+
+
+static off_t inline
+compute_current_offset (par_output_t* po)
+{
+    return po->base_offset + po->stride * po->cur_output_time_step
+	    + po->relative_offset;
+}
+
+
+static int
+write_displacement (par_output_t* po)
+{
+    size_t     ret;
+    off_t      offset;
+    fvector_t* disp_ptr;
+    double     disp_out_time;
+
+    /* Position for my output for the current outputstep */
+    offset = compute_current_offset (po);
+
+
+    DEBUG_MSG1 ("write_displacement(): ts=%d", po->cur_output_time_step + 1);
+    DEBUG_MSG3 (" range=%" OFFT_FMT ", +%" OFFT_FMT ", %" OFFT_FMT,
+		offset, po->local_time_step_chunk_size,
+		offset + po->local_time_step_chunk_size);
+
+    DEBUG_MSG2 (" stride=%" OFFT_FMT " relative_offset=%" OFFT_FMT,
+	        po->stride, po->relative_offset);
+
+    DEBUG_MSG2 (" base_offset=%" OFFT_FMT " l_base_nid=%d",
+		po->base_offset, po->local_base_node_id);
+    DEBUG_MSG1 (" wrsz=%zu", sizeof(fvector_t) * po->local_node_count);
+
+    disp_out_time = - MPI_Wtime();	    /* for timing */
+    if (fseeko (po->disp_fp, offset, SEEK_SET) != 0) {
+	solver_abort ("write_displacement", "fseeko failed",
+		      "offset=%" OFFT_FMT ", file handle = 0x%p", offset,
+		      po->disp_fp);
+	return -1;
+    }
+
+    /* address of first owned node data */
+    disp_ptr = po->solver->tm1 + po->first_owned_idx;
+
+    ret	= fwrite (disp_ptr, sizeof(fvector_t), po->local_node_count,
+		  po->disp_fp);
+
+    if (ret != po->local_node_count) {
+	solver_abort ("write_displacement", "fwrite failed",
+		      "disp_fp=0x%p, po=0x%p, offset=%" OFFT_FMT ", ret=%ld",
+		      po->disp_fp, po, offset, ret);
+	return -1;
+    }
+
+    /* There are cases where we really want to flush everything before the
+     * next step. e.g., a parallel machine where there is no client-side
+     * write-back cache.  However, in cases where the system does provide a
+     * a cache and memory is not a limiting resource it's probably OK to
+     * let the system complete the I/O in the background.
+     */
+    fflush (po->disp_fp);
+
+    if (fdatasync (fileno (po->disp_fp)) != 0) {
+	solver_abort ("write_displacement", "fdatasync failed", "ret=%ld",ret);
+    }
+
+    disp_out_time += MPI_Wtime();
+
+    DEBUG_MSG2 (" l_node_count=%d time=%f\n",
+		po->local_node_count, disp_out_time);
+    /* update timing statistics */
+    output_stats_update (&po->disp_stats, disp_out_time);
+
+    return 0;
+}
+
+
+/**
+ * Write out this PE's node velocities
+ */
+static int
+write_velocity (par_output_t* po)
+{
+    int count;
+    fvector_t vel;
+    off_t     offset;
+    double    vel_out_time = - MPI_Wtime();	    /* Timing */
+
+    const fvector_t* tm1;
+    const fvector_t* tm2;
+
+    assert (NULL != po);
+
+    offset = compute_current_offset (po);
+
+    if (fseeko (po->vel_fp, offset, SEEK_SET) != 0) {
+	solver_abort ("write_velocity", "fseeko failed",
+		      "offset=%" OFFT_FMT ", file handle = 0x%p", offset,
+		      po->vel_fp);
+	return -1;
+    }
+
+    tm1 = po->solver->tm1 + po->first_owned_idx;
+    tm2 = po->solver->tm2 + po->first_owned_idx;
+
+    for (count=0; count < po->local_node_count; count++) {
+	vel.f[0] = (tm1->f[0] - tm2->f[0]) / po->delta_t;
+	vel.f[1] = (tm1->f[1] - tm2->f[1]) / po->delta_t;
+	vel.f[2] = (tm1->f[2] - tm2->f[2]) / po->delta_t;
+
+	if (fwrite (&vel, sizeof(fvector_t), 1, po->vel_fp) != 1) {
+	    solver_abort ("write_velocity()", "fwrite failed", NULL);
+	    return -1;
+	}
+
+	tm1++;
+	tm2++;
+    }
+
+    fflush (po->vel_fp);
+
+    if (fdatasync (fileno (po->vel_fp)) != 0) {
+	solver_abort ("write_velocity", "fdatasync failed", NULL);
+    }
+
+
+    vel_out_time += MPI_Wtime();
+    output_stats_update (&po->vel_stats, vel_out_time);
+
+    return 0;
+}
+
+
+/**
+ * Output the velocity of the mesh nodes in parallel.
+ */
+static int
+po_do_output (par_output_t* po)
+{
+    int ret_d = 0, ret_v = 0;
+    off_t offset;
+
+    po_check_init (po);
+
+    if (! po->output_displacement && ! po->output_velocity) {
+	return 0;	/* nothing to do */
+    }
+
+    po->cur_output_time_step++;
+
+    offset = compute_current_offset (po);
+
+    /* is the current offset up to date? */
+    if (offset != po->current_offset) {
+        fprintf (stderr, "\nWarning!: PE %d, unexpected offset %"OFFT_FMT
+		 " != %"OFFT_FMT"\n", po->pe_id, po->current_offset, offset);
+        DEBUG_MSG2 ("Unexpected offset=%"OFFT_FMT", po->current_offset=%"OFFT_FMT"\n",
+		    offset, po->current_offset);
+
+	po->current_offset = offset;
+    }
+
+    DEBUG_MSG1("po_do_output(): offset=%"OFFT_FMT"\n", offset);
+
+    if (po->output_displacement) {
+	ret_d = write_displacement (po);
+    }
+
+    if (po->output_velocity) {
+	ret_v = write_velocity (po);
+    }
+
+
+    po->current_offset += po->stride;
+
+    return ret_v + ret_d;
+}
+
+
+/**
+ * Perform solver's output (Entry point function).
+ */
+int
+do_solver_output( void )
+{
+    if (do_parallel_output_) {
+	return po_do_output (&po_);
+    }
+
+    else {
+	solver_output_seq();
+    }
+
+    return 0;
+}
+
+
+/**
+ * Compute stats in the counters structure and set the appropriate values
+ * for the throughput (stats structure).
+ *
+ * \param[out]    stats Computed stats for latency and throughput.
+ * \param[in,out] counters Collected running counters, the collected variable
+ *	(X) is elapsed time for each output step (i.e., latency).
+ */
+static void
+po_compute_stats (
+	output_stats_t*     stats,
+	po_stat_counters_t* counters,
+	off_t		    chunk_size
+	)
+{
+    unsigned int n;
+
+    assert (NULL != stats);
+    assert (NULL != counters);
+    assert (0 < chunk_size);
+
+    /* minimum throughtput (what took the longest time) */
+    stats->tput_min = chunk_size / counters->max;
+
+    /* maximum throughtput (what took the shortest time) */
+    stats->tput_max = chunk_size / counters->min;
+
+    n		    = counters->count;
+    stats->count    = n;
+    stats->lat_avg  = counters->sum / n;
+    stats->lat_var  = sample_variance (counters->sum, counters->sum2, n);
+    stats->tput_avg = counters->sum_inv * chunk_size / n;
+    stats->tput_var = sample_variance (counters->sum_inv,counters->sum_inv2,n)
+	* chunk_size * chunk_size;
+    stats->iops     = counters->sum_inv * counters->iop_per_out_step / n;
+    stats->iop_count = counters->iop_per_out_step * counters->count;
+}
+
+
+#define STAT_DATA_LEN	9
+static int
+po_print_detailed_stats (
+	unsigned int    pe_count,
+	const int32_t*  count_table,
+	const float*	data_table,
+	FILE*	        fp
+	)
+{
+    int pid;	/* PE id */
+    int fid;	/* field id */
+
+    if (NULL == fp) { /* we can't do anything */
+	return 0;
+    }
+
+    fputs ("#\n# peid ncount avg(lat) std(lat) avg(tput) std(tput) "
+	   "min(tput) max(tput) iops iop_count wtime am_iops cv(tput)\n\n", fp);
+
+    for (pid = 0; pid < pe_count; pid++) {
+	fprintf (fp, "%d %d", pid, count_table[pid]);
+
+	for (fid = 0; fid < STAT_DATA_LEN; fid++) {
+	    fprintf (fp, " %f", data_table [pid*STAT_DATA_LEN + fid]);
+	}
+
+	/* field 7: iop_count, field 8: elapsed wall time */
+	fprintf (fp, " %f", data_table [pid*STAT_DATA_LEN + 7]
+		 / data_table [pid*STAT_DATA_LEN + 8]);
+
+	/* print coefficient of variation: stdev / avg. */
+	fprintf (fp, " %f", data_table[pid * STAT_DATA_LEN + 3]
+		 / data_table[pid * STAT_DATA_LEN + 2]);
+
+	fputc ('\n', fp);
+    }
+
+    fputs ("\n\n", fp);
+
+    return 0;
+}
+
+
+static int
+po_collect_detailed_stats (
+	par_output_t*	      po,
+	const output_stats_t* stats,
+	FILE*		      fp,
+	double		      e2e_elapsed_time
+	)
+{
+    int32_t* count_table = NULL;
+    float*   data_table  = NULL;
+    int32_t  count;
+    float    data[STAT_DATA_LEN];
+
+    assert (NULL != po);
+    assert (NULL != stats);
+
+    if (0 == po->pe_id) {
+	count_table = (int32_t*)malloc (sizeof(int32_t) * po->pe_count);
+	data_table = (float*)malloc (sizeof(float)*po->pe_count*STAT_DATA_LEN);
+	assert (NULL != count_table);
+	assert (NULL != data_table);
+    }
+
+    count = po->local_node_count;
+    MPI_Gather (&count, 1, MPI_INT, count_table, 1, MPI_INT, 0, comm_solver);
+
+    data[0] = stats->lat_avg;
+    data[1] = sqrt (stats->lat_var);
+    data[2] = stats->tput_avg;
+    data[3] = sqrt (stats->tput_var);
+    data[4] = stats->tput_min;
+    data[5] = stats->tput_max;
+    data[6] = stats->iops;
+    data[7] = stats->iop_count;
+    data[8] = MPI_Wtime() + e2e_elapsed_time; /* local elapsed time */
+
+    MPI_Gather (data, STAT_DATA_LEN, MPI_FLOAT, data_table, STAT_DATA_LEN,
+		MPI_FLOAT, 0, comm_solver);
+
+    if (0 == po->pe_id) {
+	if (NULL != fp) {
+	    po_print_detailed_stats (po->pe_count, count_table, data_table, fp);
+	}
+
+	free (count_table);
+	free (data_table);
+    }
+
+    return 0;
+}
+#undef STAT_DATA_LEN
+
+
+static int
+po_collect_stats (
+	par_output_t*	    po,
+	po_stat_counters_t* counters,
+	output_stats_t*     st,
+	FILE*		    fp,
+	const char*	    out_type,
+	double	            e2e_elapsed_time
+	)
+{
+    float min, max, sum, osum2, sum2, mina, maxa, avgv, minv, maxv, avg_iops;
+    /* mina: minimum average
+     * maxa: maximum average
+     * vara: average's variance
+     * avgv: variance's average
+     * minv: minimum variance
+     * maxv: maximum variance
+     */
+
+    assert (NULL != st);
+
+    po_compute_stats (st, counters, po->local_time_step_chunk_size);
+
+    /* reduce min, max, avg tput, stdev (avg tput) */
+    osum2 = st->tput_avg * st->tput_avg;
+
+    MPI_Reduce (&st->tput_min, &min,  1, MPI_FLOAT, MPI_MIN, 0, comm_solver);
+    MPI_Reduce (&st->tput_max, &max,  1, MPI_FLOAT, MPI_MAX, 0, comm_solver);
+    MPI_Reduce (&st->tput_avg, &mina, 1, MPI_FLOAT, MPI_MIN, 0, comm_solver);
+    MPI_Reduce (&st->tput_avg, &maxa, 1, MPI_FLOAT, MPI_MAX, 0, comm_solver);
+    MPI_Reduce (&st->tput_avg, &sum,  1, MPI_FLOAT, MPI_SUM, 0, comm_solver);
+    MPI_Reduce (&osum2,	       &sum2, 1, MPI_FLOAT, MPI_SUM, 0, comm_solver);
+    MPI_Reduce (&st->tput_var, &minv, 1, MPI_FLOAT, MPI_MIN, 0, comm_solver);
+    MPI_Reduce (&st->tput_var, &maxv, 1, MPI_FLOAT, MPI_MAX, 0, comm_solver);
+    MPI_Reduce (&st->tput_var, &avgv, 1, MPI_FLOAT, MPI_SUM, 0, comm_solver);
+    MPI_Reduce (&st->iops, &avg_iops, 1, MPI_FLOAT, MPI_SUM, 0, comm_solver);
+
+    avgv     /= po->pe_count;
+    avg_iops /= po->pe_count;
+
+
+    if (0 == po->pe_id && NULL != fp) {
+	float avg = sum / po->pe_count;
+	uint64_t iop_count;
+
+	/* hack: deduce the iop_count from counters->iop_per_out_step as
+	 * follows:
+	 * when dealing with displacement output iop_per_out_step is 1,
+	 * when dealing with velocity output iop_per_out_step is the
+	 * local node count.
+	 */
+	if (1 == counters->iop_per_out_step) { /* displacement output */
+	    iop_count = po->output_steps * po->pe_count;
+	} else { /* velocity output */
+	    iop_count = po->output_steps * po->total_node_count;
+	}
+
+	fputs ("# Output type: ", fp);
+	fputs (out_type, fp);
+
+	fprintf (fp, "\n#\n# Global iop count: %"UINT64_FMT"\n", iop_count);
+	fprintf (fp, "# Global avg (iops) amortized: %.2f\n",
+		 iop_count / po->output_elapsed_time);
+
+	fputs ("#\n# Average stats, i.e., per PE:\n#\n", fp);
+	fprintf (fp, "# min throughput: %.2f\n", min);
+	fprintf (fp, "# max throughput: %.2f\n", max);
+	fprintf (fp, "# avg (avg throughput): %.2f\n", avg);
+	fprintf (fp, "# std (avg throughput): %.2f\n",
+		 sqrt (population_variance (avg, sum2, po->pe_count)));
+	fprintf (fp, "# min (avg throughput): %.2f\n", mina);
+	fprintf (fp, "# max (avg throughput): %.2f\n#\n", maxa);
+	fprintf (fp, "# avg (std throughput): %.2f\n", sqrt (avgv));
+	fprintf (fp, "# min (std throughput): %.2f\n", sqrt (minv));
+	fprintf (fp, "# max (std throughput): %.2f\n", sqrt (maxv));
+	fprintf (fp, "#\n# avg (iops) during I/O: %.2f\n", avg_iops);
+	fprintf (fp, "# avg (iops) amortized: %.2f\n",
+		 ((float)iop_count) / (po->output_elapsed_time * po->pe_count));
+    }
+
+    /* gather details */
+    po_collect_detailed_stats (po, st, fp, e2e_elapsed_time);
+
+    return 0;
+}
+
+
+static int
+po_collect_io_stats (
+	par_output_t*   po,
+	const char*     filename,
+	output_stats_t* disp_stats,
+	output_stats_t* vel_stats,
+	double	        e2e_elapsed_time
+	)
+{
+    int   ret = 0;
+    FILE* fp  = NULL;	/* safeguard */
+
+    if (do_parallel_output_) {
+
+	if (0 == po->pe_id && NULL != filename) {
+	    fp = po_open_file (filename, "w");
+
+	    if (NULL != fp) {
+		fputs ("# Output summary stats\n#\n", fp);
+		fprintf (fp, "# Number of PEs: %d\n", po->pe_count);
+		fprintf (fp, "# Number of output time steps: %d\n",
+			 po->output_steps);
+		fprintf (fp, "# TS Stride: %"INT64_FMT"\n", po->stride);
+		fprintf (fp, "# Expected output file size: %" INT64_FMT "\n",
+			 po->expected_output_file_size);
+		fprintf (fp, "# Elapsed 4D ouput time: %.2f\n#\n#\n",
+			 po->output_elapsed_time);
+	    }
+	}
+
+	if (po_.output_displacement) {
+		ret = po_collect_stats (po, &po->disp_stats, disp_stats, fp,
+					"displacement", e2e_elapsed_time);
+	}
+
+	if (po_.output_velocity) {
+	    ret = po_collect_stats (po, &po->vel_stats, vel_stats, fp,
+				    "velocity", e2e_elapsed_time);
+	}
+
+	if (0 == po->pe_id && NULL != fp) {
+	    int flag = 0, wtime_is_global = 0, ret;
+
+	    e2e_elapsed_time += MPI_Wtime();
+	    ret = MPI_Attr_get (comm_solver, MPI_WTIME_IS_GLOBAL,
+				&wtime_is_global, &flag);
+
+	    if (!flag) {
+		wtime_is_global = 0;
+	    }
+	    fprintf (fp, "\n#\n# Approximate end-to-end time : %.2f seconds\n"
+		     "# MPI_WTIME_IS_GLOBAL: 0x%x\n#\n", e2e_elapsed_time,
+		     wtime_is_global);
+	    fprintf (fp, "# flag: %d, ret = %d\n", flag, ret);
+	    fclose (fp);
+	}
+    }
+
+    return ret;
+}
+
+
+int
+output_collect_io_stats (
+	const char*     filename,
+	output_stats_t* disp_stats,
+	output_stats_t* vel_stats,
+	double	        e2e_elapsed_time
+	)
+{
+    /* compute local throughput stats and then send them to PE0 */
+    if (do_parallel_output_) {
+	po_collect_io_stats (&po_, filename, disp_stats, vel_stats,
+			     e2e_elapsed_time);
+    }
+
+    return 0;
+}

--- a/quake/forward_gpu/output.h
+++ b/quake/forward_gpu/output.h
@@ -1,0 +1,135 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ * Description: 4D parallel output routines.
+ */
+#ifndef QUAKE_OUTPUT_H
+#define QUAKE_OUTPUT_H
+
+#include <stdio.h>
+#include <sys/types.h>
+
+#include <octor.h>
+#include "psolve.h"
+
+
+/**
+ * Structure to collect simulation output parameters.
+ */
+struct output_parameters_t {
+    /** Flag indicating whether or not to perform output */
+    int do_output;
+
+    /**
+     * Flag indicating whether the output should be peformed in parallel
+     * or sequentially (i.e., through PE 0).
+     */
+    int parallel_output;
+
+    /** Flag indicating whether or not to output node displacement. */
+    int output_displacement;
+
+    /** Flag indicating whether or not to output node velocity. */
+    int output_velocity;
+
+
+    char* displacement_filename;
+
+    char* velocity_filename;
+
+    /** Expected file output size including the header size */
+    off_t output_size;
+
+    mesh_t*   mesh;
+    solver_t* solver;
+
+    /* These fields are used in the output header, other fields needed
+     * in the header are either fixed, or obtained at run-time
+     */
+    int64_t total_nodes;	/**< Node count.			*/
+    int64_t total_elements;	/**< Element count.			*/
+    double  delta_t;		/**< Simulation delta t			*/
+
+    /** Number of simulation time steps between solver output steps     */
+    int32_t output_rate;
+
+    int32_t total_time_steps;
+    int32_t pe_id;		/**< Processing Element (PE) id / rank.	*/
+    int32_t pe_count;		/**< Number of PEs (group size).	*/
+
+    double  domain_x, domain_y, domain_z;
+
+    /** File name for the output summary stats */
+    char*       stats_filename;
+    char*       debug_filename;
+
+    /**
+     * Flag indicating whether or not to to print debug statements for
+     * the output code
+     */
+    int         output_debug;
+};
+
+typedef struct output_parameters_t output_parameters_t;
+
+
+/**
+ * Output stats.
+ */
+struct output_stats_t {
+    float	 lat_avg;	/**< Average output latency.		*/
+    float	 lat_var;	/**< Output latency variance.		*/
+    float	 tput_avg;	/**< Average value.			*/
+    float	 tput_var;	/**< Average Variance.			*/
+    float	 tput_min;	/**< Minimum value.			*/
+    float	 tput_max;	/**< Maximum value.			*/
+    float	 iops;		/**< I/O operations per second.		*/
+    float	 iop_count;	/**< Number of I/O ops performed.	*/
+    unsigned int count;		/**< Number of measurements.		*/
+};
+
+typedef struct output_stats_t output_stats_t;
+
+
+/**
+ * Output related macros.
+ */
+#ifndef	NO_OUTPUT
+#define DO_OUTPUT	1
+#else	/* NO_OUTPUT */
+#define DO_OUTPUT	0
+#endif /* NO_OUTPUT */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int do_solver_output( void );
+extern int output_init_state (output_parameters_t* params);
+extern int output_fini();
+extern int output_collect_io_stats (const char* filename, output_stats_t* disp_stats, output_stats_t* vel_stats, double e2e_elapsed_time);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* QUAKE_OUTPUT_H */

--- a/quake/forward_gpu/psolve.cu
+++ b/quake/forward_gpu/psolve.cu
@@ -1,0 +1,7714 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ * Generate an unstructured mesh and solve the linear system thereof
+ * derived.
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <float.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <math.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include "util.h"
+#include "commutil.h"
+#include "timers.h"
+#include "etree.h"
+#include "octor.h"
+#include "psolve.h"
+#include "cvm.h"
+#include "nrutila.h"
+#include "quakesource.h"
+#include "output.h"
+#include "nonlinear.h"
+#include "io_planes.h"
+#include "io_checkpoint.h"
+#include "stiffness.h"
+#include "damping.h"
+#include "quake_util.h"
+#include "buildings.h"
+#include "drm.h"
+#include "meshformatlab.h"
+
+#include <iostream>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+using namespace std;
+
+/* ONLY GLOBAL VARIABLES ALLOWED OUTSIDE OF PARAM. and GLOBAL. IN ALL OF PSOLVE!! */
+MPI_Comm comm_solver;
+MPI_Comm comm_IO;
+
+#ifndef PROCPERNODE
+#define PROCPERNODE     4
+#endif
+
+#define PI		3.14159265358979323846264338327
+
+#define GOAHEAD_MSG     100
+#define MESH_MSG	101
+#define STAT_MSG	102
+#define OUT4D_MSG       103
+#define DN_MASS_MSG     104
+#define AN_MASS_MSG     105
+#define DN_FORCE_MSG    106
+#define AN_FORCE_MSG    107
+#define DN_DISP_MSG     108
+#define AN_DISP_MSG     109
+#define CVMRECORD_MSG   110
+
+#define BATCH		(1 << 20)
+#define LINESIZE	512
+#define FILEBUFSIZE     (1 << 25)
+
+
+#define CONTRIBUTION    901  /**< Harboring processors to owner processors */
+#define SHARING		902  /**< Owner processors to harboring processors */
+
+#define DISTRIBUTION    903  /**< Dangling nodes to anchored nodes */
+#define ASSIGNMENT      904  /**< Anchored nodes to dangling nodes */
+
+
+/*---------------Initialization and cleanup routines----------------------*/
+static void    read_parameters(int argc, char **argv);
+static int32_t parse_parameters(const char *numericalin);
+static void    local_finalize(void);
+
+/*---------------- Mesh generation data structures -----------------------*/
+#ifdef USECVMDB
+
+#ifndef CVMBUFSIZE
+#define CVMBUFSIZE      100
+#endif
+
+static void     replicateDB(const char *dbname);
+static void     open_cvmdb(void);
+
+#else
+
+static int32_t zsearch(void *base, int32_t count, int32_t recordsize,
+		       const point_t *searchpt);
+static cvmrecord_t *sliceCVM(const char *cvm_flatfile);
+
+#endif
+/** cvmrecord_t: cvm record.  Onlye used if USECVMDB not defined **/
+typedef struct cvmrecord_t {
+    char key[12];
+    float Vp, Vs, density;
+} cvmrecord_t;
+
+/**
+ * mrecord_t: Complete mesh database record
+ *
+ */
+typedef struct mrecord_t {
+    etree_addr_t addr;
+    mdata_t mdata;
+} mrecord_t;
+
+/* Mesh generation related routines */
+static int32_t toexpand(octant_t *leaf, double ticksize, const void *data);
+static void    setrec(octant_t *leaf, double ticksize, void *data);
+static void    mesh_generate(void);
+static int32_t bulkload(etree_t *mep, mrecord_t *partTable, int32_t count);
+static void    mesh_output(void);
+static void    mesh_correct_properties( etree_t* cvm );
+
+static void    gpu_init(void);
+static void    solver_init(void);
+static void    solver_printstat(mysolver_t* solver);
+static void    solver_delete(void);
+static void    solver_run(void);
+       void    solver_output_seq(void);
+static int     solver_print_schedules(mysolver_t* solver);
+static schedule_t* schedule_new(void);
+static void    schedule_build(mesh_t *mesh, schedule_t *dnsched,
+			      schedule_t *ansched);
+static void    schedule_allocMPIctl(schedule_t *sched);
+static void    schedule_allocmapping(schedule_t *sched);
+static void    schedule_delete(schedule_t *sched);
+static void    schedule_prepare(schedule_t *sched, int32_t c_outsize,
+				int32_t c_insize, int32_t s_outsize,
+				int32_t s_insize);
+static void    schedule_senddata(schedule_t *sched, void *valuetable,
+				 int32_t itemsperentry, int32_t direction,
+				 int32_t msgtag);
+static int     schedule_print( schedule_t *sched, char type, FILE* out );
+static int     schedule_print_detail(schedule_t* sched, char type, FILE* out);
+static int     schedule_print_messenger_list( schedule_t* sched,
+					      messenger_t* msg, int count,
+					      char type, char cs, FILE* out );
+
+static messenger_t *messenger_new(int32_t procid);
+static void    messenger_delete(messenger_t *messenger);
+static void    messenger_set(messenger_t *messenger, int32_t outsize,
+			     int32_t insize);
+static int32_t messenger_countnodes(messenger_t *first);
+
+static void    compute_K(void);
+static void constract_Quality_Factor_Table(void);
+
+#ifdef BOUNDARY
+static char    compute_setflag(tick_t ldb[3], tick_t ruf[3],
+			       tick_t nearendp[3], tick_t farendp[3]);
+static void    compute_setboundary(float size, float Vp, float Vs,
+				   float rho, int flag, double dashpot[8][3]);
+#endif /* BOUNDARY */
+
+static void    compute_setab(double freq, double *aBasePtr, double *bBasePtr);
+static void    compute_addforce_s(int32_t timestep);
+static void    compute_adjust(void *valuetable, int32_t itemsperentry,
+			      int32_t how);
+
+static int     interpolate_station_displacements(int32_t step);
+
+
+/* ---------- Static global variables ------------------------------------ */
+
+/* These are all of the input parameters - add new ones here */
+static struct Param_t {
+    char  FourDOutFile[256]; 
+    FILE*  FourDOutFp;
+    FILE*  theMonitorFileFp;
+    char*  theMonitorFileName;
+    char  parameters_input_file[256];
+    char  cvmdb_input_file[256];
+    char  mesh_etree_output_file[256];
+    char  planes_input_file[256];
+    double  theVsCut;
+    double  theFactor;
+    double  theFreq;
+    double  theFreq_Vel;
+    double  theDeltaT;
+    double  theDeltaTSquared;
+    double  theEndT;
+    double  theStartT;
+    double  theDomainAzimuth;
+    int    monitor_stats_rate;
+    double  theSofteningFactor;
+    int     theStepMeshingFactor;
+    int32_t  theTotalSteps;
+    int32_t  theRate;
+    damping_type_t  theTypeOfDamping;
+    double	theThresholdDamping;
+    double	theThresholdVpVs;
+    int	   theDampingStatisticsFlag;
+    int	   theSchedulePrintErrorCheckFlag;
+    int	   theSchedulePrintToStdout;
+    int	   theSchedulePrintToFile;
+    char   theSchedulePrintFilename[256];
+    char*	theScheduleStatFilename;
+    char*       theMeshStatFilename;
+    noyesflag_t  printStationVelocities;
+    noyesflag_t  printK;
+    noyesflag_t  printStationAccelerations;
+    noyesflag_t  includeBuildings;
+    noyesflag_t  includeNonlinearAnalysis;
+    noyesflag_t  useInfQk;
+    int  theTimingBarriersFlag;
+    stiffness_type_t   theStiffness;
+    int      theStationsPrintRate;
+    double*  theStationX;
+    double*  theStationY;
+    double*  theStationZ;
+    int32_t  theNumberOfStations;
+    int32_t  myNumberOfStations;
+    int      IO_pool_pe_count;
+    int32_t  thePlanePrintRate;
+    int      theNumberOfPlanes;
+    char     theStationsDirOut[256];
+    station_t*  myStations;
+    int  theCheckPointingRate;
+    int    theUseCheckPoint;
+    char   theCheckPointingDirOut[256];
+    noyesflag_t  storeMeshCoordinatesForMatlab;
+    double  the4DOutSize;
+    int    theMeshOutFlag;
+    char  theCVMFlatFile[128];
+    output_parameters_t  theOutputParameters;
+    double  theRegionLong;
+    double  theRegionLat; 
+    double  theRegionDepth;
+    double  region_depth_deep_m;
+    double  theSurfaceCornersLong[4];
+    double  theSurfaceCornersLat[4];
+    double  theDomainX;
+    double  theDomainY;
+    double  theDomainZ;
+    noyesflag_t  drmImplement;
+    drm_part_t   theDrmPart;
+
+} Param;
+
+
+/* These are all of the remaining global variables - this list should not grow */
+static struct Global_t {
+    int32_t  myID;
+    int32_t  theGroupSize;
+    octree_t*  myOctree;
+    mesh_t*  myMesh;
+    int64_t  theETotal;
+    int64_t  theNTotal;
+    mysolver_t*  mySolver;
+    fvector_t*  myVelocityTable;
+    fmatrix_t  theK1[8][8];
+    fmatrix_t  theK2[8][8];
+    fmatrix_t  theK3[8][8];
+    double  theQTABLE[26][6];
+    double  theABase;
+    double  theBBase;
+    double  theCriticalT;
+    double  fastestTimeSteps;
+    double  slowestTimeSteps;
+    numerics_info_t  theNumericsInformation;
+    mpi_info_t  theMPIInformation;
+    int32_t  theNodesLoaded;
+    int32_t*  theNodesLoadedList;
+    vector3D_t*  myForces;
+    FILE*  fpsource;
+    etree_t*  theCVMEp;
+    int32_t  theCVMQueryStage;
+    double  theXForMeshOrigin;
+    double  theYForMeshOrigin;
+    double  theZForMeshOrigin;
+    cvmrecord_t*  theCVMRecord;
+    int  theCVMRecordSize;
+    int  theCVMRecordCount;
+    gpu_spec_t gpu_spec;
+} Global;
+
+
+/* ------------------------------End of declarations------------------------------ */
+
+void getGPUHardware(int device, gpu_spec_t *gpuSpecs, int dispFlag)
+{
+    int i;
+    const int kb = 1024;
+    const int mb = kb * kb;
+
+    cudaDeviceProp props;
+    memset(&props, 0, sizeof(cudaDeviceProp));
+    if (cudaGetDeviceProperties(&props, device) != cudaSuccess) {
+      fprintf(stderr, "Failed to get GPU device properties\n");
+      MPI_Abort(MPI_COMM_WORLD, ERROR);
+      exit(1);
+    }
+
+    gpuSpecs->device = device;
+    gpuSpecs->max_threads = props.maxThreadsPerBlock;
+    for (i = 0; i < 3; i++) {
+      gpuSpecs->max_block_dim[i] = props.maxThreadsDim[i];
+      gpuSpecs->max_grid_dim[i] = props.maxGridSize[i];
+    }
+
+    if (dispFlag) {
+      cout << "GPU Device " << device << ": " << props.name 
+	   << ": " << props.major << "." << props.minor << endl;
+      cout << "  Global memory:   " << props.totalGlobalMem / mb 
+	   << "mb" << endl;
+      cout << "  Shared memory:   " << props.sharedMemPerBlock / kb 
+	   << "kb" << endl;
+      cout << "  Constant memory: " << props.totalConstMem / kb << "kb" << endl;
+      cout << "  Block registers: " << props.regsPerBlock << endl << endl;
+      
+      cout << "  Warp size:         " << props.warpSize << endl;
+      cout << "  Threads per block: " << props.maxThreadsPerBlock << endl;
+      cout << "  Max block dimensions: [ " << props.maxThreadsDim[0] 
+	   << ", " << props.maxThreadsDim[1]  << ", " 
+	   << props.maxThreadsDim[2] << " ]" << endl;
+      cout << "  Max grid dimensions:  [ " << props.maxGridSize[0] << ", " 
+	   << props.maxGridSize[1]  << ", " << props.maxGridSize[2] << " ]" 
+	   << endl;
+      cout << endl;
+    }
+}
+
+static inline int
+monitor_print( const char* format, ... )
+{
+    int ret = 0;
+
+    if (format != NULL) {
+	va_list args;
+
+	va_start( args, format );
+
+	if (Param.theMonitorFileFp == NULL) {
+	    ret = vfprintf( stderr, format, args );
+	} else {
+	    ret = hu_print_tee_va( Param.theMonitorFileFp, format, args );
+	}
+
+	va_end( args );
+    }
+
+    return ret;
+}
+
+
+
+/*-----------Parameter input routines---------------------------------*/
+
+static void read_parameters( int argc, char** argv ){
+
+#define LOCAL_INIT_DOUBLE_MESSAGE_LENGTH 18  /* Must adjust this if adding double params */
+#define LOCAL_INIT_INT_MESSAGE_LENGTH 20     /* Must adjust this if adding int params */
+
+    double  double_message[LOCAL_INIT_DOUBLE_MESSAGE_LENGTH];
+    int     int_message[LOCAL_INIT_INT_MESSAGE_LENGTH];
+
+    strcpy(Param.parameters_input_file, argv[1]);
+
+    /* PE 0 reads all params from disk */
+    if (Global.myID == 0) {
+        if (parse_parameters(Param.parameters_input_file) != 0) {
+            fprintf(stderr, "Thread 0: Problem reading parameters!\n");
+            MPI_Abort(MPI_COMM_WORLD, ERROR);
+            exit(1);
+        }
+    }
+
+    /*Broadcast all double params*/
+    double_message[0]  = Param.theVsCut;
+    double_message[1]  = Param.theFactor;
+    double_message[2]  = Param.theFreq;
+    double_message[3]  = Param.theDeltaT;
+    double_message[4]  = Param.theDeltaTSquared;
+    double_message[5]  = Param.theEndT;
+    double_message[6]  = Param.theStartT;
+    double_message[7]  = Param.theDomainX;
+    double_message[8]  = Param.theDomainY;
+    double_message[9]  = Param.theDomainZ;
+    double_message[10] = Param.theDomainAzimuth;
+    double_message[11] = Param.theThresholdDamping;
+    double_message[12] = Param.theThresholdVpVs;
+    double_message[13] = Param.theSofteningFactor;
+    double_message[14] = Param.theFreq_Vel;
+    double_message[15] = Param.theRegionLat;
+    double_message[16] = Param.theRegionLong;
+    double_message[17] = Param.theRegionDepth;
+
+
+    MPI_Bcast(double_message, LOCAL_INIT_DOUBLE_MESSAGE_LENGTH, MPI_DOUBLE, 0, comm_solver);
+
+    Param.theVsCut            = double_message[0];
+    Param.theFactor           = double_message[1];
+    Param.theFreq             = double_message[2];
+    Param.theDeltaT           = double_message[3];
+    Param.theDeltaTSquared    = double_message[4];
+    Param.theEndT             = double_message[5];
+    Param.theStartT           = double_message[6];
+    Param.theDomainX          = double_message[7];
+    Param.theDomainY          = double_message[8];
+    Param.theDomainZ          = double_message[9];
+    Param.theDomainAzimuth	= double_message[10];
+    Param.theThresholdDamping = double_message[11];
+    Param.theThresholdVpVs    = double_message[12];
+    Param.theSofteningFactor  = double_message[13];
+    Param.theFreq_Vel		= double_message[14];
+    Param.theRegionLat		= double_message[15];
+    Param.theRegionLong		= double_message[16];
+    Param.theRegionDepth    = double_message[17];
+
+    /*Broadcast all integer params*/
+    int_message[0]  = Param.theTotalSteps;
+    int_message[1]  = Param.theRate;
+    int_message[2]  = Param.theNumberOfPlanes;
+    int_message[3]  = Param.theNumberOfStations;
+    int_message[4]  = (int)Param.theTypeOfDamping;
+    int_message[5]  = Param.theDampingStatisticsFlag;
+    int_message[6]  = Param.theMeshOutFlag;
+    int_message[7]  = Param.theCheckPointingRate;
+    int_message[8]  = Param.theUseCheckPoint;
+    int_message[9]  = (int)Param.includeNonlinearAnalysis;
+    int_message[10] = (int)Param.theStiffness;
+    int_message[11] = (int)Param.printK;
+    int_message[12] = (int)Param.printStationVelocities;
+    int_message[13] = (int)Param.printStationAccelerations;
+    int_message[14] = Param.theTimingBarriersFlag;
+    int_message[15] = (int)Param.includeBuildings;
+    int_message[16] = (int)Param.storeMeshCoordinatesForMatlab;
+    int_message[17] = (int)Param.drmImplement;
+    int_message[18] = (int)Param.useInfQk;
+    int_message[19] = Param.theStepMeshingFactor;
+
+
+    MPI_Bcast(int_message, LOCAL_INIT_INT_MESSAGE_LENGTH, MPI_INT, 0, comm_solver);
+
+    Param.theTotalSteps            = int_message[0];
+    Param.theRate                  = int_message[1];
+    Param.theNumberOfPlanes              = int_message[2];
+    Param.theNumberOfStations            = int_message[3];
+    Param.theTypeOfDamping         = (damping_type_t)int_message[4];
+    Param.theDampingStatisticsFlag = int_message[5];
+    Param.theMeshOutFlag                 = int_message[6];
+    Param.theCheckPointingRate           = int_message[7];
+    Param.theUseCheckPoint               = int_message[8];
+    Param.includeNonlinearAnalysis       = (noyesflag_t)int_message[9];
+    Param.theStiffness                   = (stiffness_type_t)int_message[10];
+    Param.printK                         = (noyesflag_t)int_message[11];
+    Param.printStationVelocities         = (noyesflag_t)int_message[12];
+    Param.printStationAccelerations      = (noyesflag_t)int_message[13];
+    Param.theTimingBarriersFlag          = int_message[14];
+    Param.includeBuildings               = (noyesflag_t)int_message[15];
+    Param.storeMeshCoordinatesForMatlab  = (noyesflag_t)int_message[16];
+    Param.drmImplement                   = (noyesflag_t)int_message[17];
+    Param.useInfQk                       = (noyesflag_t)int_message[18];
+    Param.theStepMeshingFactor           = int_message[19];
+
+    /*Broadcast all string params*/
+    MPI_Bcast (Param.parameters_input_file,  256, MPI_CHAR, 0, comm_solver);
+    MPI_Bcast (Param.theCheckPointingDirOut, 256, MPI_CHAR, 0, comm_solver);
+    MPI_Bcast (Param.FourDOutFile,           256, MPI_CHAR, 0, comm_solver);
+    MPI_Bcast (Param.cvmdb_input_file,       256, MPI_CHAR, 0, comm_solver);
+    MPI_Bcast (Param.mesh_etree_output_file, 256, MPI_CHAR, 0, comm_solver);
+    MPI_Bcast (Param.planes_input_file,      256, MPI_CHAR, 0, comm_solver);
+
+    return;
+}
+
+
+
+static void
+local_finalize()
+{
+
+    /* Free memory associated with the octree and mesh */
+    octor_deletetree(Global.myOctree);
+    octor_deletemesh(Global.myMesh);
+
+    /* Free the memory used by the source */
+    free(Global.myForces);
+
+    if (Global.myVelocityTable != NULL)
+	free(Global.myVelocityTable);
+
+    /* Free memory associated with the stiffness module */
+    stiffness_delete(Global.myID);
+
+    /* Free memory associated with the solver */
+    solver_delete();
+
+    return;
+}
+
+
+/**
+ * Parse a text file and return the value of a match string.
+ *
+ * \return 0 if OK, -1 on error.
+ */
+int
+parsetext (FILE* fp, const char* querystring, const char type, void* result)
+{
+    const static char delimiters[] = " =\n\t";
+
+    int32_t res = 0, found = 0;
+
+    /* Start from the beginning */
+    rewind(fp);
+
+
+    /* Look for the string until found */
+    while (!found) {
+	char line[LINESIZE];
+	char *name, *value;
+
+	/* Read in one line */
+	if (fgets(line, LINESIZE, fp) == NULL)
+	    break;
+
+	name = strtok(line, delimiters);
+	if ((name != NULL) && (strcmp(name, querystring) == 0)) {
+	    found = 1;
+	    value = strtok(NULL, delimiters);
+
+	    switch (type) {
+	    case 'i':
+		res = sscanf(value, "%d", (int *)result);
+		break;
+	    case 'f':
+		res = sscanf(value, "%f", (float *)result);
+		break;
+	    case 'd':
+		res = sscanf(value, "%lf", (double *)result);
+		break;
+	    case 's':
+		res = 1;
+		strcpy((char *)result, value);
+		break;
+	    case 'u':
+		res = sscanf(value, "%u", (uint32_t *)result);
+		break;
+	    default:
+		fprintf(stderr, "parsetext: unknown type %c\n", type);
+		return -1;
+	    }
+	}
+
+    }
+
+    return (res == 1) ? 0 : -1;
+}
+
+
+
+
+/**
+ * This is like \c parsetext with the following differences:
+ * - works only for strings;
+ * - avoids writting past the end of the string;
+ * - return convention is different, it distinguishes between "key not found"
+ *   and other type of errors.
+ *
+ * \return
+ *	1 if the key name is found and the value is stored in \c value;
+ *	0 if the key name was not found; -1 on error.
+ */
+static int
+read_config_string (FILE* fp, const char* key, char* value_ptr, size_t size)
+{
+    static const char delimiters[] = " =\n\t";
+
+    int  ret;
+    char line[LINESIZE];
+    char state[LINESIZE];
+    char *name, *value, *state_ptr;
+
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+    HU_ASSERT_PTR_ALWAYS( value_ptr );
+    HU_ASSERT_PTR_ALWAYS( key );
+
+    rewind (fp);
+    ret   = 0;
+    *value_ptr = '\0';
+
+    while (0 == ret && !ferror (fp)) {
+
+	if (fgets (line, LINESIZE, fp) == NULL) {
+	    if (!feof (fp)) {
+		ret = -1;	/* input error */
+	    }
+	    break;
+	}
+
+	state_ptr = state;
+	name      = strtok_r (line, delimiters, &state_ptr);
+
+	if ((name != NULL) && (strcmp (name, key) == 0)) {
+	    size_t value_len;
+
+	    value = strtok_r (NULL, delimiters, &state_ptr);
+
+	    if (NULL != value) {
+		value_len = strlen (value);
+
+		if (value_len >= size) {
+		    ret = -2;	/* return buffer is too short */
+		} else {
+		    strncpy (value_ptr, value, size);
+		    ret = 1;
+		}
+	    }
+
+	    break;
+	}
+    }
+
+    return ret;
+}
+
+
+/**
+ * Open material database and initialize various static global variables.
+ *
+ * \return 0 if OK, -1 on error.
+ */
+static int32_t parse_parameters( const char* numericalin )
+{
+    FILE* fp;
+
+    /*
+     * This used to be a seperate file, now aliased to numericalin.
+     * This fakes a seperate file as per old code
+     */
+    const char* physicsin = numericalin;
+
+    int32_t   samples, rate;
+    int       number_output_planes, number_output_stations,
+              damping_statistics, use_checkpoint, checkpointing_rate,
+              step_meshing;
+
+    double    freq, vscut,
+              region_origin_latitude_deg, region_origin_longitude_deg,
+              region_azimuth_leftface_deg,
+              region_depth_shallow_m, region_length_east_m,
+              region_length_north_m, region_depth_deep_m,
+              startT, endT, deltaT, softening_factor,
+              threshold_damping, threshold_VpVs, freq_vel;
+    char      type_of_damping[64],
+	      	  checkpoint_path[256],
+              include_buildings[64],
+              include_nonlinear_analysis[64],
+              stiffness_calculation_method[64],
+              print_matrix_k[64],
+              print_station_velocities[64],
+              print_station_accelerations[64],
+	      	  mesh_coordinates_for_matlab[64],
+    		  implement_drm[64],
+    		  use_infinite_qk[64];
+
+    // Casting -1 to enum type is a bad idea
+    //damping_type_t   typeOfDamping     = -1;
+    //stiffness_type_t stiffness_method  = -1;
+    //noyesflag_t      have_buildings    = -1;
+    //noyesflag_t      includeNonlinear  = -1;
+    //noyesflag_t      printMatrixK      = -1;
+    //noyesflag_t      printStationVels  = -1;
+    //noyesflag_t      printStationAccs  = -1;
+    //noyesflag_t      useInfQk          = -1;
+
+    //noyesflag_t      meshCoordinatesForMatlab  = -1;
+    //noyesflag_t      implementdrm  = -1;
+
+    damping_type_t   typeOfDamping;
+    stiffness_type_t stiffness_method;
+    noyesflag_t      have_buildings;
+    noyesflag_t      includeNonlinear;
+    noyesflag_t      printMatrixK;
+    noyesflag_t      printStationVels;
+    noyesflag_t      printStationAccs;
+    noyesflag_t      useInfQk;
+
+    noyesflag_t      meshCoordinatesForMatlab;
+    noyesflag_t      implementdrm;
+
+
+    /* Obtain the specification of the simulation */
+    if ((fp = fopen(physicsin, "r")) == NULL)
+    {
+	fprintf(stderr, "Error opening %s\n", physicsin);
+	return -1;
+    }
+
+    /* Julio, I know this violates the 80 chars printing limit, but we never
+     * print this code and is a heck of a lot easier to read it like this
+     * --Ricardo
+     */
+    if ((parsetext(fp, "region_origin_latitude_deg",  'd', &region_origin_latitude_deg  ) != 0) ||
+        (parsetext(fp, "region_origin_longitude_deg", 'd', &region_origin_longitude_deg ) != 0) ||
+        (parsetext(fp, "region_depth_shallow_m",      'd', &region_depth_shallow_m      ) != 0) ||
+        (parsetext(fp, "region_length_east_m",        'd', &region_length_east_m        ) != 0) ||
+        (parsetext(fp, "region_length_north_m",       'd', &region_length_north_m       ) != 0) ||
+        (parsetext(fp, "region_depth_deep_m",         'd', &region_depth_deep_m         ) != 0) ||
+        (parsetext(fp, "region_azimuth_leftface_deg", 'd', &region_azimuth_leftface_deg ) != 0) ||
+        (parsetext(fp, "type_of_damping",             's', &type_of_damping             ) != 0) )
+    {
+        fprintf(stderr, "Error reading region origin from %s\n", physicsin);
+        return -1;
+    }
+
+    if ( strcasecmp(type_of_damping, "rayleigh") == 0) {
+    	typeOfDamping = RAYLEIGH;
+    } else if (strcasecmp(type_of_damping, "mass") == 0) {
+    	typeOfDamping = MASS;
+    } else if (strcasecmp(type_of_damping, "none") == 0) {
+    	typeOfDamping = NONE;
+    } else if (strcasecmp(type_of_damping, "bkt") == 0) {
+    	typeOfDamping = BKT;
+    } else {
+    	solver_abort( __FUNCTION_NAME, NULL,
+    			"Unknown damping type: %s\n",
+    			type_of_damping );
+    }
+
+
+    fclose(fp); /* physics.in */
+
+    if ((fp = fopen(numericalin, "r")) == NULL) {
+	fprintf(stderr, "Error opening %s\n", numericalin);
+	return -1;
+    }
+
+    size_t monitor_name_len = 0;
+    hu_config_get_string_def( fp, "monitor_file", &Param.theMonitorFileName,
+			      &monitor_name_len, "monitor.txt" );
+
+    /* open the monitor file of the simulation in pe 0 */
+    Param.theMonitorFileFp = fopen( Param.theMonitorFileName, "w" );
+    if (Param.theMonitorFileFp == NULL) {
+	fprintf( stderr,"\n Err opening the monitor file" );
+    } else {
+	setlinebuf ( Param.theMonitorFileFp );
+    }
+
+    xfree_char( &Param.theMonitorFileName );
+
+    /* numerical.in parse texts */
+    if ((parsetext(fp, "simulation_wave_max_freq_hz",    'd', &freq                        ) != 0) ||
+        (parsetext(fp, "simulation_node_per_wavelength", 'i', &samples                     ) != 0) ||
+        (parsetext(fp, "simulation_shear_velocity_min",  'd', &vscut                       ) != 0) ||
+        (parsetext(fp, "simulation_start_time_sec",      'd', &startT                      ) != 0) ||
+        (parsetext(fp, "simulation_end_time_sec",        'd', &endT                        ) != 0) ||
+        (parsetext(fp, "simulation_delta_time_sec",      'd', &deltaT                      ) != 0) ||
+        (parsetext(fp, "softening_factor",               'd', &softening_factor            ) != 0) ||
+        (parsetext(fp, "use_progressive_meshing",        'i', &step_meshing                ) != 0) ||
+        (parsetext(fp, "simulation_output_rate",         'i', &rate                        ) != 0) ||
+        (parsetext(fp, "number_output_planes",           'i', &number_output_planes        ) != 0) ||
+        (parsetext(fp, "number_output_stations",         'i', &number_output_stations      ) != 0) ||
+        (parsetext(fp, "the_threshold_damping",          'd', &threshold_damping           ) != 0) ||
+        (parsetext(fp, "the_threshold_Vp_over_Vs",       'd', &threshold_VpVs              ) != 0) ||
+        (parsetext(fp, "do_damping_statistics",          'i', &damping_statistics          ) != 0) ||
+        (parsetext(fp, "use_checkpoint",                 'i', &use_checkpoint              ) != 0) ||
+        (parsetext(fp, "checkpointing_rate",             'i', &checkpointing_rate          ) != 0) ||
+        (parsetext(fp, "checkpoint_path",                's', &checkpoint_path             ) != 0) ||
+        (parsetext(fp, "4D_output_file",                 's', &Param.FourDOutFile          ) != 0) ||
+        (parsetext(fp, "cvmdb_input_file",               's', &Param.cvmdb_input_file      ) != 0) ||
+        (parsetext(fp, "mesh_etree_output_file",         's', &Param.mesh_etree_output_file) != 0) ||
+        (parsetext(fp, "planes_input_file",              's', &Param.planes_input_file     ) != 0) ||
+        (parsetext(fp, "include_nonlinear_analysis",     's', &include_nonlinear_analysis  ) != 0) ||
+        (parsetext(fp, "stiffness_calculation_method",   's', &stiffness_calculation_method) != 0) ||
+        (parsetext(fp, "print_matrix_k",                 's', &print_matrix_k              ) != 0) ||
+        (parsetext(fp, "print_station_velocities",       's', &print_station_velocities    ) != 0) ||
+        (parsetext(fp, "print_station_accelerations",    's', &print_station_accelerations ) != 0) ||
+        (parsetext(fp, "include_buildings",              's', &include_buildings           ) != 0) ||
+        (parsetext(fp, "mesh_coordinates_for_matlab",    's', &mesh_coordinates_for_matlab ) != 0) ||
+        (parsetext(fp, "implement_drm",    				 's', &implement_drm               ) != 0) ||
+        (parsetext(fp, "simulation_velocity_profile_freq_hz",'d', &freq_vel                ) != 0) ||
+        (parsetext(fp, "use_infinite_qk",                's', &use_infinite_qk             ) != 0) )
+    {
+        fprintf( stderr, "Error parsing simulation parameters from %s\n",
+                numericalin );
+        return -1;
+    }
+
+    hu_config_get_int_opt(fp, "output_mesh", &Param.theMeshOutFlag );
+    hu_config_get_int_opt(fp, "enable_timing_barriers",&Param.theTimingBarriersFlag);
+    hu_config_get_int_opt(fp, "forces_buffer_size", &theForcesBufferSize );
+    hu_config_get_int_opt(fp, "schedule_print_file", &Param.theSchedulePrintToFile );
+
+    hu_config_get_int_opt(fp, "schedule_print_error_check",
+			  &Param.theSchedulePrintErrorCheckFlag);
+    hu_config_get_int_opt(fp, "schedule_print_stdout",
+			  &Param.theSchedulePrintToStdout );
+
+    size_t schedule_stat_len = 0;
+    hu_config_get_string_def( fp, "stat_schedule_filename",
+			      &Param.theScheduleStatFilename,
+			      &schedule_stat_len, "stat-sched.txt" );
+    size_t mesh_stat_len = 0;
+    hu_config_get_string_def( fp, "stat_mesh_filename", &Param.theMeshStatFilename,
+			      &mesh_stat_len, "stat-mesh.txt" );
+
+    fclose( fp );
+
+    /* sanity check */
+    if (freq <= 0) {
+        fprintf(stderr, "Illegal frequency value %f\n", freq);
+        return -1;
+    }
+
+    if (freq_vel < 0 || freq_vel > freq) {
+        fprintf(stderr, "Illegal frequency value, velocity profile frequency can not be smaller than zero or bigger than max freq %f\n", freq_vel);
+        return -1;
+    }
+
+    if (samples <= 0) {
+        fprintf(stderr, "Illegal samples value %d\n", samples);
+        return -1;
+    }
+
+    if (vscut <= 0) {
+        fprintf(stderr, "Illegal vscut value %f\n", vscut);
+        return -1;
+    }
+
+    if ((startT < 0) || (endT < 0) || (startT > endT)) {
+        fprintf(stderr, "Illegal startT %f or endT %f\n", startT, endT);
+        return -1;
+    }
+
+    if (deltaT <= 0) {
+        fprintf(stderr, "Illegal deltaT %f\n", deltaT);
+        return -1;
+    }
+
+    if ( (softening_factor <= 1) && (softening_factor != 0) ) {
+        fprintf(stderr, "Illegal softening factor %f\n", softening_factor);
+        return -1;
+    }
+
+    if (step_meshing < 0) {
+        fprintf(stderr, "Illegal progressive meshing factor %d\n", step_meshing);
+        return -1;
+    }
+
+    if (rate <= 0) {
+        fprintf(stderr, "Illegal output rate %d\n", rate);
+        return -1;
+    }
+
+    if (number_output_planes < 0) {
+        fprintf(stderr, "Illegal number of output planes %d\n",
+                number_output_planes);
+        return -1;
+    }
+
+    if (number_output_stations < 0) {
+        fprintf(stderr, "Illegal number of output stations %d\n",
+                number_output_planes);
+        return -1;
+    }
+
+    if (threshold_damping < 0) {
+        fprintf(stderr, "Illegal threshold damping %f\n",
+                threshold_damping);
+        return -1;
+    }
+
+    if (threshold_VpVs < 0) {
+        fprintf(stderr, "Illegal threshold Vp over Vs %f\n",
+                threshold_VpVs);
+        return -1;
+    }
+
+    if ( (damping_statistics < 0) || (damping_statistics > 1) ) {
+        fprintf(stderr, "Illegal do damping statistics flag %d\n",
+                damping_statistics);
+        return -1;
+    }
+
+    if ( (use_checkpoint < 0) || (use_checkpoint > 1) ) {
+        fprintf(stderr, "Illegal use checkpoint flag %d\n",
+                use_checkpoint);
+        return -1;
+    }
+
+    if ( checkpointing_rate < 0 ) {
+        fprintf(stderr, "Illegal checkpointing rate %d\n",
+                use_checkpoint);
+        return -1;
+    }
+
+    if ( strcasecmp(include_nonlinear_analysis, "yes") == 0 ) {
+        includeNonlinear = YES;
+    } else if ( strcasecmp(include_nonlinear_analysis, "no") == 0 ) {
+        includeNonlinear = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+        	"Unknown response for including"
+                "nonlinear analysis (yes or no): %s\n",
+                include_nonlinear_analysis );
+    }
+
+    if ( strcasecmp(stiffness_calculation_method, "effective") == 0 ) {
+        stiffness_method = EFFECTIVE;
+    } else if ( strcasecmp(stiffness_calculation_method, "conventional") == 0 ) {
+        stiffness_method = CONVENTIONAL;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL, "Unknown response for stiffness"
+                "calculation method (effective or conventional): %s\n",
+                stiffness_calculation_method );
+    }
+
+    if ( strcasecmp(print_matrix_k, "yes") == 0 ) {
+        printMatrixK = YES;
+    } else if ( strcasecmp(print_matrix_k, "no") == 0 ) {
+        printMatrixK = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+                "Unknown response for printing K matrix (yes or no): %s\n",
+                print_matrix_k );
+    }
+
+    if ( strcasecmp(print_station_velocities, "yes") == 0 ) {
+        printStationVels = YES;
+    } else if ( strcasecmp(print_station_velocities, "no") == 0 ) {
+        printStationVels = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+                "Unknown response for printing"
+                "station velocities (yes or no): %s\n",
+                print_station_velocities );
+    }
+
+    if ( strcasecmp(print_station_accelerations, "yes") == 0 ) {
+        printStationAccs = YES;
+    } else if ( strcasecmp(print_station_accelerations, "no") == 0 ) {
+        printStationAccs = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+                "Unknown response for printing"
+                "station accelerations (yes or no): %s\n",
+                print_station_accelerations );
+    }
+
+    if ( strcasecmp(mesh_coordinates_for_matlab, "yes") == 0 ) {
+    	meshCoordinatesForMatlab = YES;
+    } else if ( strcasecmp(mesh_coordinates_for_matlab, "no") == 0 ) {
+    	meshCoordinatesForMatlab = NO;
+    } else {
+    	solver_abort( __FUNCTION_NAME, NULL,
+    			"Unknown response for mesh coordinates"
+    			"for matlab (yes or no): %s\n",
+    			mesh_coordinates_for_matlab );
+    }
+
+    if ( strcasecmp(include_buildings, "yes") == 0 ) {
+        have_buildings = YES;
+    } else if ( strcasecmp(include_buildings, "no") == 0 ) {
+        have_buildings = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+                "Unknown response for including buildings (yes or no): %s\n",
+                include_buildings );
+    }
+
+    if ( strcasecmp(implement_drm, "yes") == 0 ) {
+        implementdrm = YES;
+    } else if ( strcasecmp(implement_drm, "no") == 0 ) {
+        implementdrm = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+                "Unknown response for impelement_drm (yes or no): %s\n",
+                implement_drm );
+    }
+
+    if ( strcasecmp(use_infinite_qk, "yes") == 0 ) {
+        useInfQk = YES;
+    } else if ( strcasecmp(use_infinite_qk, "no") == 0 ) {
+        useInfQk = NO;
+    } else {
+        solver_abort( __FUNCTION_NAME, NULL,
+            "Unknown response using infinite Qk (yes or no): %s\n",
+                use_infinite_qk);
+    }
+
+    /* Init the static global variables */
+
+    Param.theRegionLat      = region_origin_latitude_deg;
+    Param.theRegionLong     = region_origin_longitude_deg ;
+    Param.theRegionDepth    = region_depth_shallow_m ;
+
+    Param.theVsCut	      = vscut;
+    Param.theFactor	      = freq * samples;
+    Param.theFreq         = freq;
+    Param.theFreq_Vel	  = freq_vel;
+    Param.theDeltaT	      = deltaT;
+    Param.theDeltaTSquared  = deltaT * deltaT;
+    Param.theStartT	      = startT;
+    Param.theEndT           = endT;
+    Param.theTotalSteps     = (int)(((endT - startT) / deltaT));
+
+    Param.theDomainX	      = region_length_north_m;
+    Param.theDomainY	      = region_length_east_m;
+    Param.region_depth_deep_m = region_depth_deep_m;
+    Param.theDomainZ	      = region_depth_deep_m - region_depth_shallow_m;
+    Param.theDomainAzimuth  = region_azimuth_leftface_deg;
+    Param.theTypeOfDamping  = typeOfDamping;
+    Param.useInfQk          = useInfQk;
+
+    Param.theRate           = rate;
+
+    Param.theNumberOfPlanes	      = number_output_planes;
+    Param.theNumberOfStations	      = number_output_stations;
+
+    Param.theSofteningFactor        = softening_factor;
+    Param.theStepMeshingFactor     = step_meshing;
+    Param.theThresholdDamping	      = threshold_damping;
+    Param.theThresholdVpVs	      = threshold_VpVs;
+    Param.theDampingStatisticsFlag  = damping_statistics;
+
+    Param.theCheckPointingRate      = checkpointing_rate;
+    Param.theUseCheckPoint	      = use_checkpoint;
+
+    Param.includeNonlinearAnalysis  = includeNonlinear;
+    Param.theStiffness              = stiffness_method;
+
+    Param.printK                    = printMatrixK;
+    Param.printStationVelocities    = printStationVels;
+    Param.printStationAccelerations = printStationAccs;
+
+    Param.includeBuildings          = have_buildings;
+
+    Param.storeMeshCoordinatesForMatlab  = meshCoordinatesForMatlab;
+
+    Param.drmImplement              = implementdrm;
+
+    strcpy( Param.theCheckPointingDirOut, checkpoint_path );
+
+    monitor_print("\n\n---------------- Some Input Data ----------------\n\n");
+    monitor_print("Vs cut:                             %f\n", Param.theVsCut);
+    monitor_print("Softening factor:                   %f\n", Param.theSofteningFactor);
+    monitor_print("Number of stations:                 %d\n", Param.theNumberOfStations);
+    monitor_print("Number of planes:                   %d\n", Param.theNumberOfPlanes);
+    monitor_print("Stiffness calculation method:       %s\n", stiffness_calculation_method);
+    monitor_print("Include buildings:                  %s\n", include_buildings);
+    monitor_print("Include nonlinear analysis:         %s\n", include_nonlinear_analysis);
+    monitor_print("Printing velocities on stations:    %s\n", print_station_velocities);
+    monitor_print("Printing accelerations on stations: %s\n", print_station_accelerations);
+    monitor_print("Mesh Coordinates For Matlab:        %s\n", mesh_coordinates_for_matlab);
+    monitor_print("cvmdb_input_file:                   %s\n", Param.cvmdb_input_file);
+    monitor_print("Implement drm:      	               %s\n", implement_drm);
+    monitor_print("\n-------------------------------------------------\n\n");
+
+    fflush(Param.theMonitorFileFp);
+
+    return 0;
+}
+
+
+
+/*-----------Mesh generation related routines------------------------------*/
+
+static void  open_cvmdb(void){
+
+#ifdef USECVMDB
+
+    MPI_Barrier(comm_solver);
+    replicateDB(Param.cvmdb_input_file);
+
+    MPI_Barrier(comm_solver);
+    Global.theCVMEp = etree_open(Param.cvmdb_input_file, O_RDONLY, CVMBUFSIZE, 0, 0 );
+
+    if (Global.theCVMEp == NULL) {
+	fprintf( stderr, "Thread %d: open_cvmdb: error opening CVM etree %s\n",
+		 Global.myID, Param.cvmdb_input_file );
+	MPI_Abort(MPI_COMM_WORLD, ERROR );
+	exit( 1 );
+    }
+
+    dbctl_t  *myctl;
+    /* Obtain the material database application control/meta data */
+    if ((myctl = cvm_getdbctl(Global.theCVMEp)) == NULL) {
+    	fprintf(stderr, "Error reading CVM etree control data\n");
+    	MPI_Abort(MPI_COMM_WORLD, ERROR );
+    	exit( 1 );
+    }
+
+    /* Check the ranges of the mesh and the scope of the CVM etree */
+    if ((Param.theRegionLat < myctl->region_origin_latitude_deg) ||
+        (Param.theRegionLong < myctl->region_origin_longitude_deg) ||
+        (Param.theRegionDepth < myctl->region_depth_shallow_m) ||
+        (Param.region_depth_deep_m > myctl->region_depth_deep_m) ||
+        (Param.theRegionLat + Param.theDomainX / DIST1LAT
+         > myctl->region_origin_latitude_deg
+         + myctl->region_length_north_m / DIST1LAT) ||
+        (Param.theRegionLong + Param.theDomainY / DIST1LON
+         > myctl->region_origin_longitude_deg +
+         myctl->region_length_east_m / DIST1LON)) {
+        fprintf(stderr, "Mesh area out of the CVM etree\n");
+        MPI_Abort(MPI_COMM_WORLD, ERROR );
+    	exit( 1 );
+    }
+
+    /* Compute the coordinates of the origin of the mesh coordinate
+       system in the CVM etree domain coordinate system */
+    Global.theXForMeshOrigin = (Param.theRegionLat
+				- myctl->region_origin_latitude_deg) * DIST1LAT;
+    Global.theYForMeshOrigin = (Param.theRegionLong
+				- myctl->region_origin_longitude_deg) * DIST1LON;
+    Global.theZForMeshOrigin = Param.theRegionDepth - myctl->region_depth_shallow_m;
+
+    /* Free memory used by myctl */
+    cvm_freedbctl(myctl);
+
+    double  double_message_extra[3];
+
+    double_message_extra[0] = Global.theXForMeshOrigin;
+    double_message_extra[1] = Global.theYForMeshOrigin;
+    double_message_extra[2] = Global.theZForMeshOrigin;
+
+    MPI_Bcast(double_message_extra, 3, MPI_DOUBLE, 0, comm_solver);
+
+    Global.theXForMeshOrigin = double_message_extra[0];
+    Global.theYForMeshOrigin = double_message_extra[1];
+    Global.theZForMeshOrigin = double_message_extra[2];
+
+#else
+    strcpy(Param.theCVMFlatFile, cvmdb_input_file);
+#endif
+
+}
+
+
+
+#ifdef USECVMDB
+
+/**
+ * replicateDB: Copy the material database to local disks.
+ *
+ */
+static void
+replicateDB(const char *dbname)
+{
+    char* destdir;
+
+#ifndef SCEC
+    char* srcpath;
+    MPI_Comm replica_comm;
+#endif /* SCEC */
+
+
+    /* Change the working directory to $LOCAL */
+#ifndef CVM_DESTDIR
+    char  curdir[256];
+    destdir = getenv( "CVM_DESTDIR" );
+    if (destdir == NULL) { /* then use current directory */
+	destdir = getcwd( curdir, 256 );
+    }
+#else
+    destdir = CVM_DESTDIR;
+#endif
+
+    /* Clean the disks:
+     * NOTE: Guys! cleanup the disk in your job script before launching
+     * psolve, using rm -rf.
+     * E.g., on Lemieux add the following line to your PBS job script,
+     * before launching psolve.
+     *   prun -m cyclic -n ${RMS_NODES} -N ${RMS_NODES} rm -rf <dirname>/
+     * where dirname is the directory you want to wipe out.
+     * This will take care of this issue.
+     *
+     * On BigBen it is even easier, it can be done from the front end
+     * since everything is a shared parallel file system.
+     *
+     * Unfortunately the 'system' function is not supported on all platforms,
+     * e.g., Cray's XT3 catamount platform (BigBen) does not have it.
+     */
+#ifndef SCEC
+    if (chdir(destdir) != 0) {
+	fprintf(stderr, "Thread %d: replicateDB: cannot chdir to %s\n",
+		Global.myID, destdir);
+	MPI_Abort(MPI_COMM_WORLD, ERROR);
+	exit(1);
+    }
+
+    MPI_Barrier(comm_solver);
+
+    /* Replicate the material database among the processors */
+    if (Global.myID % PROCPERNODE != 0) {
+	MPI_Comm_split(comm_solver, MPI_UNDEFINED, Global.myID, &replica_comm);
+
+    } else {
+	int replica_id;
+	off_t filesize, remains, batchsize;
+	void *filebuf;
+	int src_fd = -1, dest_fd;
+
+	MPI_Comm_split(comm_solver, 0, Global.myID, &replica_comm);
+	MPI_Comm_rank(replica_comm, &replica_id);
+
+	if (replica_id == 0) {
+	    struct stat statbuf;
+
+#ifndef CVM_SRRCPATH
+	    srcpath = getenv("CVM_SRCPATH");
+#else
+	    srcpath = CVM_SRCPATH;
+#endif
+
+	    if (stat(srcpath, &statbuf) != 0) {
+		fprintf(stderr,
+			"Thread 0: replicateDB: Cannot get stat of %s\n",
+			srcpath);
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+
+	    filesize = statbuf.st_size;
+	    src_fd = open(srcpath, O_RDONLY);
+	    if (src_fd == -1) {
+		fprintf(stderr,
+			"Thread 0: replicateDB: Cannot open cvm source db\n");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+	}
+
+
+	MPI_Bcast(&filesize, sizeof(off_t), MPI_CHAR, 0, replica_comm);
+	//theDBSize = filesize;
+
+	if ((filebuf = malloc(FILEBUFSIZE)) == NULL) {
+	    fprintf(stderr, "Thread %d: replicateDB: ", Global.myID);
+	    fprintf(stderr, "run out of memory while ");
+	    fprintf(stderr, "preparing to receive material database\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* Everyone opens a replicate db */
+	dest_fd = open(dbname, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR);
+	if (dest_fd == -1) {
+	    fprintf(stderr, "Thread %d: replicateDB: ", Global.myID);
+	    fprintf(stderr, "cannot create replica database\n");
+	    perror("open");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	remains = filesize;
+	while (remains > 0) {
+	    batchsize = (remains > FILEBUFSIZE) ? FILEBUFSIZE : remains;
+
+	    if (replica_id == 0) {
+		if (read(src_fd, filebuf, batchsize) !=	 batchsize) {
+		    fprintf(stderr, "Thread 0: replicateDB: ");
+		    fprintf(stderr, "Cannot read database\n");
+		    perror("read");
+		    MPI_Abort(MPI_COMM_WORLD, ERROR);
+		    exit(1);
+		}
+	    }
+
+	    MPI_Bcast(filebuf, batchsize, MPI_CHAR, 0, replica_comm);
+
+	    if (write(dest_fd, filebuf, batchsize) != batchsize) {
+		fprintf(stderr, "Thread %d: replicateDB: ", Global.myID);
+		fprintf(stderr, "Cannot write replica database\n");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+
+	    remains -= batchsize;
+	}
+
+	free(filebuf);
+
+	if (close(dest_fd) != 0) {
+	    fprintf(stderr, "Thread %d: replicateDB: ", Global.myID);
+	    fprintf(stderr, "cannot close replica database\n");
+	    perror("close");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	if (replica_id == 0) {
+	    close(src_fd);
+	}
+
+	MPI_Comm_free(&replica_comm);
+
+    } /* processors participating in the replication */
+
+#endif /* SCEC */
+
+    return ;
+}
+
+
+
+/**
+ * Assign values (material properties) to a leaf octant specified by
+ * octleaf.  In order to refine the mesh, select the minimum Vs of 27
+ * sample points: 8 near the corners and 19 midpoints.
+ */
+static void
+setrec( octant_t* leaf, double ticksize, void* data )
+{
+    double x_m, y_m, z_m;	/* x:south-north, y:east-west, z:depth */
+    tick_t halfticks;
+    cvmpayload_t g_props;	/* cvm record with ground properties */
+    cvmpayload_t g_props_min;	/* cvm record with the min Vs found */
+
+    int i_x, i_y, i_z, n_points = 3;
+    double points[3];
+
+    int res = 0;
+    edata_t* edata = (edata_t*)data;
+
+    points[0] = 0.01;
+    points[1] = 1;
+    points[2] = 1.99;
+
+    halfticks = (tick_t)1 << (PIXELLEVEL - leaf->level - 1);
+    edata->edgesize = ticksize * halfticks * 2;
+
+    /* Check for buildings and proceed according to the buildings setrec */
+    if ( Param.includeBuildings == YES ) {
+		if ( bldgs_setrec( leaf, ticksize, edata, Global.theCVMEp,Global.theXForMeshOrigin,Global.theYForMeshOrigin,Global.theZForMeshOrigin ) ) {
+            return;
+        }
+    }
+
+    g_props_min.Vs  = FLT_MAX;
+    g_props_min.Vp  = NAN;
+    g_props_min.rho = NAN;
+
+    for ( i_x = 0; i_x < n_points; i_x++ ) {
+
+	x_m = (Global.theXForMeshOrigin
+	       + (leaf->lx + points[i_x] * halfticks) * ticksize);
+
+	for ( i_y = 0; i_y < n_points; i_y++ ) {
+
+	    y_m  = Global.theYForMeshOrigin
+		+ (leaf->ly + points[i_y] * halfticks) * ticksize;
+
+	    for ( i_z = 0; i_z < n_points; i_z++) {
+
+		z_m = Global.theZForMeshOrigin
+		    + (leaf->lz +  points[i_z] * halfticks) * ticksize;
+
+		/* Shift the domain if buildings are considered */
+		if ( Param.includeBuildings == YES ) {
+                    z_m -= get_surface_shift();
+		}
+
+		res = cvm_query( Global.theCVMEp, y_m, x_m, z_m, &g_props );
+
+		if (res != 0) {
+		    continue;
+		}
+
+		if ( g_props.Vs < g_props_min.Vs ) {
+		    /* assign minimum value of vs to produce elements
+		     * that are small enough to rightly represent the model */
+		    g_props_min = g_props;
+		}
+
+		if (g_props.Vs <= Param.theVsCut) {
+		    /* stop early if needed, completely break out of all
+		     * the loops, the label is just outside the loop */
+		    goto outer_loop_label;
+		}
+	    }
+	}
+    }
+ outer_loop_label: /* in order to completely break out from the inner loop */
+
+    edata->Vp  = g_props_min.Vp;
+    edata->Vs  = g_props_min.Vs;
+    edata->rho = g_props_min.rho;
+
+    if (res != 0 && g_props_min.Vs == DBL_MAX) {
+	/* all the queries failed, then center out of bound point. Set Vs
+	 * to force split */
+	edata->Vs = Param.theFactor * edata->edgesize / 2;
+    } else if (edata->Vs <= Param.theVsCut) {	/* adjust Vs and Vp */
+	double VpVsRatio = edata->Vp / edata->Vs;
+
+	edata->Vs = Param.theVsCut;
+	edata->Vp = Param.theVsCut * VpVsRatio;
+    }
+
+    return;
+}
+
+#else /* USECVMDB */
+
+static int32_t
+zsearch(void *base, int32_t count, int32_t recordsize, const point_t *searchpt)
+{
+    int32_t start, end, offset, found;
+
+    start = 0;
+    end = count - 1;
+    offset = (start + end ) / 2;
+
+    found = 0;
+    do {
+	if (end < start) {
+	    /* the two pointer crossed each other */
+	    offset = end;
+	    found = 1;
+	} else {
+	    const void *pivot = (char *)base + offset * recordsize;
+
+	    switch (octor_zcompare(searchpt, pivot)) {
+	    case (0): /* equal */
+		found = 1;
+		break;
+	    case (1): /* searchpoint larger than the pivot */
+		start = offset + 1;
+		offset = (start + end) / 2;
+		break;
+	    case (-1): /* searchpoint smaller than the pivot */
+		end = offset - 1;
+		offset = (start + end) / 2;
+		break;
+	    }
+	}
+    } while (!found);
+
+    return offset;
+}
+
+
+static cvmrecord_t *sliceCVM(const char *cvm_flatfile)
+{
+    cvmrecord_t *cvmrecord;
+    int32_t bufferedbytes, bytecount, recordcount;
+    if (Global.myID == Global.theGroupSize - 1) {
+	/* the last processor reads data and
+	   distribute to other processors*/
+
+	struct timeval starttime, endtime;
+	float iotime = 0, memmovetime = 0;
+	MPI_Request *isendreqs;
+	MPI_Status *isendstats;
+	FILE *fp;
+	int fd, procid;
+	struct stat statbuf;
+	void *maxbuf;
+	const point_t *intervaltable;
+	off_t bytesent;
+	int32_t offset;
+	const int maxcount =  (1 << 29) / sizeof(cvmrecord_t);
+	const int maxbufsize = maxcount * sizeof(cvmrecord_t);
+
+	fp = fopen(cvm_flatfile, "r");
+	if (fp == NULL) {
+	    fprintf(stderr, "Thread %d: Cannot open flat CVM file\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	fd = fileno(fp);
+	if (fstat(fd, &statbuf) != 0) {
+	    fprintf(stderr, "Thread %d: Cannot get the status of CVM file\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	intervaltable = octor_getintervaltable(Global.myOctree);
+
+	/*
+	for (procid = 0; procid <= Global.myID; procid++) {
+	    fprintf(stderr, "interval[%d] = {%d, %d, %d}\n", procid,
+		    intervaltable[procid].x << 1, intervaltable[procid].y << 1,
+		    intervaltable[procid].z << 1);
+	}
+	*/
+
+	bytesent = 0;
+	maxbuf = malloc(maxbufsize) ;
+	if (maxbuf == NULL) {
+	    fprintf(stderr, "Thread %d: Cannot allocate send buffer\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	isendreqs = (MPI_Request *)malloc(sizeof(MPI_Request) * Global.theGroupSize);
+	isendstats = (MPI_Status *)malloc(sizeof(MPI_Status) * Global.theGroupSize);
+	if ((isendreqs == NULL) || (isendstats == NULL)) {
+	    fprintf(stderr, "Thread %d: Cannot allocate isend controls\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* Try to read max number of CVM records as allowed */
+	//	gettimeofday(&starttime, NULL);
+	recordcount = fread(maxbuf, sizeof(cvmrecord_t),
+			    maxbufsize / sizeof(cvmrecord_t), fp);
+	//	gettimeofday(&endtime, NULL);
+
+	iotime += (endtime.tv_sec - starttime.tv_sec) * 1000.0
+	    + (endtime.tv_usec - starttime.tv_usec) / 1000.0;
+
+	if (recordcount != maxbufsize / sizeof(cvmrecord_t)) {
+	    fprintf(stderr, "Thread %d: Cannot read-init buffer\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* start with proc 0 */
+	procid = 0;
+
+	while (procid < Global.myID) { /* repeatedly fill the buffer */
+	    point_t searchpoint, *point;
+	    int newreads;
+	    int isendcount = 0;
+
+	    /* we have recordcount to work with */
+	    cvmrecord = (cvmrecord_t *)maxbuf;
+
+	    while (procid < Global.myID) { /* repeatedly send out data */
+
+		searchpoint.x = intervaltable[procid + 1].x << 1;
+		searchpoint.y = intervaltable[procid + 1].y << 1;
+		searchpoint.z = intervaltable[procid + 1].z << 1;
+
+		offset = zsearch(cvmrecord, recordcount, Global.theCVMRecordSize,
+				 &searchpoint);
+
+		point = (point_t *)(cvmrecord + offset);
+
+		if ((point->x != searchpoint.x) ||
+		    (point->y != searchpoint.y) ||
+		    (point->z != searchpoint.z)) {
+		    break;
+		} else {
+		    bytecount = offset * sizeof(cvmrecord_t);
+		    MPI_Isend(cvmrecord, bytecount, MPI_CHAR, procid,
+			      CVMRECORD_MSG, comm_solver,
+			      &isendreqs[isendcount]);
+		    isendcount++;
+
+		    /*
+		      fprintf(stderr,
+		      "Procid = %d offset = %qd bytecount = %d\n",
+		      procid, (int64_t)bytesent, bytecount);
+		    */
+
+		    bytesent += bytecount;
+
+		    /* prepare for the next processor */
+		    recordcount -= offset;
+		    cvmrecord = (cvmrecord_t *)point;
+		    procid++;
+		}
+	    }
+
+	    /* Wait till the data in the buffer has been sent */
+	    MPI_Waitall(isendcount, isendreqs, isendstats);
+
+	    /* Move residual data to the beginning of the buffer
+	       and try to fill the newly free space */
+	    bufferedbytes = sizeof(cvmrecord_t) * recordcount;
+
+	    // gettimeofday(&starttime, NULL);
+	    memmove(maxbuf, cvmrecord, bufferedbytes);
+	    // gettimeofday(&endtime, NULL);
+	    memmovetime += (endtime.tv_sec - starttime.tv_sec) * 1000.0
+		+ (endtime.tv_usec - starttime.tv_usec) / 1000.0;
+
+	    // gettimeofday(&starttime, NULL);
+	    newreads = fread((char *)maxbuf + bufferedbytes,
+			     sizeof(cvmrecord_t), maxcount - recordcount, fp);
+	    // gettimeofday(&endtime, NULL);
+	    iotime += (endtime.tv_sec - starttime.tv_sec) * 1000.0
+		+ (endtime.tv_usec - starttime.tv_usec) / 1000.0;
+
+	    recordcount += newreads;
+
+	    if (newreads == 0)
+		break;
+	}
+
+	free(maxbuf);
+	free(isendreqs);
+	free(isendstats);
+
+	/* I am supposed to accomodate the remaining octants */
+	bytecount = statbuf.st_size - bytesent;
+
+	cvmrecord = (cvmrecord_t *)malloc(bytecount);
+	if (cvmrecord == NULL) {
+	    fprintf(stderr, "Thread %d: out of memory\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* fseek exiting the for loop has file cursor propertly */
+	if (fseeko(fp, bytesent, SEEK_SET) != 0) {
+	    fprintf(stderr, "Thread %d: fseeko failed\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	//	gettimeofday(&starttime, NULL);
+	if (fread(cvmrecord, 1, bytecount, fp) != (size_t)bytecount) {
+	    fprintf(stderr, "Thread %d: fail to read the last chunk\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+	//	gettimeofday(&endtime, NULL);
+	iotime += (endtime.tv_sec - starttime.tv_sec) * 1000.0
+	    + (endtime.tv_usec - starttime.tv_usec) / 1000.0;
+
+	/*
+	fprintf(stderr, "Procid = %d offset = %qd bytecount = %d\n",
+		Global.myID, (int64_t)bytesent, bytecount);
+	*/
+
+	fclose(fp);
+
+	fprintf(stdout, "Read %s (%.2fMB) in %.2f seconds (%.2fMB/sec)\n",
+		cvm_flatfile, (float)statbuf.st_size / (1 << 20),
+		iotime / 1000,
+		(float)statbuf.st_size / (1 << 20) / (iotime / 1000));
+
+	fprintf(stdout, "Memmove takes %.2f seconds\n",
+		(float)memmovetime / 1000);
+
+    } else {
+	/* wait for my turn till PE(n - 1) tells me to go ahead */
+
+	MPI_Status status;
+
+	MPI_Probe(Global.theGroupSize - 1, CVMRECORD_MSG, comm_solver, &status);
+	MPI_Get_count(&status, MPI_CHAR, &bytecount);
+
+	cvmrecord = (cvmrecord_t *)malloc(bytecount);
+	if (cvmrecord == NULL) {
+	    fprintf(stderr, "Thread %d: out of memory\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	MPI_Recv(cvmrecord, bytecount, MPI_CHAR, Global.theGroupSize - 1,
+		 CVMRECORD_MSG, comm_solver,	 &status);
+
+    }
+
+    /* Every processor should set these parameters correctly */
+    Global.theCVMRecordCount = bytecount / sizeof(cvmrecord_t);
+    if (Global.theCVMRecordCount * sizeof(cvmrecord_t) != (size_t)bytecount) {
+	fprintf(stderr, "Thread %d: received corrupted CVM data\n",
+		Global.myID);
+	MPI_Abort(MPI_COMM_WORLD, ERROR);
+	exit(1);
+    }
+
+    return cvmrecord;
+}
+
+
+static cvmrecord_t *sliceCVM_old(const char *cvm_flatfile)
+{
+    cvmrecord_t *cvmrecord;
+    int32_t bufferedbytes, bytecount, recordcount;
+
+    if (Global.myID == Global.theGroupSize - 1) {
+	/* the last processor reads data and
+	   distribute to other processors*/
+
+	FILE *fp;
+	int fd, procid;
+	struct stat statbuf;
+	void *maxbuf;
+	const point_t *intervaltable;
+	off_t bytesent;
+	int32_t offset;
+	const int maxcount =  (1 << 29) / sizeof(cvmrecord_t);
+	const int maxbufsize = maxcount * sizeof(cvmrecord_t);
+
+	fp = fopen(cvm_flatfile, "r");
+	if (fp == NULL) {
+	    fprintf(stderr, "Thread %d: Cannot open flat CVM file\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	fd = fileno(fp);
+	if (fstat(fd, &statbuf) != 0) {
+	    fprintf(stderr, "Thread %d: Cannot get the status of CVM file\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	intervaltable = octor_getintervaltable(Global.myOctree);
+	/*
+	for (procid = 0; procid <= Global.myID; procid++) {
+	    fprintf(stderr, "interval[%d] = {%d, %d, %d}\n", procid,
+		    intervaltable[procid].x << 1, intervaltable[procid].y << 1,
+		    intervaltable[procid].z << 1);
+	}
+	*/
+
+	bytesent = 0;
+	maxbuf = malloc(maxbufsize) ;
+	if (maxbuf == NULL) {
+	    fprintf(stderr, "Thread %d: Cannot allocate send buffer\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* Try to read max number of CVM records as allowed */
+	recordcount = fread(maxbuf, sizeof(cvmrecord_t),
+			    maxbufsize / sizeof(cvmrecord_t), fp);
+
+	if (recordcount != maxbufsize / sizeof(cvmrecord_t)) {
+	    fprintf(stderr, "Thread %d: Cannot read-init buffer\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* start with proc 0 */
+	procid = 0;
+
+	while (procid < Global.myID) { /* repeatedly fill the buffer */
+	    point_t searchpoint, *point;
+	    int newreads;
+
+	    /* we have recordcount to work with */
+	    cvmrecord = (cvmrecord_t *)maxbuf;
+
+	    while (procid < Global.myID) { /* repeatedly send out data */
+		searchpoint.x = intervaltable[procid + 1].x << 1;
+		searchpoint.y = intervaltable[procid + 1].y << 1;
+		searchpoint.z = intervaltable[procid + 1].z << 1;
+
+		offset = zsearch(cvmrecord, recordcount, Global.theCVMRecordSize,
+				 &searchpoint);
+
+		point = (point_t *)(cvmrecord + offset);
+
+		if ((point->x != searchpoint.x) ||
+		    (point->y != searchpoint.y) ||
+		    (point->z != searchpoint.z)) {
+		    break;
+		} else {
+		    bytecount = offset * sizeof(cvmrecord_t);
+		    MPI_Send(cvmrecord, bytecount, MPI_CHAR, procid,
+			     CVMRECORD_MSG, comm_solver);
+		    /*
+		    fprintf(stderr,
+			    "Procid = %d offset = %qd bytecount = %d\n",
+			    procid, (int64_t)bytesent, bytecount);
+		    */
+
+		    bytesent += bytecount;
+
+		    /* prepare for the next processor */
+		    recordcount -= offset;
+		    cvmrecord = (cvmrecord_t *)point;
+		    procid++;
+		}
+	    }
+
+	    /* Move residual data to the beginning of the buffer
+	       and try to fill the newly free space */
+	    bufferedbytes = sizeof(cvmrecord_t) * recordcount;
+	    memmove(maxbuf, cvmrecord, bufferedbytes);
+	    newreads = fread((char *)maxbuf + bufferedbytes,
+			     sizeof(cvmrecord_t), maxcount - recordcount, fp);
+	    recordcount += newreads;
+
+	    if (newreads == 0)
+		break;
+	}
+
+	free(maxbuf);
+
+	/* I am supposed to accomodate the remaining octants */
+	bytecount = statbuf.st_size - bytesent;
+
+	cvmrecord = (cvmrecord_t *)malloc(bytecount);
+	if (cvmrecord == NULL) {
+	    fprintf(stderr, "Thread %d: out of memory for %d bytes\n",
+		    Global.myID, bytecount);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* fseek exiting the for loop has file cursor propertly */
+	if (fseeko(fp, bytesent, SEEK_SET) != 0) {
+	    fprintf(stderr, "Thread %d: fseeko failed\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	if (fread(cvmrecord, 1, bytecount, fp) != (size_t)bytecount) {
+	    fprintf(stderr, "Thread %d: fail to read the last chunk\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/*
+	  fprintf(stderr, "Procid = %d offset = %qd bytecount = %d\n",
+	  Global.myID, (int64_t)bytesent, bytecount);
+	*/
+
+	fclose(fp);
+
+    } else {
+	/* wait for my turn till PE(n - 1) tells me to go ahead */
+
+	MPI_Status status;
+
+	MPI_Probe(Global.theGroupSize - 1, CVMRECORD_MSG, comm_solver, &status);
+	MPI_Get_count(&status, MPI_CHAR, &bytecount);
+
+	cvmrecord = (cvmrecord_t *)malloc(bytecount);
+	if (cvmrecord == NULL) {
+	    fprintf(stderr, "Thread %d: out of memory\n", Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	MPI_Recv(cvmrecord, bytecount, MPI_CHAR, Global.theGroupSize - 1,
+		 CVMRECORD_MSG, comm_solver,	 &status);
+
+    }
+
+    /* Every processor should set these parameters correctly */
+    Global.theCVMRecordCount = bytecount / sizeof(cvmrecord_t);
+    if (Global.theCVMRecordCount * sizeof(cvmrecord_t) != (size_t)bytecount) {
+	fprintf(stderr, "Thread %d: received corrupted CVM data\n",
+		Global.myID);
+	MPI_Abort(MPI_COMM_WORLD, ERROR);
+	exit(1);
+    }
+
+    return cvmrecord;
+}
+
+
+
+/**
+ * setrec: Search the CVM record array to obtain the material property of
+ *	   a leaf octant.
+ *
+ */
+void setrec(octant_t *leaf, double ticksize, void *data)
+{
+    cvmrecord_t *agghit;
+    edata_t *edata;
+    etree_tick_t x, y, z;
+    etree_tick_t halfticks;
+    point_t searchpoint;
+
+    edata = (edata_t *)data;
+
+    halfticks = (tick_t)1 << (PIXELLEVEL - leaf->level - 1);
+
+    edata->edgesize = ticksize * halfticks * 2;
+
+    searchpoint.x = x = leaf->lx + halfticks;
+    searchpoint.y = y = leaf->ly + halfticks;
+    searchpoint.z = z = leaf->lz + halfticks;
+
+    if ((x * ticksize >= Param.theDomainX) ||
+	(y * ticksize >= Param.theDomainY) ||
+	(z * ticksize >= Param.theDomainZ)) {
+	/* Center point out the bound. Set Vs to force split */
+	edata->Vs = Param.theFactor * edata->edgesize / 2;
+    } else {
+	int offset;
+
+	/* map the coordinate from the octor address space to the
+	   etree address space */
+	searchpoint.x = x << 1;
+	searchpoint.y = y << 1;
+	searchpoint.z = z << 1;
+
+	/* Inbound */
+	offset = zsearch(Global.theCVMRecord, Global.theCVMRecordCount, Global.theCVMRecordSize,
+			 &searchpoint);
+	if (offset < 0) {
+	    fprintf(stderr, "setrec: fatal error\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	agghit = Global.theCVMRecord + offset;
+	edata->Vs = agghit->Vs;
+	edata->Vp = agghit->Vp;
+	edata->rho = agghit->density;
+
+	/* Adjust the Vs */
+	edata->Vs = (edata->Vs < Param.theVsCut) ? Param.theVsCut : edata->Vs;
+    }
+
+    return;
+}
+#endif	/* USECVMDB */
+
+
+/**
+ * mesh_generate: Generate and partition an unstructured octree mesh.
+ *
+ */
+static void
+mesh_generate()
+{
+
+    int mstep, step = 1;
+    double originalFactor = Param.theFactor;
+    double ppwl = Param.theFactor / Param.theFreq;
+    double prevtref = 0, prevtbal = 0, prevtpar = 0;
+    int64_t tote, mine, maxe;
+
+    if (Global.myID == 0) {
+        fprintf(stdout, "Meshing: ");
+        if (Param.theStepMeshingFactor == 0) {
+            fprintf(stdout, "Conventional\n\n");
+        } else {
+            fprintf(stdout, "Progressive\n\n");
+        }
+        fprintf(stdout, "Stage %14s Min %7s Max %5s Total    Time(s)","","","");
+        if (Param.theStepMeshingFactor == 0) {
+            fprintf(stdout, "\n\n");
+        } else {
+            fprintf(stdout, "   Step  f(Hz)\n\n");
+        }
+    }
+
+    /*----  Generate and partition an unstructured octree mesh ----*/
+    MPI_Barrier(comm_solver);
+    Timer_Start("Octor Newtree");
+    if (Global.myID == 0) {
+        fprintf(stdout, "New tree %41s","");
+    }
+    Global.myOctree = octor_newtree( Param.theDomainX, Param.theDomainY, Param.theDomainZ,
+            sizeof(edata_t), Global.myID, Global.theGroupSize,
+            comm_solver, get_surface_shift());
+
+    /* NOTE:
+     * If you want to see the carving process, replace by:
+     *     Global.myOctree = octor_newtree(
+     *             Param.theDomainX, Param.theDomainY, Param.theDomainZ,
+     *             sizeof(edata_t), Global.myID, Global.theGroupSize,
+     *             comm_solver, 0);
+     */
+
+    if (Global.myOctree == NULL) {
+        fprintf(stderr, "Thread %d: mesh_generate: fail to create octree\n",
+                Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+    MPI_Barrier(comm_solver);
+    Timer_Stop("Octor Newtree");
+    if (Global.myID == 0) {
+        fprintf(stdout, "%9.2f\n\n", Timer_Value("Octor Newtree", (TimerKind)0) );
+    }
+
+    /* Essential for DRM implementation */
+    if (Param.drmImplement == YES) {
+        drm_fix_coordinates(Global.myOctree->ticksize);
+    }
+
+#ifdef USECVMDB
+    Global.theCVMQueryStage = 0; /* Query CVM database to refine the mesh */
+#else
+     /* Use flat data record file and distibute the data in memories */
+    if (Global.myID == 0) {
+	fprintf(stdout, "slicing CVMDB ...");
+    }
+    Timer_Start("Slice CVM");
+    Global.theCVMRecord = sliceCVM(Param.theCVMFlatFile);
+    MPI_Barrier(comm_solver);
+    Timer_Stop("Slice CVM");
+    if (Global.theCVMRecord == NULL) {
+	fprintf(stderr, "Thread %d: Error obtaining the CVM records from %s\n",
+		Global.myID, Param.theCVMFlatFile);
+	MPI_Abort(MPI_COMM_WORLD, ERROR);
+	exit(1);
+    };
+    if (Global.myID == 0) {
+	fprintf(stdout, "done : %9.2f seconds\n", Timer_Value("Slice CVM", (TimerKind)0));
+    }
+#endif
+
+    for ( mstep = Param.theStepMeshingFactor; mstep >= 0; mstep-- ) {
+
+        double myFactor = (double)(1 << mstep); // 2^mstep
+        Param.theFactor = originalFactor / myFactor;
+
+        /* Refinement */
+        Timer_Start("Octor Refinetree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "Refining     ");
+            fflush(stdout);
+        }
+        if (octor_refinetree(Global.myOctree, toexpand, setrec) != 0) {
+            fprintf(stderr, "Thread %d: mesh_generate: fail to refine octree\n",Global.myID);
+            MPI_Abort(MPI_COMM_WORLD, ERROR); exit(1);
+        }
+        MPI_Barrier(comm_solver);
+        tote = octor_getleavescount(Global.myOctree, GLOBAL);
+        mine = octor_getminleavescount(Global.myOctree, GLOBAL);
+        maxe = octor_getmaxleavescount(Global.myOctree, GLOBAL);
+        if (Global.myID == 0) {
+            fprintf(stdout, "%11"INT64_FMT" %11"INT64_FMT" %11"INT64_FMT, mine, maxe, tote);
+            fflush(stdout);
+        }
+        Timer_Stop("Octor Refinetree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "%11.2f", Timer_Value("Octor Refinetree", (TimerKind)0) - prevtref);
+            if (Param.theStepMeshingFactor == 0 ) {
+                fprintf(stdout, "\n");
+            } else {
+                fprintf(stdout, "   %4d %6.2f\n", step, Param.theFactor/ppwl);
+            }
+            prevtref = Timer_Value("Octor Refinetree", (TimerKind)0);
+            fflush(stdout);
+        }
+
+        /* Balancing */
+        Timer_Start("Octor Balancetree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "Balancing    ");
+            fflush(stdout);
+        }
+        if (octor_balancetree(Global.myOctree, setrec, Param.theStepMeshingFactor) != 0) {
+            fprintf(stderr, "Thread %d: mesh_generate: fail to balance octree\n",Global.myID);
+            MPI_Abort(MPI_COMM_WORLD, ERROR); exit(1);
+        }
+        MPI_Barrier(comm_solver);
+        tote = octor_getleavescount(Global.myOctree, GLOBAL);
+        mine = octor_getminleavescount(Global.myOctree, GLOBAL);
+        maxe = octor_getmaxleavescount(Global.myOctree, GLOBAL);
+        if (Global.myID == 0) {
+            fprintf(stdout, "%11"INT64_FMT" %11"INT64_FMT" %11"INT64_FMT, mine, maxe, tote);
+            fflush(stdout);
+        }
+        Timer_Stop("Octor Balancetree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "%11.2f\n", Timer_Value("Octor Balancetree", (TimerKind)0) - prevtbal);
+            prevtbal = Timer_Value("Octor Balancetree", (TimerKind)0);
+            fflush(stdout);
+        }
+
+        /* Partitioning */
+        Timer_Start("Octor Partitiontree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "Partitioning ");
+            fflush(stdout);
+        }
+        if (octor_partitiontree(Global.myOctree, bldgs_nodesearch) != 0) {
+            fprintf(stderr, "Thread %d: mesh_generate: fail to balance load\n",Global.myID);
+            MPI_Abort(MPI_COMM_WORLD, ERROR); exit(1);
+        }
+        MPI_Barrier(comm_solver);
+        tote = octor_getleavescount(Global.myOctree, GLOBAL);
+        mine = octor_getminleavescount(Global.myOctree, GLOBAL);
+        maxe = octor_getmaxleavescount(Global.myOctree, GLOBAL);
+        if (Global.myID == 0) {
+            fprintf(stdout, "%11"INT64_FMT" %11"INT64_FMT" %11"INT64_FMT, mine, maxe, tote);
+            fflush(stdout);
+        }
+        Timer_Stop("Octor Partitiontree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "%11.2f\n\n", Timer_Value("Octor Partitiontree", (TimerKind)0) - prevtpar);
+            prevtpar = Timer_Value("Octor Partitiontree", (TimerKind)0);
+            fflush(stdout);
+        }
+
+        step++;
+        fflush(stdout);
+        MPI_Barrier(comm_solver);
+    }
+
+    /* Buildings Carving */
+    if ( Param.includeBuildings == YES ) {
+
+        Timer_Start("Carve Buildings");
+        if (Global.myID == 0) {
+            fprintf(stdout, "Carving buildings");
+            fflush(stdout);
+        }
+
+        /* NOTE: If you want to see the carving process, comment next line */
+        octor_carvebuildings(Global.myOctree, 1, bldgs_nodesearch);
+        MPI_Barrier(comm_solver);
+        Timer_Stop("Carve Buildings");
+        if (Global.myID == 0) {
+	  fprintf(stdout, "%9.2f\n", Timer_Value("Carve Buildings", (TimerKind)0) );
+            fflush(stdout);
+        }
+
+        Timer_Start("Octor Partitiontree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "Repartitioning");
+            fflush(stdout);
+        }
+        if (octor_partitiontree(Global.myOctree, bldgs_nodesearch) != 0) {
+            fprintf(stderr, "Thread %d: mesh_generate: fail to balance load\n",
+                    Global.myID);
+            MPI_Abort(MPI_COMM_WORLD, ERROR);
+            exit(1);
+        }
+        MPI_Barrier(comm_solver);
+        Timer_Stop("Octor Partitiontree");
+        if (Global.myID == 0) {
+            fprintf(stdout, "%9.2f\n", Timer_Value("Octor Partitiontree", (TimerKind)0));
+            fflush(stdout);
+        }
+    }
+
+    if ( Global.myID == 0 && Param.theStepMeshingFactor !=0 ) {
+        fprintf(stdout, "Total refine    %33s %9.2f\n", "", Timer_Value("Octor Refinetree", (TimerKind)0));
+        fprintf(stdout, "Total balance   %33s %9.2f\n", "", Timer_Value("Octor Balancetree", (TimerKind)0));
+        fprintf(stdout, "Total partition %33s %9.2f\n\n", "", Timer_Value("Octor Partitiontree", (TimerKind)0));
+        fflush(stdout);
+    }
+
+    Timer_Start("Octor Extractmesh");
+    if (Global.myID == 0) {
+        fprintf(stdout, "Extracting the mesh %30s","");
+        fflush(stdout);
+    }
+    Global.myMesh = octor_extractmesh(Global.myOctree, bldgs_nodesearch);
+    if (Global.myMesh == NULL) {
+        fprintf(stderr, "Thread %d: mesh_generate: fail to extract mesh\n",
+                Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+    MPI_Barrier(comm_solver);
+    Timer_Stop("Octor Extractmesh");
+    if (Global.myID == 0) {
+        fprintf(stdout, "%9.2f\n", Timer_Value("Octor Partitiontree", (TimerKind)0));
+    }
+
+    Timer_Start( "Mesh correct properties" );
+    /* Re-populates the mesh with actual values from the CVM-etree */
+    if (Global.myID == 0) {
+        fprintf(stdout,"Correcting mesh properties %23s","");
+        fflush(stdout);
+    }
+
+    mesh_correct_properties( Global.theCVMEp );
+
+    MPI_Barrier( comm_solver );
+    Timer_Stop( "Mesh correct properties" );
+    if (Global.myID == 0) {
+        fprintf(stdout, "%9.2f\n\n",Timer_Value( "Mesh correct properties", (TimerKind)0 ) );
+        fflush(stdout);
+    }
+
+#ifdef USECVMDB
+    /* Close the material database */
+    etree_close(Global.theCVMEp);
+#else
+    free(Global.theCVMRecord);
+#endif /* USECVMDB */
+}
+
+
+/**
+ * toexpand: Instruct the Octor library whether a leaf octant needs to
+ *	     be expanded or not. Return 1 if true, 0 otherwise.
+ *
+ */
+static int32_t
+toexpand(octant_t *leaf, double ticksize, const void *data) {
+
+	if ( data == NULL ) {
+		return 1;
+	}
+
+	int      res;
+	edata_t *edata = (edata_t *)data;
+
+	if ( Param.includeBuildings == YES ) {
+		res = bldgs_toexpand( leaf, ticksize, edata, Param.theFactor );
+		if ( res != -1 ) {
+			return res;
+		}
+	}
+
+	if ( Param.drmImplement == YES) {
+		//if( Param.drmImplement == YES && Param.theDrmPart != PART1 ) {
+		res = drm_toexpand( leaf, ticksize, edata );
+		if ( res != -1 ) {
+			return res;
+		}
+	}
+
+	return vsrule( edata, Param.theFactor );
+}
+
+/**
+ * bulkload: Append the data to the end of the mesh database. Return 0 if OK,
+ *	     -1 on error.
+ *
+ */
+static int32_t
+bulkload(etree_t *mep, mrecord_t *partTable, int32_t count)
+{
+    int index;
+
+    for (index = 0; index < count; index++) {
+	void *payload = &partTable[index].mdata;
+
+	if (etree_append(mep, partTable[index].addr, payload) != 0) {
+	    /* Append error */
+	    return -1;
+	}
+    }
+
+    return 0;
+}
+
+
+/** Enumeration of the counters used in the mesh statistics */
+enum mesh_stat_count_t {
+    ELEMENT_COUNT, NODE_COUNT, DANGLING_COUNT, HARBORED_COUNT, MESH_COUNT_LENGTH
+};
+
+
+
+static void
+mesh_print_stat_imp( int32_t* st, int group_size, FILE* out )
+{
+    int pid;
+    global_id_t total_count[MESH_COUNT_LENGTH] = { 0, 0, 0, 0 };
+
+    fputs( "\n"
+	   "# ------------------------------------------------------------\n"
+	   "# Mesh statistics:\n"
+	   "# ------------------------------------------------------------\n"
+	   "# Rank    Elements       Nodes     D-nodes     H-nodes\n", out );
+
+    for (pid = 0; pid < group_size; pid++) {
+	fprintf( out, "%06d %11d %11d %11d %11d\n", pid, st[ELEMENT_COUNT],
+		 st[NODE_COUNT], st[DANGLING_COUNT], st[HARBORED_COUNT] );
+
+	/* add to total count */
+	total_count[ELEMENT_COUNT]  += st[ELEMENT_COUNT];
+	total_count[NODE_COUNT]	    += st[NODE_COUNT];
+	total_count[DANGLING_COUNT] += st[DANGLING_COUNT];
+	total_count[HARBORED_COUNT] += st[HARBORED_COUNT];
+
+	st += MESH_COUNT_LENGTH;	/* move to next row */
+    }
+
+    fputs( "\n\n"
+	    "# ------------------------------------------------------------\n"
+	   "# Total\n"
+	   "# ------------------------------------------------------------\n",
+	   out );
+
+    fprintf( out, "       %11"INT64_FMT" %11"INT64_FMT" %11"INT64_FMT
+	     " %11"INT64_FMT"\n\n",
+	     total_count[ELEMENT_COUNT], total_count[NODE_COUNT],
+	     total_count[DANGLING_COUNT], total_count[HARBORED_COUNT] );
+
+    /* copy totals to static globals */
+    /* TODO this should be computed through different means */
+    Global.theETotal  = total_count[ELEMENT_COUNT];
+    Global.theNTotal  = total_count[NODE_COUNT];
+
+
+    /* output aggregate information to the monitor file / stdout */
+    monitor_print(
+		   "Total elements:                      %11"INT64_FMT"\n"
+		   "Total nodes:                         %11"INT64_FMT"\n"
+		   "Total dangling nodes:                %11"INT64_FMT"\n\n",
+		   total_count[ELEMENT_COUNT], total_count[NODE_COUNT],
+		   total_count[DANGLING_COUNT] );
+}
+
+
+static int
+mesh_collect_print_stats( local_id_t mesh_stat[MESH_COUNT_LENGTH], int my_id,
+			  int group_size, const char* fname )
+{
+    local_id_t* st = NULL;
+
+    if (0 == my_id) { /* only the root node allocates memory */
+	XMALLOC_VAR_N( st, local_id_t, (group_size * MESH_COUNT_LENGTH) );
+    }
+
+    MPI_Gather( mesh_stat, MESH_COUNT_LENGTH, MPI_INT,
+		st,        MESH_COUNT_LENGTH, MPI_INT, 0, comm_solver );
+
+    if (0 == my_id) { /* the root node prints the stats */
+        const size_t bufsize = 1048576;  // 1MB
+	FILE* out = hu_fopen( Param.theMeshStatFilename, "w" );
+
+	setvbuf( out, NULL, _IOFBF, bufsize );
+	mesh_print_stat_imp( st, group_size, out );
+	hu_fclosep( &out );
+	xfree_int32_t( &st );
+    }
+
+    return 0;
+}
+
+
+static void
+mesh_printstat_imp( const mesh_t* mesh, int my_id, int group_size,
+		    const char* fname )
+{
+    local_id_t mesh_stat[MESH_COUNT_LENGTH];
+
+    mesh_stat[ ELEMENT_COUNT  ] = mesh->lenum;
+    mesh_stat[ NODE_COUNT     ] = mesh->lnnum;
+    mesh_stat[ DANGLING_COUNT ] = mesh->ldnnum;
+    mesh_stat[ HARBORED_COUNT ] = mesh->nharbored;
+
+    mesh_collect_print_stats( mesh_stat, my_id, group_size, fname );
+}
+
+
+/**
+ * Gather and print mesh statistics to a file with the given name.
+ *
+ * \param fname Name of the file where the statistics should be stored.
+ */
+static void
+mesh_print_stat( const octree_t* oct, const mesh_t* mesh, int my_id,
+		 int group_size, const char* fname )
+{
+    /* collective function calls */
+    int32_t gmin = octor_getminleaflevel( oct, GLOBAL );
+    int32_t gmax = octor_getmaxleaflevel( oct, GLOBAL );
+
+    mesh_printstat_imp( mesh, my_id, group_size, fname );
+
+    if (Global.myID == 0) {
+	monitor_print( "Maximum leaf level = %d\n", gmax );
+	monitor_print( "Minimum leaf level = %d\n", gmin );
+    }
+}
+
+
+/**
+ * Join elements and nodes, and send to Thread 0 for output.
+ */
+static void
+mesh_output()
+{
+    int32_t eindex;
+    int32_t remains, batch, batchlimit, idx;
+    mrecord_t *partTable;
+
+    Timer_Start("Mesh Out");
+
+    batchlimit = BATCH;
+
+    /* Allocate a fixed size buffer space to store the join results */
+    partTable = (mrecord_t *)calloc(batchlimit, sizeof(mrecord_t));
+    if (partTable == NULL) {
+	fprintf(stderr,	 "Thread %d: mesh_output: out of memory\n", Global.myID);
+	MPI_Abort(MPI_COMM_WORLD, ERROR);
+	exit(1);
+    }
+
+    if (Global.myID == 0) {
+	etree_t *mep;
+	int32_t procid;
+
+	printf("mesh_output ... ");
+
+	mep = etree_open(Param.mesh_etree_output_file, O_CREAT|O_RDWR|O_TRUNC, 0,
+			 sizeof(mdata_t),3);
+	if (mep == NULL) {
+	    fprintf(stderr, "Thread 0: mesh_output: ");
+	    fprintf(stderr, "cannot create mesh etree\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	/* Begin an appending operation */
+	if (etree_beginappend(mep, 1) != 0) {
+	    fprintf(stderr, "Thread 0: mesh_output: \n");
+	    fprintf(stderr, "cannot begin an append operation\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	eindex = 0;
+	while (eindex < Global.myMesh->lenum) {
+	    remains = Global.myMesh->lenum - eindex;
+	    batch = (remains < batchlimit) ? remains : batchlimit;
+
+	    for (idx = 0; idx < batch; idx++) {
+		mrecord_t *mrecord;
+		int32_t whichnode;
+		int32_t localnid0;
+
+		mrecord = &partTable[idx];
+
+		/* Fill the address field */
+		localnid0 = Global.myMesh->elemTable[eindex].lnid[0];
+
+		mrecord->addr.x = Global.myMesh->nodeTable[localnid0].x;
+		mrecord->addr.y = Global.myMesh->nodeTable[localnid0].y;
+		mrecord->addr.z = Global.myMesh->nodeTable[localnid0].z;
+		mrecord->addr.level = Global.myMesh->elemTable[eindex].level;
+		mrecord->addr.type = ETREE_LEAF;
+
+		/* Find the global node ids for the vertices */
+		for (whichnode = 0; whichnode < 8; whichnode++) {
+		    int32_t localnid;
+		    int64_t globalnid;
+
+		    localnid = Global.myMesh->elemTable[eindex].lnid[whichnode];
+		    globalnid = Global.myMesh->nodeTable[localnid].gnid;
+
+		    mrecord->mdata.nid[whichnode] = globalnid;
+		}
+
+		/* data points to mdata_t type */
+		memcpy(&mrecord->mdata.edgesize,
+		       Global.myMesh->elemTable[eindex].data,
+		       sizeof(edata_t));
+
+		eindex++;
+	    } /* for a batch */
+
+	    if (bulkload(mep, partTable, batch) != 0) {
+		fprintf(stderr, "Thread 0: mesh_output: ");
+		fprintf(stderr, "error bulk-loading data\n");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+	} /* for all the elements Thread 0 has */
+
+	/* Receive data from other processors */
+	for (procid = 1; procid < Global.theGroupSize; procid++) {
+	    MPI_Status status;
+	    int32_t rcvbytecount;
+
+	    /* Signal the next processor to go ahead */
+	    MPI_Send(NULL, 0, MPI_CHAR, procid, GOAHEAD_MSG, comm_solver);
+
+	    while (1) {
+		MPI_Probe(procid, MESH_MSG, comm_solver, &status);
+		MPI_Get_count(&status, MPI_CHAR, &rcvbytecount);
+
+		batch = rcvbytecount / sizeof(mrecord_t);
+
+		MPI_Recv(partTable, rcvbytecount, MPI_CHAR, procid,
+			 MESH_MSG, comm_solver, &status);
+
+		if (batch == 0) {
+		    /* Done */
+		    break;
+		}
+
+		if (bulkload(mep, partTable, batch) != 0) {
+		    fprintf(stderr, "Thread 0: mesh_output: ");
+		    fprintf(stderr, "cannot bulkloading data from ");
+		    fprintf(stderr, "Thread %d\n", procid);
+		    MPI_Abort(MPI_COMM_WORLD, ERROR);
+		    exit(1);
+		}
+	    } /* while there is more data to be received from procid */
+	} /* for all the processors */
+
+	/* End the appending operation */
+	etree_endappend(mep);
+
+	/* Close the mep to ensure the data is on disk */
+	if (etree_close(mep) != 0) {
+	    fprintf(stderr, "Thread 0: mesh_output ");
+	    fprintf(stderr, "error closing the etree database\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+    } else {
+	/* Processors other than 0 needs to send data to 0 */
+	int32_t sndbytecount;
+	MPI_Status status;
+
+	/* Wait for me turn */
+	MPI_Recv(NULL, 0, MPI_CHAR, 0, GOAHEAD_MSG, comm_solver, &status);
+
+	eindex = 0;
+	while (eindex < Global.myMesh->lenum) {
+	    remains = Global.myMesh->lenum - eindex;
+	    batch = (remains < batchlimit) ? remains : batchlimit;
+
+	    for (idx = 0; idx < batch; idx++) {
+		mrecord_t *mrecord;
+		int32_t whichnode;
+		int32_t localnid0;
+
+		mrecord = &partTable[idx];
+
+		/* Fill the address field */
+		localnid0 = Global.myMesh->elemTable[eindex].lnid[0];
+
+		mrecord->addr.x = Global.myMesh->nodeTable[localnid0].x;
+		mrecord->addr.y = Global.myMesh->nodeTable[localnid0].y;
+		mrecord->addr.z = Global.myMesh->nodeTable[localnid0].z;
+		mrecord->addr.level = Global.myMesh->elemTable[eindex].level;
+		mrecord->addr.type = ETREE_LEAF;
+
+		/* Find the global node ids for the vertices */
+		for (whichnode = 0; whichnode < 8; whichnode++) {
+		    int32_t localnid;
+		    int64_t globalnid;
+
+		    localnid = Global.myMesh->elemTable[eindex].lnid[whichnode];
+		    globalnid = Global.myMesh->nodeTable[localnid].gnid;
+
+		    mrecord->mdata.nid[whichnode] = globalnid;
+		}
+
+		memcpy(&mrecord->mdata.edgesize,
+		       Global.myMesh->elemTable[eindex].data,
+		       sizeof(edata_t));
+
+		eindex++;
+	    } /* for a batch */
+
+
+	    /* Send data to proc 0 */
+	    sndbytecount = batch * sizeof(mrecord_t);
+	    MPI_Send(partTable, sndbytecount, MPI_CHAR, 0, MESH_MSG,
+		     comm_solver);
+	} /* While there is data left to be sent */
+
+	/* Send an empty message to indicate the end of my transfer */
+	MPI_Send(NULL, 0, MPI_CHAR, 0, MESH_MSG, comm_solver);
+    }
+
+    /* Free the memory for the partial join results */
+    free(partTable);
+
+    Timer_Stop("Mesh Out");
+
+    if (Global.myID == 0) {
+	printf("done : %9.2f seconds\n", Timer_Value("Mesh Out", (TimerKind)0) );
+    }
+
+    return;
+}
+
+
+/*-----------Computation routines ------------------------------*/
+
+/*
+   Macros to facitilate computation
+
+   INTEGRAL_1: Integral_Delfixl_Delfjxl()
+   INTEGRAL_2: Integral_Delfixl_Delfjxm()
+ */
+
+#define INTEGRAL_1(xki, xkj, xli, xlj, xmi, xmj) \
+(4.5 * xki * xkj * (1 + xli * xlj / 3) * (1 + xmi * xmj / 3) / 8)
+
+#define INTEGRAL_2(xki, xlj, xmi, xmj) \
+(4.5 * xki * xlj * (1 + xmi * xmj / 3) / 8)
+
+#define DS_TOTAL_INTERVALS	    40
+#define DS_TOTAL_PARAMETERS	     6
+
+/**
+ * Compute histograms for xi, zeta and associated values to understand
+ * what is happenning with those parameters involved the damping and
+ * delta T.
+ */
+static void
+damping_statistics (
+	double min_xi,
+	double max_xi,
+	double min_zeta,
+	double max_zeta,
+	double min_VsVp,
+	double max_VsVp,
+	double min_VpVsZ,
+	double max_VpVsZ,
+	double min_Vs,
+	double max_Vs
+	)
+{
+    static const int totalintervals  = DS_TOTAL_INTERVALS;
+    static const int totalparameters = DS_TOTAL_PARAMETERS;
+
+    int interval, parameter, row, col, matrixelements;
+
+    double  min_VpVs, max_VpVs;
+
+    double  themins[DS_TOTAL_PARAMETERS],
+	    themaxs[DS_TOTAL_PARAMETERS],
+	    spacing[DS_TOTAL_PARAMETERS];
+
+    int32_t counters[DS_TOTAL_PARAMETERS][DS_TOTAL_INTERVALS],
+	    global_counter[DS_TOTAL_PARAMETERS][DS_TOTAL_INTERVALS],
+	    global_total[DS_TOTAL_PARAMETERS],
+	    eindex;
+
+    /* Initializing clue values and variables */
+
+    min_VpVs = 1 / max_VsVp;
+    max_VpVs = 1 / min_VsVp;
+
+    themins[0] = min_zeta;
+    themins[1] = min_xi;
+    themins[2] = min_VsVp;
+    themins[3] = min_VpVs;
+    themins[4] = min_VpVsZ;
+    themins[5] = min_Vs;
+
+    themaxs[0] = max_zeta;
+    themaxs[1] = max_xi;
+    themaxs[2] = max_VsVp;
+    themaxs[3] = max_VpVs;
+    themaxs[4] = max_VpVsZ;
+    themaxs[5] = max_Vs;
+
+    for ( row = 0; row < totalparameters; row++ )
+    {
+	for ( col = 0; col < totalintervals; col++ )
+	{
+	    counters[row][col] = 0;
+	}
+	global_total[row] = 0;
+    }
+
+    for ( row = 0; row < totalparameters; row++ )
+    {
+	spacing[row] = ( themaxs[row] - themins[row] ) / totalintervals;
+    }
+
+    /* loop over the elements */
+    for ( eindex = 0; eindex < Global.myMesh->lenum; eindex++)
+    {
+	/* loop variables */
+	elem_t	*elemp;
+	edata_t *edata;
+	double	 a, b,
+		 omega,
+		 elementvalues[6];
+
+	/* capturing the elements */
+	elemp = &Global.myMesh->elemTable[eindex];
+	edata = (edata_t *)elemp->data;
+
+	/* the parameteres */
+	elementvalues[0] = 10 / edata->Vs;
+	  /* (edata->Vs < 1500) ? 25 / edata->Vs : 5 / edata->Vs; */
+	  /* zeta */
+	omega = 3.46410161514 / ( edata->edgesize / edata->Vp );     /* freq in rad */
+	a = elementvalues[0] * Global.theABase;			    /* a     */
+	b = elementvalues[0] * Global.theBBase;			    /* b     */
+	elementvalues[1] = ( a / (2 * omega)) + ( b * omega / 2 );  /* xi    */
+	elementvalues[2] = ( edata->Vs / edata->Vp);		    /* Vs/Vp */
+	elementvalues[3] = edata->Vp / edata->Vs;		    /* Vp/Vs */
+	elementvalues[4] = elementvalues[0] * ( edata->Vp / edata->Vs );
+	/* Vp/Vs*zeta  */
+	elementvalues[5] = edata->Vs;				    /* Vs    */
+
+	/* loop over the parameters */
+	for ( parameter = 0; parameter < totalparameters; parameter++ )
+	{
+	    /* loop over each interval */
+	    for ( interval = 0; interval < totalintervals; interval++)
+	    {
+		/* loop variables */
+		double liminf, limsup;
+
+		/* histogram limits */
+		liminf = themins[parameter] + (interval * spacing[parameter]);
+		limsup = liminf + spacing[parameter];
+
+		/* for the last interval adjust to the max value */
+		if ( interval == totalintervals-1 )
+		{
+		    limsup = themaxs[parameter];
+		}
+
+		/* counting elements within the interval */
+		if ( ( elementvalues[parameter] >  liminf ) &&
+		     ( elementvalues[parameter] <= limsup ) )
+		{
+		    counters[parameter][interval]++;
+		}
+	    } /* ends loop on intervals */
+	} /* ends loop on parameters */
+    } /*ends loop on elements */
+
+    /* add all counting results from each processor */
+    matrixelements = totalparameters * totalintervals;
+    MPI_Reduce (&counters[0][0], &global_counter[0][0], matrixelements,
+		MPI_INT, MPI_SUM, 0, comm_solver);
+    MPI_Bcast (&global_counter[0][0], matrixelements, MPI_INT,0,comm_solver);
+
+    /* sums the total of elements for each histogram */
+    if (Global.myID == 0)
+    {
+	for ( parameter = 0; parameter < totalparameters; parameter++)
+	{
+	    global_counter[parameter][0]++;
+	    for ( interval = 0; interval < totalintervals; interval++)
+	    {
+		global_total[parameter] = global_total[parameter]
+		    + global_counter[parameter][interval];
+	    }
+	}
+    }
+
+    /* MPI Barrier */
+    MPI_Barrier( comm_solver );
+
+    /* prints to the terminal the histograms */
+    if (Global.myID == 0)
+    {
+	/* header to identify each column */
+	printf("\n\n\tThe histograms of the following parameters: \n\n");
+	printf("\t 1. Zeta\n");
+	printf("\t 2. Xi\n");
+	printf("\t 3. Vs/Vp\n");
+	printf("\t 4. Vp/Vs\n");
+	printf("\t 5. Vp/Vs*zeta\n");
+	printf("\t 6. Vs\n\n");
+	printf("\tAre given in the following table\n");
+	printf("\t(each column is one of the parameters)\n\n\t");
+
+	/* printing the histograms */
+	for ( interval = 0; interval < totalintervals; interval++)
+	{
+	    for ( parameter = 0; parameter < totalparameters; parameter++)
+	    {
+		printf("%12d",global_counter[parameter][interval]);
+	    }
+	    printf("\n\t");
+	}
+
+	/* prints the total of elements for each column */
+	printf("\n\tTotals:\n\n\t");
+	for ( parameter = 0; parameter < totalparameters; parameter++)
+	{
+	    printf("%12d",global_total[parameter]);
+	}
+
+	/* prints the interval witdth */
+	printf("\n\n\tAnd the intervals width is:");
+	for ( parameter = 0; parameter < totalparameters; parameter++)
+	{
+	    printf("\n\t %2d. %.6f ",parameter+1,spacing[parameter]);
+	}
+	printf ("\n\n");
+	fflush (stdout);
+    }
+
+    return;
+} /* end damping_statistics */
+
+
+/**
+ * Determine the limit values associated with the damping and delta_t problem.
+ */
+static void solver_set_critical_T()
+{
+    int32_t eindex;			/* element index	 */
+
+    double  min_h_over_Vp = 1e32;	/* the min h/Vp group	 */
+    double  min_h_over_Vp_global;
+    int32_t min_h_over_Vp_elem_index = -1;
+
+    double  min_dt_factor_X = 1e32;	/* the min delta_t group */
+    double  min_dt_factor_Z = 1e32,
+	    min_dt_factor_X_global,
+	    min_dt_factor_Z_global;
+    int32_t min_dt_factor_X_elem_index = -1,
+	    min_dt_factor_Z_elem_index = -1;
+
+    double  min_zeta = 1e32;		/* the zeta group	 */
+    double  max_zeta = 0,
+	    min_zeta_global,
+	    max_zeta_global;
+    int32_t min_zeta_elem_index = -1,
+	    max_zeta_elem_index = -1;
+
+    double  min_xi = 1e32;		/* the xi group		 */
+    double  max_xi = 0,
+	    min_xi_global,
+	    max_xi_global;
+    int32_t min_xi_elem_index = -1,
+	    max_xi_elem_index = -1;
+
+    double  min_VsVp = 1e32;		/* the Vs/Vp group	 */
+    double  min_VsVp_global,
+	    max_VsVp = 0,
+	    max_VsVp_global;
+    int32_t min_VsVp_elem_index = -1,
+	    max_VsVp_elem_index = -1;
+
+    double  min_VpVsZ = 1e32;		/* the Vp/Vs group	 */
+    double  min_VpVsZ_global,
+	    max_VpVsZ = 0,
+	    max_VpVsZ_global;
+    int32_t min_VpVsZ_elem_index = -1,
+	    max_VpVsZ_elem_index = -1;
+
+    double  min_Vs = 1e32;		/* the Vs group		 */
+    double  min_Vs_global,
+	    max_Vs = 0,
+	    max_Vs_global;
+    int32_t min_Vs_elem_index = -1,
+	    max_Vs_elem_index = -1;
+
+    /* Find the minima and maxima for all needed coefficients */
+    /* Start loop over the mesh elements */
+    for (eindex = 0; eindex < Global.myMesh->lenum; eindex++)
+    {
+	/* Loop local variables */
+
+	elem_t	*elemp;	      /* pointer to the mesh database		      */
+	edata_t *edata;	      /* pointer to the element data		      */
+
+	double	 ratio;	      /* the h/Vp ratio				      */
+	double	 zeta;	      /* the time domain zeta-damping		      */
+	double	 xi;	      /* the freq domain xi-damping		      */
+	double	 omega;	      /* the element associated freq from w=3.46*Vp/h */
+	double	 a, b;	      /* the same constants we use for C = aM + bK    */
+	double	 dt_factor_X; /* the factor of 0.577(1-xi)*h/Vp		      */
+	double	 dt_factor_Z; /* the factor of 0.577(1-zeta)*h/Vp	      */
+	double	 VsVp;	      /* the quotient Vs/Vp			      */
+	double	 VpVsZ;	      /* the result of Vp / Vs * zeta		      */
+	double	 Vs;	      /* the Vs					      */
+
+	/* Captures the element */
+
+	elemp = &Global.myMesh->elemTable[eindex];
+	edata = (edata_t *)elemp->data;
+
+	/* Calculate the clue quantities */
+
+	ratio	    = edata->edgesize / edata->Vp;
+
+	/* Old formula for damping */
+	/* zeta	       = (edata->Vs < 1500) ? 25 / edata->Vs : 5 / edata->Vs; */
+	/* New formula acording to Graves */
+
+	zeta	    = 10 / edata->Vs;
+
+	omega	    = 3.46410161514 / ratio;
+	a	    = zeta * Global.theABase;
+	b	    = zeta * Global.theBBase;
+	xi	    = ( a / (2 * omega)) + ( b * omega / 2 );
+	dt_factor_X = 0.57735026919 * ( 1 - xi ) * ratio;
+	dt_factor_Z = 0.57735026919 * ( 1 - zeta ) * ratio;
+	VsVp	    = edata->Vs / edata->Vp;
+	VpVsZ	    = zeta * ( edata->Vp / edata->Vs );
+	Vs	    = edata->Vs;
+
+	/* Updating for extreme values */
+
+	/* ratio */
+	if ( ratio < min_h_over_Vp )
+	{
+	    min_h_over_Vp = ratio;
+	    min_h_over_Vp_elem_index = eindex;
+	}
+
+	/* dt_factors */
+	if ( dt_factor_X < min_dt_factor_X )
+	{
+	    min_dt_factor_X = dt_factor_X;
+	    min_dt_factor_X_elem_index = eindex;
+	}
+	if ( dt_factor_Z < min_dt_factor_Z )
+	{
+	    min_dt_factor_Z = dt_factor_Z;
+	    min_dt_factor_Z_elem_index = eindex;
+	}
+
+	/* min_zeta and max_zeta */
+	if ( zeta < min_zeta )
+	{
+	    min_zeta = zeta;
+	    min_zeta_elem_index = eindex;
+	}
+	if ( zeta > max_zeta )
+	{
+	    max_zeta = zeta;
+	    max_zeta_elem_index = eindex;
+	}
+
+	/* min_xi and max_xi */
+	if ( xi < min_xi )
+	{
+	    min_xi = xi;
+	    min_xi_elem_index = eindex;
+	}
+	if ( xi > max_xi )
+	{
+	    max_xi = xi;
+	    max_xi_elem_index = eindex;
+	}
+
+	/* min Vs/Vp */
+	if ( VsVp < min_VsVp )
+	{
+	    min_VsVp = VsVp;
+	    min_VsVp_elem_index = eindex;
+	}
+	if ( VsVp > max_VsVp )
+	{
+	    max_VsVp = VsVp;
+	    max_VsVp_elem_index = eindex;
+	}
+
+	/* min and max VpVsZ */
+	if ( VpVsZ < min_VpVsZ )
+	{
+	    min_VpVsZ = VpVsZ;
+	    min_VpVsZ_elem_index = eindex;
+	}
+	if ( VpVsZ > max_VpVsZ )
+	{
+	    max_VpVsZ = VpVsZ;
+	    max_VpVsZ_elem_index = eindex;
+	}
+
+	/* min Vs */
+	if ( Vs < min_Vs )
+	{
+	    min_Vs = Vs;
+	    min_Vs_elem_index = eindex;
+	}
+	if ( Vs > max_Vs )
+	{
+	    max_Vs = Vs;
+	    max_Vs_elem_index = eindex;
+	}
+
+    } /* End of the loop over the mesh elements */
+
+    /* Reducing to global values */
+    MPI_Reduce(&min_h_over_Vp,	 &min_h_over_Vp_global,	  1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+    if ( Param.theDampingStatisticsFlag == 1 )
+    {
+	MPI_Reduce(&min_dt_factor_X, &min_dt_factor_X_global, 1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+	MPI_Reduce(&min_dt_factor_Z, &min_dt_factor_Z_global, 1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+	MPI_Reduce(&min_zeta,	     &min_zeta_global,	      1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+	MPI_Reduce(&max_zeta,	     &max_zeta_global,	      1, MPI_DOUBLE, MPI_MAX, 0, comm_solver);
+	MPI_Reduce(&min_xi,	     &min_xi_global,	      1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+	MPI_Reduce(&max_xi,	     &max_xi_global,	      1, MPI_DOUBLE, MPI_MAX, 0, comm_solver);
+	MPI_Reduce(&min_VsVp,	     &min_VsVp_global,	      1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+	MPI_Reduce(&max_VsVp,	     &max_VsVp_global,	      1, MPI_DOUBLE, MPI_MAX, 0, comm_solver);
+	MPI_Reduce(&min_VpVsZ,	     &min_VpVsZ_global,	      1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+	MPI_Reduce(&max_VpVsZ,	     &max_VpVsZ_global,	      1, MPI_DOUBLE, MPI_MAX, 0, comm_solver);
+	MPI_Reduce(&min_Vs,	     &min_Vs_global,	      1, MPI_DOUBLE, MPI_MIN, 0, comm_solver);
+	MPI_Reduce(&max_Vs,	     &max_Vs_global,	      1, MPI_DOUBLE, MPI_MAX, 0, comm_solver);
+    }
+
+    /* Inform everyone about the global values */
+    MPI_Bcast(&min_h_over_Vp_global,   1, MPI_DOUBLE, 0, comm_solver);
+    if ( Param.theDampingStatisticsFlag == 1 )
+    {
+	MPI_Bcast(&min_dt_factor_X_global, 1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&min_dt_factor_Z_global, 1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&min_zeta_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&max_zeta_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&min_xi_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&max_xi_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&min_VsVp_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&max_VsVp_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&min_VpVsZ_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&max_VpVsZ_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&min_Vs_global,	   1, MPI_DOUBLE, 0, comm_solver);
+	MPI_Bcast(&max_Vs_global,	   1, MPI_DOUBLE, 0, comm_solver);
+    }
+
+    /* go for damping statistics */
+    if ( Param.theDampingStatisticsFlag == 1 )
+    {
+	damping_statistics(min_xi_global,   max_xi_global,   min_zeta_global,  max_zeta_global,
+			   min_VsVp_global, max_VsVp_global, min_VpVsZ_global, max_VpVsZ_global,
+			   min_Vs_global,   max_Vs_global);
+    }
+
+    /* Static global variable for the critical delta t */
+    Global.theCriticalT = min_h_over_Vp_global;
+
+    /* Printing of information */
+    MPI_Barrier( comm_solver );
+    if (Global.myID == 0)
+    {
+	if ( Param.theDampingStatisticsFlag == 1 )
+	{
+	    printf("\n\n Critical delta t related information: \n\n");
+	    printf("\t 1. The minimum h/Vp	   = %.6f \n", min_h_over_Vp_global);
+	    printf("\t 2. The minimum dt X	   = %.6f \n", min_dt_factor_X_global);
+	    printf("\t 3. The minimum dt Z	   = %.6f \n", min_dt_factor_Z_global);
+	    printf("\t 4. The minimum zeta	   = %.6f \n", min_zeta_global);
+	    printf("\t 5. The maximum zeta	   = %.6f \n", max_zeta_global);
+	    printf("\t 6. The minimum xi	   = %.6f \n", min_xi_global);
+	    printf("\t 7. The maximum xi	   = %.6f \n", max_xi_global);
+	    printf("\t 8. The minimum Vs/Vp	   = %.6f \n", min_VsVp_global);
+	    printf("\t 9. The maximum Vs/Vp	   = %.6f \n", max_VsVp_global);
+	    printf("\t10. The minimum (Vp/Vs)*zeta = %.6f \n", min_VpVsZ_global);
+	    printf("\t11. The maximum (Vp/Vs)*zeta = %.6f \n", max_VpVsZ_global);
+	    printf("\t12. The minimum Vs	   = %.6f \n", min_Vs_global);
+	    printf("\t13. The maximum Vs	   = %.6f \n", max_Vs_global);
+	}
+	else
+	{
+	    printf("\n\n Critical delta t related information: \n\n");
+	    printf("\t The minimum h/Vp = %.6f \n\n", min_h_over_Vp_global);
+	}
+    }
+
+#ifdef AUTO_DELTA_T
+    /* Set the critical delta T */
+    Param.theDeltaT	     = Global.theCriticalT;
+    Param.theDeltaTSquared = Param.theDeltaT * Param.theDeltaT;
+
+    /* Set the total steps */
+    Param.theTotalSteps    = (int)(((Param.theEndT - Param.theStartT) / Param.theDeltaT));
+#endif /* AUTO_DELTA_T */
+
+    /* Printing location and element properties of the maximum values */
+    if ( Param.theDampingStatisticsFlag == 1 )
+    {
+	/* Local variables */
+
+	double	local_extremes[13],
+		global_extremes[13];
+	int32_t element_indices[13];
+	int32_t extreme_index;
+
+	local_extremes[0]  = min_h_over_Vp;
+	local_extremes[1]  = min_dt_factor_X;
+	local_extremes[2]  = min_dt_factor_Z;
+	local_extremes[3]  = min_zeta;
+	local_extremes[4]  = max_zeta;
+	local_extremes[5]  = min_xi;
+	local_extremes[6]  = max_xi;
+	local_extremes[7]  = min_VsVp;
+	local_extremes[8]  = max_VsVp;
+	local_extremes[9]  = min_VpVsZ;
+	local_extremes[10] = max_VpVsZ;
+	local_extremes[11] = min_Vs;
+	local_extremes[12] = max_Vs;
+
+	global_extremes[0]  = min_h_over_Vp_global;
+	global_extremes[1]  = min_dt_factor_X_global;
+	global_extremes[2]  = min_dt_factor_Z_global;
+	global_extremes[3]  = min_zeta_global;
+	global_extremes[4]  = max_zeta_global;
+	global_extremes[5]  = min_xi_global;
+	global_extremes[6]  = max_xi_global;
+	global_extremes[7]  = min_VsVp_global;
+	global_extremes[8]  = max_VsVp_global;
+	global_extremes[9]  = min_VpVsZ_global;
+	global_extremes[10] = max_VpVsZ_global;
+	global_extremes[11] = min_Vs_global;
+	global_extremes[12] = max_Vs_global;
+
+	element_indices[0]  = min_h_over_Vp_elem_index;
+	element_indices[1]  = min_dt_factor_X_elem_index;
+	element_indices[2]  = min_dt_factor_Z_elem_index;
+	element_indices[3]  = min_zeta_elem_index;
+	element_indices[4]  = max_zeta_elem_index;
+	element_indices[5]  = min_xi_elem_index;
+	element_indices[6]  = max_xi_elem_index;
+	element_indices[7]  = min_VsVp_elem_index;
+	element_indices[8]  = max_VsVp_elem_index;
+	element_indices[9]  = min_VpVsZ_elem_index;
+	element_indices[10] = max_VpVsZ_elem_index;
+	element_indices[11] = min_Vs_elem_index;
+	element_indices[12] = max_Vs_elem_index;
+
+	/* Printing section title */
+	MPI_Barrier( comm_solver );
+	if (Global.myID == 0)
+	{
+	    printf("\n\t Their corresponding element properties and coordinates are: \n\n");
+	}
+
+	/* Loop over the six extreme values */
+	MPI_Barrier( comm_solver );
+	for ( extreme_index = 0; extreme_index < 13; extreme_index++ )
+	{
+	    MPI_Barrier( comm_solver );
+	    if ( local_extremes[extreme_index] == global_extremes[extreme_index] )
+	    {
+		tick_t	 ldb[3];
+		elem_t	*elemp;
+		edata_t *edata;
+		int lnid0 = Global.myMesh->elemTable[element_indices[extreme_index]].lnid[0];
+
+		ldb[0] = Global.myMesh->nodeTable[lnid0].x;
+		ldb[1] = Global.myMesh->nodeTable[lnid0].y;
+		ldb[2] = Global.myMesh->nodeTable[lnid0].z;
+
+		elemp  = &Global.myMesh->elemTable[element_indices[extreme_index]];
+		edata  = (edata_t *)elemp->data;
+
+		printf("\t For extreme value No. %d:", extreme_index + 1);
+		printf("\n\t\t h = %.6f, Vp = %.6f Vs = %.6f rho = %.6f",
+		       edata->edgesize, edata->Vp , edata->Vs, edata->rho);
+		printf("\n\t\t by thread %d, element_coord = (%.6f, %.6f, %.6f)\n\n",
+		       Global.myID, ldb[0] * Global.myMesh->ticksize, ldb[1] * Global.myMesh->ticksize,
+		       ldb[2] * Global.myMesh->ticksize);
+	    }
+	    MPI_Barrier( comm_solver );
+	} /* End of loop over the extreme values */
+
+	if (Global.myID == 0) {
+	    fflush (stdout);
+	}
+    } /* end if damping statistics */
+
+    return;
+} /* End solver_set_critical_T */
+
+
+/**
+ * Iterates through all processor to obtain the minimum * edgesize of the
+ * mesh.
+ */
+static void get_minimum_edge()
+{
+    int32_t eindex;
+    double min_h = 1e32, min_h_global;
+    int32_t min_h_elem_index;
+
+    /* Find the minimal h/Vp in the domain */
+    for (eindex = 0; eindex < Global.myMesh->lenum; eindex++) {
+        elem_t *elemp;	 /* pointer to the mesh database */
+        edata_t *edata;
+        double h;
+
+        elemp = &Global.myMesh->elemTable[eindex];
+        edata = (edata_t *)elemp->data;
+
+        /* Update the min_h value. (h = edgesize)  */
+        h = edata->edgesize;
+        if (h < min_h) {
+            min_h = h;
+            min_h_elem_index = eindex;
+        }
+    }
+
+    MPI_Reduce(&min_h, &min_h_global, 1, MPI_DOUBLE,
+            MPI_MIN, 0, comm_solver);
+    /* Inform everyone of this value */
+    MPI_Bcast(&min_h_global, 1, MPI_DOUBLE, 0, comm_solver);
+
+    if (Global.myID == 0) {
+        printf("\nThe minimal h	 = %.6f\n\n\n", min_h_global);
+    }
+
+    Global.theNumericsInformation.minimumh=min_h_global;
+
+    return;
+}
+
+
+/**
+ * Print the stiffness matrix K1, K2 and K3 to the given output stream.
+ */
+static void
+print_K_stdoutput()
+{
+    int i, j, iloc, jloc;
+
+    fprintf(stdout, "\n\nStiffness Matrix K1 \n\n");
+    for ( i = 0 ; i < 8 ; i++){
+        for ( iloc = 0; iloc < 3; iloc++){
+            for ( j = 0; j < 8; j++) {
+                for (jloc = 0; jloc < 3; jloc++) {
+                    fprintf(stdout, "%10.2e", Global.theK1[i][j].f[iloc][jloc]);
+                }
+            }
+            fprintf(stdout, "\n");
+        }
+    }
+
+    fprintf(stdout, "\n\nStiffness Matrix K2 \n\n");
+    for ( i = 0 ; i < 8 ; i++){
+        for ( iloc = 0; iloc < 3; iloc++){
+            for ( j = 0; j < 8; j++) {
+                for (jloc = 0; jloc < 3; jloc++) {
+                    fprintf(stdout, "%10.2e", Global.theK2[i][j].f[iloc][jloc]);
+                }
+            }
+            fprintf(stdout, "\n");
+        }
+    }
+
+    fprintf(stdout, "\n\nStiffness Matrix K3 \n\n");
+    for ( i = 0 ; i < 8 ; i++){
+        for ( iloc = 0; iloc < 3; iloc++){
+            for ( j = 0; j < 8; j++) {
+                for (jloc = 0; jloc < 3; jloc++) {
+                    fprintf(stdout, "%10.2e", Global.theK3[i][j].f[iloc][jloc]);
+                }
+            }
+            fprintf(stdout, "\n");
+        }
+    }
+
+    fprintf(stdout, "\n\n");
+}
+
+
+
+/**
+ * mu_and_lambda: Calculates mu and lambda according to the element values
+ *                of Vp, Vs, and Rho and verifies/applies some rules defined
+ *                by Jacobo, Leonardo and Ricardo.  It was originally within
+ *                solver_init but was moved out because it needs to be used
+ *                in other places as well (nonlinear)
+ */
+void mu_and_lambda(double *theMu, double *theLambda,
+                   edata_t *edata, int32_t eindex)
+{
+
+    double mu, lambda;
+
+    mu = edata->rho * edata->Vs * edata->Vs;
+
+    if ( edata->Vp > (edata->Vs * Param.theThresholdVpVs) ) {
+        lambda = edata->rho * edata->Vs * edata->Vs * Param.theThresholdVpVs
+               * Param.theThresholdVpVs - 2 * mu;
+    } else {
+        lambda = edata->rho * edata->Vp * edata->Vp - 2 * mu;
+    }
+
+    /* Adjust Vs, Vp to fix Poisson ratio problem, formula provided by Jacobo */
+    if ( lambda < 0 ) {
+        if ( edata->Vs < 500 )
+            edata->Vp = 2.45 * edata->Vs;
+        else if ( edata->Vs < 1200 )
+            edata->Vp = 2 * edata->Vs;
+        else
+            edata->Vp = 1.87 * edata->Vs;
+
+        lambda = edata->rho * edata->Vp * edata->Vp;
+    }
+
+    if ( lambda < 0) {
+        fprintf(stderr, "\nThread %d: %d element produces negative lambda = %.6f; Vp = %f; Vs = %f; Rho = %f",
+                Global.myID, eindex, lambda, edata->Vp, edata->Vs, edata->rho);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+    }
+
+    /* assign results to returning values */
+    *theMu = mu;
+    *theLambda = lambda;
+}
+
+
+/**
+ * gpu_init: Select one of the attached GPU devices and retrieve its
+ *           specifications.
+ *
+ */
+static void gpu_init()
+{
+    int myDevID, devCount;
+
+    /* Select a GPU device for this process */
+    if (cudaGetDeviceCount(&devCount) != cudaSuccess) {
+      fprintf(stderr, "Failed to get GPU device count\n");
+      MPI_Abort(MPI_COMM_WORLD, ERROR);
+      exit(1);
+    }
+
+    myDevID = (Global.myID % devCount);
+    
+    /* Retrieve device hardware details */
+    if (Global.myID == 0) {
+      /* Only Rank 0 dumps GPU information */
+      getGPUHardware(myDevID, &(Global.gpu_spec), 1);
+    } else {
+      getGPUHardware(myDevID, &(Global.gpu_spec), 0);
+    }
+}
+
+
+/**
+ * Init matrices and constants, build comm schedule, allocate/init space
+ * for the solver.
+ */
+static void solver_init()
+{
+    /* local variables */
+    int32_t eindex;
+    int32_t c_outsize, c_insize, s_outsize, s_insize;
+
+    /* compute the damping parameters a/zeta and b/zeta */
+    compute_setab(Param.theFreq, &Global.theABase, &Global.theBBase);
+
+    /* find out the critical delta T of the current simulation */
+    /* and goes for the damping statistics if falg is == 1     */
+    MPI_Barrier( comm_solver );
+    solver_set_critical_T();
+
+    /* find the minimum edge size */
+
+    get_minimum_edge();
+
+    /* Init stiffness matrices and other constants */
+    compute_K();
+
+    /* For debugging */
+    if ( ( Param.printK == YES ) && ( Global.myID == 0 ) ) {
+        print_K_stdoutput();
+    }
+
+    compute_setab(Param.theFreq, &Global.theABase, &Global.theBBase);
+
+    /* allocation of memory */
+    Global.mySolver = (mysolver_t *)malloc(sizeof(mysolver_t));
+    if (Global.mySolver == NULL) {
+        fprintf(stderr, "Thread %d: solver_init: out of memory\n", Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    /* Allocate memory */
+    Global.mySolver->eTable = (e_t *)calloc(Global.myMesh->lenum, sizeof(e_t));
+    Global.mySolver->nTable = (n_t *)calloc(Global.myMesh->nharbored, sizeof(n_t));
+    Global.mySolver->tm1    = (fvector_t *)calloc(Global.myMesh->nharbored, sizeof(fvector_t));
+    Global.mySolver->tm2    = (fvector_t *)calloc(Global.myMesh->nharbored, sizeof(fvector_t));
+    Global.mySolver->force  = (fvector_t *)calloc(Global.myMesh->nharbored, sizeof(fvector_t));
+    Global.mySolver->conv_shear_1 = (fvector_t *)calloc(8 * Global.myMesh->lenum, sizeof(fvector_t));
+    Global.mySolver->conv_shear_2 = (fvector_t *)calloc(8 * Global.myMesh->lenum, sizeof(fvector_t));
+    Global.mySolver->conv_kappa_1 = (fvector_t *)calloc(8 * Global.myMesh->lenum, sizeof(fvector_t));
+    Global.mySolver->conv_kappa_2 = (fvector_t *)calloc(8 * Global.myMesh->lenum, sizeof(fvector_t));
+
+    Global.mySolver->dn_sched = schedule_new();
+    Global.mySolver->an_sched = schedule_new();
+
+    if ( (Global.mySolver->eTable == NULL) ||
+         (Global.mySolver->nTable == NULL) ||
+         (Global.mySolver->tm1    == NULL) ||
+         (Global.mySolver->tm2    == NULL) ||
+         (Global.mySolver->force  == NULL) ||
+         (Global.mySolver->conv_shear_1 == NULL) ||
+         (Global.mySolver->conv_shear_2 == NULL) ||
+         (Global.mySolver->conv_kappa_1 == NULL) ||
+         (Global.mySolver->conv_kappa_2 == NULL) ) {
+
+        fprintf(stderr, "Thread %d: solver_init: out of memory\n", Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    if ( Param.printStationAccelerations == YES ) {
+
+        Global.mySolver->tm3 = (fvector_t *)calloc(Global.myMesh->nharbored, sizeof(fvector_t));
+
+        if ( Global.mySolver->tm3 == NULL ) {
+
+            fprintf(stderr, "Thread %d: solver_init: out of memory for accs\n", Global.myID);
+            MPI_Abort(MPI_COMM_WORLD, ERROR);
+            exit(1);
+        }
+    }
+
+    /* For each element:
+     * Initialize the data structures. tm1, tm2 and force have
+     * already been initialized to 0 by calloc(). */
+    for (eindex = 0; eindex < Global.myMesh->lenum; eindex++)
+    {
+        elem_t  *elemp; /* pointer to the mesh database */
+        edata_t *edata;
+        e_t     *ep;    /* pointer to the element constant table */
+        double   mass, M, mu, lambda;
+        int j;
+
+#ifdef BOUNDARY
+        tick_t  edgeticks;
+        tick_t  ldb[3], ruf[3];
+        int32_t lnid0;
+        char    flag;
+        double  dashpot[8][3];
+#endif
+
+        double zeta, a, b;
+
+        /* Note the difference between the two tables */
+        elemp = &Global.myMesh->elemTable[eindex];
+        edata = (edata_t *)elemp->data;
+        ep    = &Global.mySolver->eTable[eindex];
+
+        /* Calculate the Lame constants */
+        mu_and_lambda(&mu, &lambda, edata, eindex);
+
+        /* coefficients for term (deltaT_squared * Ke * Ut) */
+        ep->c1 = Param.theDeltaTSquared * edata->edgesize * mu / 9;
+        ep->c2 = Param.theDeltaTSquared * edata->edgesize * lambda / 9;
+
+        /* coefficients for term (b * deltaT * Ke_off * (Ut-1 - Ut)) */
+        /* Anelastic attenuation (material damping) */
+
+        /* Old formula for damping */
+        /* zeta = (edata->Vs < 1500) ? 25 / edata->Vs : 5 / edata->Vs; */
+
+        /* New formula for damping according to Graves */
+        	zeta = 10 / edata->Vs;
+
+        if ( zeta > Param.theThresholdDamping ) {
+        	zeta = Param.theThresholdDamping;
+        }
+
+        /* the a,b coefficients */
+        a = zeta * Global.theABase;
+        b = zeta * Global.theBBase;
+
+        /* coefficients for term (b * deltaT * Ke_off * (Ut-1 - Ut)) */
+        ep->c3 = b * Param.theDeltaT * edata->edgesize * mu / 9;
+        ep->c4 = b * Param.theDeltaT * edata->edgesize * lambda / 9;
+
+#ifdef BOUNDARY
+
+        /* Set the flag for the element */
+        lnid0 = elemp->lnid[0];
+
+        ldb[0] = Global.myMesh->nodeTable[lnid0].x;
+        ldb[1] = Global.myMesh->nodeTable[lnid0].y;
+        ldb[2] = Global.myMesh->nodeTable[lnid0].z;
+
+        edgeticks = (tick_t)1 << (PIXELLEVEL - elemp->level);
+        ruf[0] = ldb[0] + edgeticks;
+        ruf[1] = ldb[1] + edgeticks;
+        ruf[2] = ldb[2] + edgeticks;
+
+        flag = compute_setflag(ldb, ruf, Global.myOctree->nearendp,
+                Global.myOctree->farendp);
+        if (flag != 13) {
+            compute_setboundary(edata->edgesize, edata->Vp, edata->Vs,
+                                edata->rho, flag, dashpot);
+        }
+#endif /* BOUNDARY */
+
+        /* Assign the element mass to its vertices */
+        /* mass is the total mass of the element   */
+        /* and M is the mass assigned to each node */
+        mass = edata->rho * edata->edgesize * edata->edgesize *edata->edgesize;
+        M    = mass / 8;
+
+        /* For each node */
+        for (j = 0; j < 8; j++)
+        {
+            int32_t lnid;
+            int axis;
+            n_t *np;
+
+            lnid = elemp->lnid[j];
+            np   = &Global.mySolver->nTable[lnid];
+
+            np->mass_simple += M;
+
+            /* loop for each axis */
+            for (axis = 0; axis < 3; axis++ )
+            {
+                np->mass_minusaM[axis]	-= (Param.theDeltaT * a * M);
+                np->mass2_minusaM[axis] -= (Param.theDeltaT * a * M);
+
+#ifdef BOUNDARY
+                if (flag != 13)
+                {
+                    /* boundary impact */
+                    np->mass_minusaM[axis]  -= (Param.theDeltaT * dashpot[j][axis]);
+                    np->mass2_minusaM[axis] -= (Param.theDeltaT * dashpot[j][axis]);
+                }
+#endif /* BOUNDARY */
+
+                np->mass_minusaM[axis]	+= M;
+                np->mass2_minusaM[axis] += (M * 2);
+
+            } /* end loop for each axis */
+
+        } /* end loop for each node */
+
+    } /* eindex for elements */
+
+    /* Build the communication schedules */
+    schedule_build(Global.myMesh, Global.mySolver->dn_sched, Global.mySolver->an_sched);
+
+#ifdef DEBUG
+    /* For debug purpose, add gnid into the data field. */
+    c_outsize = sizeof(n_t) + sizeof(int64_t);
+    c_insize  = sizeof(n_t) + sizeof(int64_t);
+    s_outsize = sizeof(n_t) + sizeof(int64_t);
+    s_insize  = sizeof(n_t) + sizeof(int64_t);
+#else
+    c_outsize = sizeof(n_t);
+    c_insize  = sizeof(n_t);
+    s_outsize = sizeof(n_t);
+    s_insize  = sizeof(n_t);
+#endif /* DEBUG */
+
+    schedule_prepare(Global.mySolver->dn_sched, c_outsize, c_insize,
+		     s_outsize, s_insize);
+
+    schedule_prepare(Global.mySolver->an_sched, c_outsize, c_insize,
+		     s_outsize, s_insize);
+
+    /* Send mass information of dangling nodes to their owners */
+    schedule_senddata(Global.mySolver->dn_sched, Global.mySolver->nTable,
+	      sizeof(n_t) / sizeof(solver_float), CONTRIBUTION, DN_MASS_MSG);
+
+    /* Distribute the mass from dangling nodes to anchored nodes. (local) */
+    compute_adjust(Global.mySolver->nTable, sizeof(n_t) / sizeof(solver_float),
+		   DISTRIBUTION);
+
+    /* Send mass information of anchored nodes to their owner processors*/
+    schedule_senddata(Global.mySolver->an_sched, Global.mySolver->nTable,
+	      sizeof(n_t) / sizeof(solver_float), CONTRIBUTION, AN_MASS_MSG);
+
+    /* Save device configuration */
+    Global.mySolver->gpu_spec = &(Global.gpu_spec);
+
+    /* Allocate device memory */
+    if (cudaMalloc((void**)&(Global.mySolver->elemTableDevice), 
+		   Global.myMesh->lenum * sizeof(elem_t)) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to allocate elemTable memory\n", 
+		Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+    if (cudaMalloc((void**)&(Global.mySolver->eTableDevice), 
+		   Global.myMesh->lenum * sizeof(e_t)) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to allocate etable memory\n", 
+		Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+    if (cudaMalloc((void**)&(Global.mySolver->tm1Device), 
+		   Global.myMesh->nharbored * sizeof(fvector_t)) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to allocate tm1 memory\n", 
+		Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+    if (cudaMalloc((void**)&(Global.mySolver->forceDevice), 
+		   Global.myMesh->nharbored * sizeof(fvector_t)) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to allocate force memory\n", 
+		Global.myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    /* Copy mesh and solver elements to device */
+    cudaMemcpy(Global.mySolver->elemTableDevice, Global.myMesh->elemTable, 
+	       Global.myMesh->lenum * sizeof(elem_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(Global.mySolver->eTableDevice, Global.mySolver->eTable, 
+	       Global.myMesh->lenum * sizeof(e_t), cudaMemcpyHostToDevice);
+
+    return;
+}
+
+
+/**
+ * Print the communication schedule of each processor to the given output
+ * stream.
+ */
+static void
+solver_printstat_to_stream( mysolver_t* solver, FILE* out )
+{
+    /**
+     * Enumeration for the indices in the counts array
+     * the first 4 values are for the dangling nodes:
+     * the last 4 values are for the anchored nodes.
+     */
+    enum solver_msg_idx_t {
+	I_DN_C_P,	/**< 0: Dangling contribution processor count */
+	I_DN_C_N,	/**< 1: Dangling contribution node count */
+	I_DN_S_P,	/**< 2: Dangling shared processor count */
+	I_DN_S_N,	/**< 3: Dangling shared node count */
+	I_AN_C_P,	/**< 4: Shared contribution processor count */
+	I_AN_C_N,	/**< 5: Shared contribution node count */
+	I_AN_S_P,	/**< 6: Shared shared processor count */
+	I_AN_S_N,	/**< 7: Shared shared node count */
+	I_SCHED_LAST	/**< 8: Number of counters */
+    };
+
+    int32_t* recv_counts = NULL;
+    int32_t  send_counts[I_SCHED_LAST];
+
+    /* number of processors this PE communicates with */
+    send_counts[I_DN_C_P] = solver->dn_sched->c_count;
+    send_counts[I_DN_S_P] = solver->dn_sched->s_count;
+    send_counts[I_AN_C_P] = solver->an_sched->c_count;
+    send_counts[I_AN_S_P] = solver->an_sched->s_count;
+
+    /* number of nodes this PE communicates */
+    send_counts[I_DN_C_N] = messenger_countnodes( solver->dn_sched->first_c );
+    send_counts[I_DN_S_N] = messenger_countnodes( solver->dn_sched->first_s );
+    send_counts[I_AN_C_N] = messenger_countnodes( solver->an_sched->first_c );
+    send_counts[I_AN_S_N] = messenger_countnodes( solver->an_sched->first_s );
+
+
+    if (Global.myID == 0) {
+	/* allocate a buffer in PE 0 to receive stats from all other PEs */
+	XMALLOC_VAR_N( recv_counts, int32_t, I_SCHED_LAST * Global.theGroupSize );
+    }
+
+    MPI_Gather( send_counts, I_SCHED_LAST, MPI_INT,
+		recv_counts, I_SCHED_LAST, MPI_INT, 0, comm_solver );
+
+    if (Global.myID == 0) {
+	int      pe_id;
+	int32_t* pe_counts = recv_counts;
+
+	fprintf( out, "# Solver communication schedule summary:\n"
+		 "#   PE dc_p     dc_n ds_p     ds_n ac_p     ac_n as_p"
+		 "     as_n total_ncnt\n" );
+
+	for (pe_id = 0; pe_id < Global.theGroupSize; pe_id++) {
+	    /* print a row for a PE, each row has I_SCHED_LAST (8) items
+	     * besides the pe_id and the total node sum at the end */
+	    int pe_comm_count = pe_counts[I_DN_C_N] +
+				pe_counts[I_DN_S_N] +
+				pe_counts[I_AN_C_N] +
+				pe_counts[I_AN_S_N];
+
+	    fprintf( out, "%6d %4d %8d %4d %8d %4d %8d %4d %8d %10d\n",
+		     pe_id,
+		     pe_counts[I_DN_C_P],
+		     pe_counts[I_DN_C_N],
+		     pe_counts[I_DN_S_P],
+		     pe_counts[I_DN_S_N],
+		     pe_counts[I_AN_C_P],
+		     pe_counts[I_AN_C_N],
+		     pe_counts[I_AN_S_P],
+		     pe_counts[I_AN_S_N],
+		     pe_comm_count );
+
+	    pe_counts += I_SCHED_LAST; /* advance a row of size I_SCHED_LAST */
+	}
+
+	fprintf( out, "\n\n" );
+	fflush( out );
+
+	free( recv_counts );
+    }
+
+    return;
+}
+
+/**
+ * Print the communication schedule of each processor to the given output
+ * stream.
+ */
+static void
+solver_printstat( mysolver_t* solver )
+{
+    FILE* stat_out = NULL;
+
+    if (Global.myID == 0) {
+	stat_out = hu_fopen( Param.theScheduleStatFilename, "w" );
+    }
+
+    solver_printstat_to_stream( solver, stat_out );
+
+    if (Global.myID == 0) {
+	hu_fclose( stat_out );
+	xfree_char( & Param.theScheduleStatFilename );
+    }
+}
+
+
+/**
+ * solver_delete: Release all the memory associate with Global.mySolver.
+ *
+ */
+static void solver_delete()
+{
+    if (Global.mySolver == NULL) {
+	return;
+    }
+
+    /* Free device memory */
+    cudaFree(Global.mySolver->elemTableDevice);
+    cudaFree(Global.mySolver->eTableDevice);
+    cudaFree(Global.mySolver->tm1Device);
+    cudaFree(Global.mySolver->forceDevice);
+
+    free(Global.mySolver->eTable);
+    free(Global.mySolver->nTable);
+
+    free(Global.mySolver->tm1);
+    free(Global.mySolver->tm2);
+    free(Global.mySolver->force);
+
+    free(Global.mySolver->conv_shear_1);
+    free(Global.mySolver->conv_shear_2);
+    free(Global.mySolver->conv_kappa_1);
+    free(Global.mySolver->conv_kappa_2);
+
+    schedule_delete(Global.mySolver->dn_sched);
+    schedule_delete(Global.mySolver->an_sched);
+
+    free(Global.mySolver);
+}
+
+static int
+read_myForces( int32_t timestep )
+{
+    off_t   whereToRead;
+    size_t  to_read, read_count;
+
+    whereToRead = ((off_t)sizeof(int32_t))
+		+ Global.theNodesLoaded * sizeof(int32_t)
+		+ Global.theNodesLoaded * timestep * sizeof(double) * 3;
+
+    hu_fseeko( Global.fpsource, whereToRead, SEEK_SET );
+
+    to_read    = Global.theNodesLoaded * 3;
+    read_count = hu_fread( Global.myForces, sizeof(double), to_read, Global.fpsource );
+
+    return 0;	/* if we got here everything went OK */
+}
+
+
+/**
+ * check the max and min value of displacement.
+ */
+static void
+solver_debug_overflow( mysolver_t* solver, mesh_t* mesh, int step )
+{
+    int nindex;
+    double max_disp, min_disp, global_max_disp, global_min_disp;
+
+    max_disp = DBL_MIN;
+    min_disp = DBL_MAX;
+
+    /* find the min and max X displacement components */
+    for (nindex = 0; nindex < mesh->nharbored; nindex++) {
+	fvector_t* tm2Disp;
+	n_t* np;
+
+	np      = &solver->nTable[nindex];
+	tm2Disp = solver->tm2 + nindex;
+
+	max_disp = (max_disp > tm2Disp->f[0]) ? max_disp : tm2Disp->f[0];
+	min_disp = (min_disp < tm2Disp->f[0]) ? min_disp : tm2Disp->f[0];
+    }
+
+    /* get global min and max values */
+    MPI_Reduce( &min_disp, &global_min_disp, 1, MPI_DOUBLE,
+		MPI_MIN, 0, comm_solver );
+
+    MPI_Reduce( &max_disp, &global_max_disp, 1, MPI_DOUBLE,
+		MPI_MAX, 0, comm_solver );
+
+    if (Global.myID == 0) {
+	printf("Timestep %d: max_dx = %.6f min_dx = %.6f\n",
+	       step, global_max_disp, global_min_disp);
+    }
+}
+
+
+int
+darray_has_nan_nd( const double* v, int dim, const size_t len[] )
+{
+    HU_ASSERT_PTR_ALWAYS( v );
+    HU_ASSERT_PTR_ALWAYS( len );
+    HU_ASSERT_ALWAYS( dim > 0 );
+
+    size_t* idx = XMALLOC_N( size_t, dim );
+    int     ret = hu_darray_has_nan_nd( v, dim, len, idx );
+
+    if (ret != 0) {
+	int i;
+
+	fputs( "WARNING!: Found NAN value at index", stderr );
+
+	for (i = 0; i < dim; i++) {
+	    fprintf( stderr, " %zu", idx[i] );
+	}
+
+	fputc( '\n', stderr );
+    }
+
+    free( idx );
+    idx = NULL;
+
+    return ret;
+}
+
+
+
+/**
+ * Check a fvector_t array for NAN values.
+ */
+static int
+fvector_array_has_nan( const fvector_t* f, size_t len, const char* varname )
+{
+    size_t lengths[2];
+    const double* v = (double*)f;
+
+    lengths[0] = len;
+    lengths[1] = 3;
+
+    if (darray_has_nan_nd( v, 2, lengths ) != 0) {
+        if (NULL == varname) {
+	    varname = "(unknown)";
+	}
+	fputs( "fvector_t varname=", stderr );
+	fputs( varname, stderr );
+	fputc( '\n', stderr );
+
+	return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * Debug function to check the solver structures for NAN.
+ * The checked structures are the displacement arrays (tm1 & tm2) and
+ * the forces array.
+ */
+void
+solver_check_nan( mysolver_t* solver, int node_count, int time_step )
+{
+    HU_ASSERT_PTR_ALWAYS( solver );
+
+    int ret1 = fvector_array_has_nan( solver->tm1, node_count, "tm1" );
+    int ret2 = fvector_array_has_nan( solver->tm2, node_count, "tm2" );
+    int ret3 = fvector_array_has_nan( solver->force, node_count, "force" );
+
+    if ((ret1 | ret2 | ret3) != 0) {
+	hu_solver_abort( __FUNCTION_NAME, NULL,
+			 "Found a NAN value at timestep %d", time_step );
+    }
+}
+
+
+static void solver_run_init_comm( mysolver_t* solver )
+{
+    /* The int64_t (global node id) is for debug purpose */
+    static const int debug_size = (DO_DEBUG) ? sizeof(int64_t) : 0;
+
+    /* properly setup the communication schedule */
+    int c_outsize = sizeof(fvector_t) + debug_size;     /* force */
+    int c_insize  = sizeof(fvector_t) + debug_size;     /* displacement */
+    int s_outsize = sizeof(fvector_t) + debug_size;     /* displacement */
+    int s_insize  = sizeof(fvector_t) + debug_size;     /* force */
+
+    schedule_prepare(solver->dn_sched,c_outsize,c_insize,s_outsize,s_insize);
+    schedule_prepare(solver->an_sched,c_outsize,c_insize,s_outsize,s_insize);
+
+    solver_print_schedules( solver );
+}
+
+
+/**
+ * \note Globals used:
+ * - Global.myID (read)
+ * - Param.theDeltaT (read)
+ * - startingStep (read)
+ */
+/* show a progress bar to make the process less anxious! */
+static void solver_update_status( int step, const int start_step ){
+
+    static double lastCheckedTime = 0;
+    double interval = 0;
+    double CurrTime;
+
+    if (Global.myID == 0) {
+
+	CurrTime = Timer_Value( "Total Wall Clock", (TimerKind)0 );
+
+	if (lastCheckedTime==0) {
+	    lastCheckedTime = CurrTime;
+	    return;
+	}
+
+	monitor_print( "*" );
+
+        if (step % Param.monitor_stats_rate == 0) {
+	    interval = CurrTime - lastCheckedTime;
+	    if (interval > Global.slowestTimeSteps) Global.slowestTimeSteps = interval;
+	    if (interval < Global.fastestTimeSteps) Global.fastestTimeSteps = interval;
+            monitor_print( "     Sim=% 12.6f     ETA=% 6.1f    WC=% 6.1f\n",
+                           step * Param.theDeltaT,
+			   ((Param.theTotalSteps - step) / Param.monitor_stats_rate) * interval,
+                           CurrTime);
+	    lastCheckedTime = CurrTime;
+        }
+
+    }
+}
+
+
+static void solver_write_checkpoint( int step, int start_step ){
+
+    if ((Param.theCheckPointingRate != 0) && (step != start_step) &&
+        ((step % Param.theCheckPointingRate) == 0)) {
+
+        checkpoint_write( step, Global.myID, Global.myMesh, Param.theCheckPointingDirOut, Global.theGroupSize,
+			     Global.mySolver, comm_solver );
+    }
+
+}
+
+
+/**
+ * \note Globals used:
+ * - Param.theRate (read)
+ */
+static void solver_output_wavefield( int step )
+{
+    if (DO_OUTPUT && (step % Param.theRate == 0)) {
+        /* output the current timestep */
+        do_solver_output();
+    }
+}
+
+
+/**
+ * \note Globals used:
+ * - thePlanePrintRate (read)
+ */
+static void solver_output_planes( mysolver_t* solver, int my_id, int step )
+{
+    if (Param.theNumberOfPlanes != 0) {
+        if (step % Param.thePlanePrintRate == 0) {
+            Timer_Start( "Print Planes" );
+            planes_print( my_id, Param.IO_pool_pe_count, Param.theNumberOfPlanes, solver );
+            Timer_Stop( "Print Planes" );
+        }
+    }
+}
+
+
+static void solver_output_stations( int step )
+{
+    if (Param.theNumberOfStations !=0) {
+        if (step % Param.theStationsPrintRate == 0) {
+            Timer_Start( "Print Stations" );
+            interpolate_station_displacements( step );
+            Timer_Stop( "Print Stations" );
+        }
+    }
+}
+
+
+/**
+ * Calculate the nonlinear entities necessary for the next step computation
+ * of force correction.
+ *
+ * \note Globals used:
+ * - Param.theNumberOfStations
+ * - Param.myNumberOfStations
+ * - Param.myStations
+ * - Param.theDeltaT
+ */
+static void solver_nonlinear_state( mysolver_t *solver,
+                                    mesh_t     *mesh,
+                                    fmatrix_t   k1[8][8],
+                                    fmatrix_t   k2[8][8],
+                                    int step )
+{
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        Timer_Start( "Compute Non-linear Entities" );
+        compute_nonlinear_state ( mesh, solver, Param.theNumberOfStations,
+                                  Param.myNumberOfStations, Param.myStations, Param.theDeltaT );
+        if ( get_geostatic_total_time() > 0 ) {
+            compute_bottom_reactions( mesh, solver, k1, k2, step, Param.theDeltaT );
+        }
+        Timer_Stop( "Compute Non-linear Entities" );
+        if (Param.theNumberOfStations != 0) {
+            Timer_Start( "Print Stations" );
+            print_nonlinear_stations( mesh, solver, Param.myStations,
+                                      Param.myNumberOfStations, Param.theDeltaT,
+                                      step, Param.theStationsPrintRate);
+            Timer_Stop( "Print Stations" );
+        }
+    }
+}
+
+
+static void solver_read_source_forces( int step )
+{
+    Timer_Start( "Read My Forces" );
+    if (Global.theNodesLoaded > 0) {
+        read_myForces( step );
+    }
+    Timer_Stop( "Read My Forces" );
+}
+
+/**
+ * TODO: This method uses global variable Param.theDeltaT
+ */
+static void solver_load_fixedbase_displacements( mysolver_t* solver, int step )
+{
+    Timer_Start( "Load Fixedbase Disps" );
+    if ( get_fixedbase_flag() == YES ) {
+        bldgs_load_fixedbase_disps ( solver, Param.theDeltaT, step);
+    }
+    Timer_Stop( "Load Fixedbase Disps" );
+}
+
+
+/** Compute the force due to the earthquake source. */
+static void solver_compute_force_source( int step )
+{
+    Timer_Start( "Compute addforces s" );
+    compute_addforce_s( step );
+    Timer_Stop( "Compute addforces s" );
+}
+
+
+/** Compute the force due to element stiffness matrices. */
+static void
+solver_compute_force_stiffness( mysolver_t *solver,
+                                mesh_t     *mesh,
+                                fmatrix_t   k1[8][8],
+                                fmatrix_t   k2[8][8] )
+{
+	Timer_Start( "Compute addforces e" );
+	if(Param.theTypeOfDamping != BKT)
+	{
+		if (Param.theStiffness == EFFECTIVE) {
+			compute_addforce_effective_gpu( mesh, solver );
+		}
+		else if (Param.theStiffness == CONVENTIONAL) {
+			compute_addforce_conventional( mesh, solver, k1, k2 );
+		}
+	}
+	Timer_Stop( "Compute addforces e" );
+}
+
+
+/** Compute contribution of damping to the force vector */
+static void
+solver_compute_force_damping( mysolver_t *solver,
+                              mesh_t     *mesh,
+                              fmatrix_t   k1[8][8],
+                              fmatrix_t   k2[8][8] )
+{
+	Timer_Start( "Damping addforce" );
+
+	if(Param.theTypeOfDamping == RAYLEIGH  || Param.theTypeOfDamping == MASS)
+	{
+		damping_addforce(Global.myMesh, Global.mySolver, Global.theK1, Global.theK2);
+	}
+	else if(Param.theTypeOfDamping == BKT)
+	{
+		calc_conv(Global.myMesh, Global.mySolver, Param.theFreq, Param.theDeltaT, Param.theDeltaTSquared);
+		//addforce_conv(myMesh, mySolver, theFreq, theDeltaT, theDeltaTSquared);
+		constant_Q_addforce(Global.myMesh, Global.mySolver, Param.theFreq, Param.theDeltaT, Param.theDeltaTSquared);
+	}
+	else
+	{}
+
+	Timer_Stop( "Damping addforce" );
+}
+
+/**
+ * Compute the nonlinear contribution to the force.
+ * \param deltaT2 Delta t^2 (i.e., squared).
+ */
+static void
+solver_compute_force_nonlinear( mysolver_t *solver,
+                                mesh_t     *mesh,
+                                double      deltaT2 )
+{
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        Timer_Start( "Compute addforces Non-linear" );
+        compute_addforce_nl( mesh, solver, deltaT2 );
+        Timer_Stop( "Compute addforces Non-linear" );
+    }
+}
+
+static void
+solver_compute_force_gravity( mysolver_t *solver, mesh_t *mesh, int step )
+{
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        Timer_Start( "Compute addforces gravity" );
+        if ( get_geostatic_total_time() > 0 ) {
+            compute_addforce_gravity( mesh, solver, step, Param.theDeltaT );
+        }
+        Timer_Stop( "Compute addforces gravity" );
+    }
+}
+
+/** Send the forces on dangling nodes to their owner processors */
+static void solver_send_force_dangling( mysolver_t* solver )
+{
+//    HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+
+    Timer_Start( "1st schedule send data (contribution)" );
+    schedule_senddata( solver->dn_sched, solver->force,
+                       sizeof(fvector_t) / sizeof(solver_float), CONTRIBUTION,
+                       DN_FORCE_MSG);
+    Timer_Stop( "1st schedule send data (contribution)" );
+}
+
+
+static void solver_adjust_forces(  mysolver_t* solver )
+{
+    Timer_Start( "1st compute adjust (distribution)" );
+    /* Distribute the forces to LOCAL anchored nodes */
+    compute_adjust( solver->force, sizeof(fvector_t) / sizeof(solver_float),
+                    DISTRIBUTION);
+    Timer_Stop( "1st compute adjust (distribution)" );
+}
+
+
+static void solver_send_force_anchored( mysolver_t* solver )
+{
+//    HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+
+    Timer_Start( "2nd schedule send data (contribution)" );
+    /* Send the forces on anchored nodes to their owner processors */
+    schedule_senddata( solver->an_sched, solver->force,
+                       sizeof(fvector_t) / sizeof(solver_float), CONTRIBUTION,
+                       AN_FORCE_MSG );
+    Timer_Stop( "2nd schedule send data (contribution)" );
+}
+
+
+/** Compute new displacements of my harbored nodes */
+static void
+solver_compute_displacement( mysolver_t* solver, mesh_t* mesh )
+{
+    lnid_t nindex;
+
+    Timer_Start( "Compute new displacement" );
+    for (nindex = 0; nindex < mesh->nharbored; nindex++) {
+
+        const n_t*       np         = &solver->nTable[nindex];
+        fvector_t        nodalForce = solver->force[nindex];
+        const fvector_t* tm1Disp    = solver->tm1 + nindex;
+        fvector_t*       tm2Disp    = solver->tm2 + nindex;
+
+        /* total nodal forces */
+        nodalForce.f[0] += np->mass2_minusaM[0] * tm1Disp->f[0]
+                         - np->mass_minusaM[0]  * tm2Disp->f[0];
+        nodalForce.f[1] += np->mass2_minusaM[1] * tm1Disp->f[1]
+                         - np->mass_minusaM[1]  * tm2Disp->f[1];
+        nodalForce.f[2] += np->mass2_minusaM[2] * tm1Disp->f[2]
+                         - np->mass_minusaM[2]  * tm2Disp->f[2];
+
+        /* Save tm3 for accelerations */
+        if ( Param.printStationAccelerations == YES ) {
+
+            fvector_t* tm3Disp = solver->tm3 + nindex;
+
+            tm3Disp->f[0] = tm2Disp->f[0];
+            tm3Disp->f[1] = tm2Disp->f[1];
+            tm3Disp->f[2] = tm2Disp->f[2];
+        }
+
+        /* overwrite tm2 */
+        tm2Disp->f[0] = nodalForce.f[0] / np->mass_simple;
+        tm2Disp->f[1] = nodalForce.f[1] / np->mass_simple;
+        tm2Disp->f[2] = nodalForce.f[2] / np->mass_simple;
+
+    } /* for (nindex ...): all my harbored nodes */
+
+    /* zero out the force vector for all nodes */
+    memset( solver->force, 0, sizeof(fvector_t) * mesh->nharbored );
+
+    Timer_Stop( "Compute new displacement" );
+}
+
+static void
+solver_geostatic_fix(int step)
+{
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        Timer_Start( "Compute addforces gravity" );
+        if ( get_geostatic_total_time() > 0 ) {
+            geostatic_displacements_fix( Global.myMesh, Global.mySolver, Param.theDomainZ,
+                                         Param.theDeltaT, step );
+        }
+        Timer_Stop( "Compute addforces gravity" );
+    }
+}
+
+/** Share the displacement of anchored nodes with other processors. */
+static void solver_send_displacement_anchored( mysolver_t* solver )
+{
+//    HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+
+    Timer_Start("3rd schedule send data (sharing)");
+    schedule_senddata(Global.mySolver->an_sched, Global.mySolver->tm2,
+                      sizeof(fvector_t) / sizeof(solver_float), SHARING,
+                      AN_DISP_MSG);
+    Timer_Stop("3rd schedule send data (sharing)");
+
+}
+
+
+/** Adjust the displacements of my LOCAL dangling nodes. */
+static void solver_adjust_displacement(  mysolver_t* solver )
+{
+    Timer_Start( "2nd compute adjust (assignment)" );
+    compute_adjust( Global.mySolver->tm2, sizeof(fvector_t) / sizeof(solver_float),
+                    ASSIGNMENT );
+    Timer_Stop( "2nd compute adjust (assignment)" );
+}
+
+
+/** Share the displacement of dangling nodes with other processors. */
+static void solver_send_displacement_dangling( mysolver_t* solver )
+{
+//    HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+
+    Timer_Start( "4th schadule send data (sharing)" );
+    schedule_senddata( Global.mySolver->dn_sched, Global.mySolver->tm2,
+                       sizeof(fvector_t) / sizeof(solver_float), SHARING,
+                       DN_DISP_MSG );
+    Timer_Stop( "4th schadule send data (sharing)" );
+}
+
+
+/**
+ * Hook for instrumentation or other functionality in the solver_run loop.
+ */
+static void
+solver_loop_hook_bottom( mysolver_t* solver, mesh_t* mesh, int step )
+{
+    if (0) {
+        solver_debug_overflow( solver, mesh, step );
+    }
+}
+
+
+static void solver_output_wavefield_close( void )
+{
+    if (DO_OUTPUT && (Param.FourDOutFp != NULL)) {
+        fclose( Param.FourDOutFp );     /* close the output file */
+    }
+}
+
+
+static void solver_run_collect_timers( void )
+{
+    /* Get min and max of individual cumulative times.
+     * this is NOT best and worst single step times
+     */
+    if( Timer_Exists("Print Planes") ) {
+        Timer_Reduce("Print Planes",   (TimerKind)(MAX | MIN), comm_solver);
+    }
+
+    if( Timer_Exists("Print Stations") ) {
+        Timer_Reduce("Print Stations", (TimerKind)(MAX | MIN), comm_solver);
+    }
+
+    if ( Timer_Exists("Compute Non-linear Entities") ) {
+        Timer_Reduce("Compute Non-linear Entities", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    }
+
+    if ( Timer_Exists("Compute addforces Non-linear") ) {
+        Timer_Reduce("Compute addforces Non-linear", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+        Timer_Reduce("Compute addforces gravity",    (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    }
+
+    if ( Timer_Exists("Solver drm output") ) {
+        Timer_Reduce("Solver drm output", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    }
+
+    if ( Timer_Exists("Solver drm read displacements") ) {
+        Timer_Reduce("Solver drm read displacements", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    }
+
+    if ( Timer_Exists("Solver drm force compute") ) {
+        Timer_Reduce("Solver drm force compute", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    }
+
+    Timer_Reduce("Read My Forces",                        (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("Compute addforces s",                   (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("Compute addforces e",                   (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("Damping addforce",                      (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("1st schedule send data (contribution)", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("1st compute adjust (distribution)",     (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("2nd schedule send data (contribution)", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("Compute new displacement",              (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("3rd schedule send data (sharing)",      (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("2nd compute adjust (assignment)",       (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("4th schadule send data (sharing)",      (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+
+    Timer_Reduce("Solver I/O",      (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("Compute Physics", (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+    Timer_Reduce("Communication",   (TimerKind)(MAX | MIN | AVERAGE), comm_solver);
+}
+
+
+/**
+ * March forward in time and output the result whenever necessary.
+ */
+static void solver_run()
+{
+    int32_t step, startingStep;
+
+    solver_run_init_comm( Global.mySolver );
+
+    /* sets new starting step if loading checkpoint */
+    if (Param.theUseCheckPoint == 1) {
+        startingStep = checkpoint_read(Global.myID, Global.myMesh, Param.theCheckPointingDirOut,
+				       Global.theGroupSize, Global.mySolver,comm_solver);
+    } else {
+        startingStep = 0;
+    }
+
+    if (Global.myID == 0) {
+        /* print header for monitor file */
+        monitor_print( "solver_run() start\nStarting time step = %d\n\n",
+                       startingStep );
+        monitor_print( "Sim = Simulation time (s), Sol = Solver time (s), WC = Wall Clock Time (s)\n");
+    }
+
+    MPI_Barrier( comm_solver );
+
+    /* march forward in time */
+    for (step = startingStep; step < Param.theTotalSteps; step++) {
+
+        fvector_t* tmpvector;
+
+        /* prepare for a new iteration
+         * swap displacement vectors for t(n) and t(n-1) */
+        tmpvector     = Global.mySolver->tm2;
+        Global.mySolver->tm2 = Global.mySolver->tm1;
+        Global.mySolver->tm1 = tmpvector;
+
+        Timer_Start( "Solver I/O" );
+        solver_write_checkpoint( step, startingStep );
+        solver_update_status( step, startingStep );
+        solver_output_wavefield( step );
+        solver_output_planes( Global.mySolver, Global.myID, step );
+        solver_output_stations( step );
+        solver_output_drm_nodes( Global.mySolver, step, Param.theTotalSteps );
+        solver_read_source_forces( step );
+        solver_read_drm_displacements( step , Param.theDeltaT ,Param.theTotalSteps );
+        Timer_Stop( "Solver I/O" );
+
+        Timer_Start( "Compute Physics" );
+        solver_nonlinear_state( Global.mySolver, Global.myMesh, Global.theK1, Global.theK2, step );
+        solver_compute_force_source( step );
+        solver_compute_effective_drm_force( Global.mySolver, Global.myMesh,Global.theK1, Global.theK2, step, Param.theDeltaT );
+        solver_compute_force_stiffness( Global.mySolver, Global.myMesh, Global.theK1, Global.theK2 );
+        solver_compute_force_damping( Global.mySolver, Global.myMesh, Global.theK1, Global.theK2 );
+        solver_compute_force_gravity( Global.mySolver, Global.myMesh, step );
+        solver_compute_force_nonlinear( Global.mySolver, Global.myMesh, Param.theDeltaTSquared );
+        Timer_Stop( "Compute Physics" );
+
+        Timer_Start( "Communication" );
+        HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+        solver_send_force_dangling( Global.mySolver );
+        solver_adjust_forces( Global.mySolver );
+        HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+        solver_send_force_anchored( Global.mySolver );
+        Timer_Stop( "Communication" );
+
+        Timer_Start( "Compute Physics" );
+        solver_compute_displacement( Global.mySolver, Global.myMesh );
+        solver_geostatic_fix( step );
+        solver_load_fixedbase_displacements( Global.mySolver, step );
+        Timer_Stop( "Compute Physics" );
+
+        Timer_Start( "Communication" );
+        HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+        solver_send_displacement_anchored( Global.mySolver );
+        solver_adjust_displacement( Global.mySolver );
+        HU_COND_GLOBAL_BARRIER( Param.theTimingBarriersFlag );
+        solver_send_displacement_dangling( Global.mySolver );
+        Timer_Stop( "Communication" );
+
+        solver_loop_hook_bottom( Global.mySolver, Global.myMesh, step );
+    } /* for (step = ....): all steps */
+
+    solver_drm_close();
+    solver_output_wavefield_close();
+    solver_run_collect_timers();
+}
+
+
+/**
+ * Output the velocity of the mesh nodes for the current timestep. Send
+ * the data to Thread 0 who is responsible for dumping the data to disk.
+ *
+ * \note This is only useful for very small distributed setups where:
+ * - There is no parallel file system.
+ * - The distributed file system does not have POSIX semantics.
+ * - The distributed file system performs poorly with just a few clients
+ *   and the effective overall performance is better when only one client
+ *   (i.e., PE 0) is writing to the FS.
+ */
+void
+solver_output_seq()
+{
+    int32_t nindex;
+    int32_t batchlimit, idx;
+
+#ifdef DEBUG
+    int64_t gnid_prev, gnid_current;
+    int32_t first_counted;
+#endif /* DEBUG */
+
+    batchlimit = BATCH * 10;
+
+    /* Allocate a fixed size buffer space if not initiazlied */
+    if (Global.myVelocityTable == NULL) {
+	Global.myVelocityTable = (fvector_t *)calloc(batchlimit, sizeof(fvector_t));
+	if (Global.myVelocityTable == NULL) {
+	    fprintf(stderr,  "Thread %d: solver_output_seq: out of memory\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+    }
+
+    if (Global.myID == 0) {
+	int32_t procid;
+#ifdef DEBUG
+	first_counted = 0;
+#endif
+
+	if (Param.FourDOutFp == NULL) {
+	    out_hdr_t out_hdr;
+
+	    /* First output, create the output file */
+	    Param.FourDOutFp = fopen(Param.FourDOutFile, "w+");
+	    if (Param.FourDOutFp == NULL) {
+		fprintf(stderr, "Thread 0: solver_output_seq: ");
+		fprintf(stderr, "cannot create %s\n", Param.FourDOutFile);
+		perror("fopen");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+
+	    /* Write the header that contains the metadata */
+	    out_hdr.domain_x = Param.theDomainX;
+	    out_hdr.domain_y = Param.theDomainY;
+	    out_hdr.domain_z = Param.theDomainZ;
+	    out_hdr.total_nodes = Global.theNTotal;
+	    out_hdr.total_elements = Global.theETotal;
+	    out_hdr.mesh_ticksize = Global.myMesh->ticksize;
+	    out_hdr.output_steps = (Param.theTotalSteps - 1) / Param.theRate + 1;
+
+	    if (fwrite(&out_hdr, sizeof(out_hdr_t), 1, Param.FourDOutFp) != 1){
+		fprintf(stderr, "Thread 0: solver_output_seq: ");
+		fprintf(stderr, "fail to write 4D-out header info\n");
+		perror("fwrite");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+	}
+
+	/* Output my owned nodes' velocities */
+	nindex = 0;
+	while (nindex < Global.myMesh->nharbored) {
+	    fvector_t vel;
+
+	    if (Global.myMesh->nodeTable[nindex].ismine) {
+		vel.f[0] =
+		    (Global.mySolver->tm1[nindex].f[0]
+		     - Global.mySolver->tm2[nindex].f[0])  / Param.theDeltaT;
+		vel.f[1] =
+		    (Global.mySolver->tm1[nindex].f[1]
+		     - Global.mySolver->tm2[nindex].f[1])  / Param.theDeltaT;
+		vel.f[2] =
+		    (Global.mySolver->tm1[nindex].f[2]
+		     - Global.mySolver->tm2[nindex].f[2])  / Param.theDeltaT;
+
+
+		if (fwrite(&vel, sizeof(fvector_t), 1, Param.FourDOutFp) != 1) {
+		    fprintf(stderr, "Thread 0: solver_output_seq: error\n");
+		    MPI_Abort(MPI_COMM_WORLD, ERROR);
+		    exit(1);
+		}
+
+		Param.the4DOutSize += sizeof(fvector_t);
+
+#ifdef DEBUG
+		gnid_current = Global.myMesh->nodeTable[nindex].gnid;
+
+		if (first_counted) {
+		    if (gnid_prev != (gnid_current - 1)) {
+			fprintf( stderr, "PE 0: uncontinuous gnid\n"
+				 "   gnid_prev = %" INT64_FMT
+				 ", gnid_current = %" INT64_FMT "\n",
+				 gnid_prev, gnid_current);
+		    }
+		} else {
+		    first_counted = 1;
+		}
+
+		gnid_prev = gnid_current;
+
+		if ((vel.f[0] != 0) ||
+		    (vel.f[1] != 0) ||
+		    (vel.f[2] != 0)) {
+		    /*
+		    fprintf(stderr, "Thread 0: Node %ld	 non-zero values\n",
+			    gnid_current);
+		    */
+		}
+#endif /* DEBUG */
+
+	    }
+
+	    nindex++;
+	}
+
+	/* Receive data from other processors */
+	for (procid = 1; procid < Global.theGroupSize; procid++) {
+	    MPI_Status status;
+	    int32_t rcvbytecount;
+
+	    /* Signal the next processor to go ahead */
+	    MPI_Send(NULL, 0, MPI_CHAR, procid, GOAHEAD_MSG, comm_solver);
+
+	    while (1) {
+		MPI_Probe(procid, OUT4D_MSG, comm_solver, &status);
+		MPI_Get_count(&status, MPI_CHAR, &rcvbytecount);
+
+		/* Receive the data even if rcvbytecount == 0. Otherwise
+		   the 0-byte message would get stuck in the message queue */
+		MPI_Recv(Global.myVelocityTable, rcvbytecount, MPI_CHAR, procid,
+			 OUT4D_MSG, comm_solver, &status);
+
+		if (rcvbytecount == 0) {
+		    /* Done */
+		    break;
+		}
+
+		if (fwrite(Global.myVelocityTable, rcvbytecount, 1, Param.FourDOutFp) != 1) {
+		    fprintf(stderr, "Thread 0: solver_output_seq: error\n");
+		    MPI_Abort(MPI_COMM_WORLD, ERROR);
+		    exit(1);
+		}
+
+		Param.the4DOutSize += rcvbytecount;
+
+	    } /* while there is more data to be received from procid */
+	} /* for all the processors */
+
+    } else {
+	/* Processors other than 0 needs to send data to 0 */
+	int32_t sndbytecount;
+	MPI_Status status;
+
+	/* Wait for me turn */
+	MPI_Recv(NULL, 0, MPI_CHAR, 0, GOAHEAD_MSG, comm_solver, &status);
+
+#ifdef DEBUG
+	first_counted = 0;
+#endif
+
+
+	nindex = 0;
+	while (nindex < Global.myMesh->nharbored) {
+	    fvector_t *velp;
+
+	    idx = 0;
+	    while ((idx < batchlimit) &&
+		   (nindex < Global.myMesh->nharbored)) {
+
+		if (Global.myMesh->nodeTable[nindex].ismine) {
+
+		    velp = &Global.myVelocityTable[idx];
+
+		    velp->f[0] =
+			(Global.mySolver->tm1[nindex].f[0]
+			 - Global.mySolver->tm2[nindex].f[0])	/ Param.theDeltaT;
+		    velp->f[1] =
+			(Global.mySolver->tm1[nindex].f[1]
+			 - Global.mySolver->tm2[nindex].f[1])	/ Param.theDeltaT;
+		    velp->f[2] =
+			(Global.mySolver->tm1[nindex].f[2]
+			 - Global.mySolver->tm2[nindex].f[2])	/ Param.theDeltaT;
+
+
+		    idx++;
+
+#ifdef DEBUG
+		    gnid_current = Global.myMesh->nodeTable[nindex].gnid;
+
+		    if (first_counted) {
+			if (gnid_prev != (gnid_current - 1)) {
+			    fprintf( stderr, "PE %d uncontinuous gnid\n"
+				     "	gnid_prev = %" INT64_FMT
+				     ", gnid_current = %" INT64_FMT "\n",
+				     Global.myID, gnid_prev, gnid_current );
+			}
+		    } else {
+			first_counted = 1;
+		    }
+
+		    gnid_prev = gnid_current;
+
+		    /* debug */
+		    /*
+		    if ((velp->f[0] != 0) ||
+			(velp->f[1] != 0) ||
+			(velp->f[2] != 0)) {
+			fprintf(stderr,
+				"Thread %d: there are non-zero values\n",
+				Global.myID);
+				}
+		    */
+#endif /* DEBUG */
+
+		}
+
+		nindex++;
+	    }
+
+	    /* Send data to proc 0 */
+
+	    if (idx > 0) {
+		/* I have some real data to send */
+		sndbytecount = idx * sizeof(fvector_t);
+		MPI_Send(Global.myVelocityTable, sndbytecount, MPI_CHAR, 0, OUT4D_MSG,
+			 comm_solver);
+	    }
+	} /* While there is data left to be sent */
+
+	/* Send an empty message to indicate the end of my transfer */
+	MPI_Send(NULL, 0, MPI_CHAR, 0, OUT4D_MSG, comm_solver);
+    }
+
+    return;
+}
+
+
+/**
+ * Allocate and initialize a scheduler.
+ */
+static schedule_t*
+schedule_new()
+{
+    schedule_t *sched;
+
+    sched = (schedule_t *)malloc(sizeof(schedule_t));
+    if (sched == NULL)
+	return NULL;
+
+    sched->c_count = 0;
+    sched->first_c = NULL;
+    sched->messenger_c = (messenger_t **)
+	calloc(Global.theGroupSize, sizeof(messenger_t *));
+    if (sched->messenger_c == NULL)
+	return NULL;
+
+    sched->s_count = 0;
+    sched->first_s = NULL;
+    sched->messenger_s = (messenger_t **)
+	calloc(Global.theGroupSize, sizeof(messenger_t *));
+    if (sched->messenger_s == NULL)
+	return NULL;
+
+    return sched;
+}
+
+
+
+/**
+ * Allocate the mapping table for each of my messenger.
+ */
+static void
+schedule_allocmapping( schedule_t *sched )
+{
+    messenger_t *messenger;
+    int32_t nodecount;
+
+    messenger = sched->first_c;
+    while (messenger != NULL) {
+	nodecount = messenger->nodecount;
+
+	messenger->mapping =
+	    (int32_t *)calloc(nodecount, sizeof(int32_t));
+
+	if (messenger->mapping == NULL) {
+	    fprintf(stderr, "Thread %d: schedule_allocamapping: ", Global.myID);
+	    fprintf(stderr, " out of memory\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	messenger = messenger->next;
+    }
+
+    messenger = sched->first_s;
+    while (messenger != NULL) {
+	nodecount = messenger->nodecount;
+
+	messenger->mapping =
+	    (int32_t *)calloc(nodecount, sizeof(int32_t));
+
+	if (messenger->mapping == NULL) {
+	    fprintf(stderr, "Thread %d: schedule_allocamapping: ", Global.myID);
+	    fprintf(stderr, " out of memory\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+
+	messenger = messenger->next;
+    }
+
+    return;
+}
+
+
+/**
+ * Allocate MPI controls for non-blocing receives.
+ */
+static void
+schedule_allocMPIctl( schedule_t* sched )
+{
+    if (sched->c_count != 0) {
+	sched->irecvreqs_c =
+	    (MPI_Request *)malloc(sizeof(MPI_Request) * sched->c_count);
+	sched->irecvstats_c =
+	    (MPI_Status *)malloc(sizeof(MPI_Status) * sched->c_count);
+
+	if ((sched->irecvreqs_c == NULL) ||
+	    (sched->irecvstats_c == NULL)) {
+	    fprintf(stderr, "Thread %d: schedule_allocMPIctl: ", Global.myID);
+	    fprintf(stderr, "out of memory\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+    } else {
+	sched->irecvreqs_c = NULL;
+	sched->irecvstats_c = NULL;
+    }
+
+    if (sched->s_count != 0) {
+	sched->irecvreqs_s =
+	    (MPI_Request *)malloc(sizeof(MPI_Request) * sched->s_count);
+	sched->irecvstats_s =
+	    (MPI_Status *)malloc(sizeof(MPI_Status) * sched->s_count);
+
+	if ((sched->irecvreqs_s == NULL) ||
+	    (sched->irecvstats_s == NULL)) {
+	    fprintf(stderr, "Thread %d: schedule_allocMPIctl: ", Global.myID);
+	    fprintf(stderr, "out of memory\n");
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+    } else {
+	sched->irecvreqs_s = NULL;
+	sched->irecvstats_s = NULL;
+    }
+
+    return;
+}
+
+
+/**
+ * Build a communication schedule using local information.
+ */
+static void
+schedule_build( mesh_t* mesh, schedule_t* dnsched, schedule_t* ansched )
+{
+    int32_t nindex;
+    node_t* nodep;
+    messenger_t* messenger;
+
+    for (nindex = 0; nindex < mesh->nharbored; nindex++) {
+	nodep = &mesh->nodeTable[nindex];
+	int32_t owner, sharer;
+
+	if (!nodep->ismine) {
+	    /* I do not own this node. Add its owner processor to my c-list */
+
+	    owner = nodep->proc.ownerid;
+
+	    if (nodep->isanchored) {
+		messenger = ansched->messenger_c[owner];
+	    } else {
+		messenger = dnsched->messenger_c[owner];
+	    }
+
+	    if (messenger == NULL) {
+		messenger = messenger_new(owner);
+		if (messenger == NULL) {
+		    fprintf(stderr, "Thread %d: schedule_build: ", Global.myID);
+		    fprintf(stderr, "out of memory.\n");
+		    MPI_Abort(MPI_COMM_WORLD, ERROR);
+		    exit(1);
+		}
+
+		if (nodep->isanchored) {
+		    ansched->c_count++;
+		    ansched->messenger_c[owner] = messenger;
+		    messenger->next = ansched->first_c;
+		    ansched->first_c = messenger;
+		} else {
+		    dnsched->c_count++;
+		    dnsched->messenger_c[owner] = messenger;
+		    messenger->next = dnsched->first_c;
+		    dnsched->first_c = messenger;
+		}
+	    }
+
+	    /* Update the number of nodecount for the messenger */
+	    messenger->nodecount++;
+
+	} else {
+	    /* I own this node. Add any sharing processor to my s-list */
+
+	    int32link_t *int32link;
+
+	    int32link = nodep->proc.share;
+	    while (int32link != NULL) {
+		sharer = int32link->id;
+
+		if (nodep->isanchored) {
+		    messenger = ansched->messenger_s[sharer];
+		} else {
+		    messenger = dnsched->messenger_s[sharer];
+		}
+
+		if (messenger == NULL) {
+		    messenger = messenger_new(sharer);
+		    if (messenger == NULL) {
+			fprintf(stderr, "Thread %d: schedule_build: ", Global.myID);
+			fprintf(stderr, "out of memory.\n");
+			MPI_Abort(MPI_COMM_WORLD, ERROR);
+			exit(1);
+		    }
+
+		    if (nodep->isanchored) {
+			ansched->s_count++;
+			ansched->messenger_s[sharer] = messenger;
+			messenger->next = ansched->first_s;
+			ansched->first_s = messenger;
+		    } else {
+			dnsched->s_count++;
+			dnsched->messenger_s[sharer] = messenger;
+			messenger->next = dnsched->first_s;
+			dnsched->first_s = messenger;
+		    }
+		}
+
+		/* Update the nodecount */
+		messenger->nodecount++;
+
+		/* Move to the next sharing processor */
+		int32link = int32link->next;
+	    }
+	}
+    }
+
+    /* Allocate MPI controls */
+    schedule_allocMPIctl(ansched);
+    schedule_allocMPIctl(dnsched);
+
+    /* Allocate localnode table for each of the messegners I have */
+    schedule_allocmapping(ansched);
+    schedule_allocmapping(dnsched);
+
+    /* Go through the nodes again and fill out the mapping table */
+    for (nindex = 0; nindex < mesh->nharbored; nindex++) {
+	nodep = &mesh->nodeTable[nindex];
+	int32_t owner, sharer;
+
+	if (!nodep->ismine) {
+	    /* I do not own this node. Add its owner processor to my c-list */
+	    owner = nodep->proc.ownerid;
+
+	    if (nodep->isanchored) {
+		messenger = ansched->messenger_c[owner];
+	    } else {
+		messenger = dnsched->messenger_c[owner];
+	    }
+
+	    if (messenger == NULL) {
+		fprintf(stderr, "Thread %d: schedule_build: ", Global.myID);
+		fprintf(stderr, "encounter NULL messenger.\n");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+
+	    /* Fill in the mapping */
+	    messenger->mapping[messenger->nidx] = nindex;
+	    messenger->nidx++;
+
+	} else {
+	    /* I own this node. Add any sharing processor to my s-list */
+
+	    int32link_t *int32link;
+
+	    int32link = nodep->proc.share;
+	    while (int32link != NULL) {
+		sharer = int32link->id;
+
+		if (nodep->isanchored) {
+		    messenger = ansched->messenger_s[sharer];
+		} else {
+		    messenger = dnsched->messenger_s[sharer];
+		}
+
+		if (messenger == NULL) {
+		    fprintf(stderr, "Thread %d: schedule_build: ", Global.myID);
+		    fprintf(stderr, "encounter NULL messenger.\n");
+		    MPI_Abort(MPI_COMM_WORLD, ERROR);
+		    exit(1);
+		}
+
+		messenger->mapping[messenger->nidx] = nindex;
+		messenger->nidx++;
+
+		/* Move to the next sharing processor */
+		int32link = int32link->next;
+	    }
+	}
+    }
+
+    return ;
+}
+
+
+
+/**
+ * Release memory used by a scheduler.
+ */
+static void
+schedule_delete( schedule_t* sched )
+{
+    messenger_t *current, *next;
+
+    /* Release messengers overseeing my contributions */
+    current = sched->first_c;
+    while (current != NULL) {
+	next = current->next;
+
+	messenger_delete(current);
+	current = next;
+    }
+
+    /* Release messengers overseeing shareing with others */
+    current = sched->first_s;
+    while (current != NULL) {
+	next = current->next;
+
+	messenger_delete(current);
+	current = next;
+    }
+
+    if (sched->irecvreqs_c != NULL)
+	free(sched->irecvreqs_c);
+    if (sched->irecvstats_c != NULL)
+	free(sched->irecvstats_c);
+    free(sched->messenger_c);
+
+    if (sched->irecvreqs_s != NULL)
+	free(sched->irecvreqs_s);
+    if (sched->irecvstats_s != NULL)
+	free(sched->irecvstats_s);
+    free(sched->messenger_s);
+
+    free(sched);
+
+    return;
+}
+
+
+
+/**
+ * Allocate the memory for data exchange.
+ */
+static void
+schedule_prepare( schedule_t* sched, int32_t c_outsize, int32_t c_insize,
+		  int32_t s_outsize, int32_t s_insize )
+{
+    messenger_t* messenger;
+
+    messenger = sched->first_c;
+    while (messenger != NULL) {
+	messenger_set(messenger, c_outsize, c_insize);
+	messenger = messenger->next;
+    }
+
+    messenger = sched->first_s;
+    while (messenger != NULL) {
+	messenger_set(messenger, s_outsize, s_insize);
+	messenger = messenger->next;
+    }
+
+    return;
+
+}
+
+
+
+/**
+ * Assemble the proper information for the group of messengers managed by
+ * a scheduler and send the data.
+ *
+ * \param direction: CONTRIBUTION or SHARING.
+ */
+static void
+schedule_senddata(schedule_t *sched, void *valuetable, int32_t itemsperentry,
+		  int32_t direction, int32_t msgtag)
+{
+    messenger_t *send_messenger, *recv_messenger;
+    int32_t irecvcount, irecvnum, bytesize;
+    MPI_Request *irecvreqs;
+    MPI_Status *irecvstats;
+
+#ifdef DEBUG
+    int64_t *gnidp;
+#endif /* DEBUG */
+
+    if (direction == CONTRIBUTION) {
+	send_messenger = sched->first_c;
+	recv_messenger = sched->first_s;
+	irecvcount = sched->s_count;
+	irecvreqs = sched->irecvreqs_s;
+	irecvstats = sched->irecvstats_s;
+    } else {
+	send_messenger = sched->first_s;
+	recv_messenger = sched->first_c;
+	irecvcount = sched->c_count;
+	irecvreqs = sched->irecvreqs_c;
+	irecvstats = sched->irecvstats_c;
+    }
+
+    /* Post receives */
+    irecvnum = 0;
+    while (recv_messenger != NULL) {
+	bytesize = recv_messenger->nodecount * recv_messenger->insize;
+	MPI_Irecv(recv_messenger->indata, bytesize, MPI_CHAR,
+		  recv_messenger->procid, msgtag, comm_solver,
+		  &irecvreqs[irecvnum]);
+
+	irecvnum++;
+	recv_messenger = recv_messenger->next;
+    }
+
+    /* Asssemble outgoing messages */
+    while (send_messenger != NULL) {
+	int32_t lnid, idx, entry;
+	solver_float *dvalue;
+	solver_float *out;
+
+	for (idx = 0; idx < send_messenger->nidx; idx++) {
+
+	    lnid = send_messenger->mapping[idx];
+
+	    out = (solver_float *)((char *)send_messenger->outdata +
+			     send_messenger->outsize * idx);
+
+	    dvalue = (solver_float *)valuetable + itemsperentry * lnid;
+
+	    for (entry = 0; entry < itemsperentry; entry++)
+		*(out + entry) = *(dvalue + entry);
+
+#ifdef DEBUG
+	    /* For debug, carry the global node id */
+	    gnidp = (int64_t *)
+		((char *)out + itemsperentry * sizeof(solver_float));
+	    *gnidp = Global.myMesh->nodeTable[lnid].gnid;
+#endif /* DEBUG */
+	}
+
+	send_messenger = send_messenger->next;
+    }
+
+    /* Revisit messengers */
+    if (direction == CONTRIBUTION) {
+	send_messenger = sched->first_c;
+	recv_messenger = sched->first_s;
+    } else {
+	send_messenger = sched->first_s;
+	recv_messenger = sched->first_c;
+    }
+
+    /* Send the data */
+    while (send_messenger != NULL) {
+	bytesize = send_messenger->nodecount * send_messenger->outsize;
+	MPI_Send(send_messenger->outdata, bytesize, MPI_CHAR,
+		 send_messenger->procid, msgtag, comm_solver);
+	send_messenger = send_messenger->next;
+    }
+
+    /* Wait till I receive all the data I want */
+    if (irecvcount != 0) {
+	MPI_Waitall(irecvcount, irecvreqs, irecvstats);
+    }
+
+    while (recv_messenger != NULL) {
+	int32_t lnid, idx, entry;
+	solver_float *dvalue;
+	solver_float *in;
+
+	for (idx = 0; idx < recv_messenger->nidx; idx++) {
+
+	    lnid = recv_messenger->mapping[idx];
+
+	    in = (solver_float *)((char *)recv_messenger->indata +
+			    recv_messenger->insize * idx);
+
+	    dvalue = (solver_float *)valuetable + itemsperentry * lnid;
+
+	    for (entry = 0; entry < itemsperentry; entry++) {
+		if (direction == CONTRIBUTION) {
+		    *(dvalue + entry) += *(in + entry);
+		} else {
+		    /* SHARING, overwrite my local value */
+		    *(dvalue + entry) = *(in + entry);
+		}
+	    }
+
+#ifdef DEBUG
+	    /* For debug, check the global node id */
+	    gnidp = (int64_t *)
+		((char *)in + itemsperentry * sizeof(solver_float));
+
+	    if (*gnidp != Global.myMesh->nodeTable[lnid].gnid) {
+		fprintf(stderr, "Thread %d: solver_init: gnids do not match\n",
+			Global.myID);
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+#endif /* DEBUG */
+	} /* for all the incoming data */
+
+	recv_messenger = recv_messenger->next;
+    }
+
+
+    /* MPI_Barrier(comm_solver);  */
+
+    return;
+}
+
+
+/**
+ * Print messenger entry data to the given output stream.
+ * The output line contains the following information:
+ * "pe_id type c/s rpe nodecount outsize insize"
+ *
+ * \note Printing is not synchronized accross PEs, so lines can be out of
+ * order / interleaved
+ */
+static int
+messenger_print( messenger_t* msg, char type, char cs, FILE* out )
+{
+    int ret;
+
+    assert( NULL != msg );
+
+    ret = fprintf( out, "msg_info: %d %c %c %d %d %d %d %d\n", Global.myID, type, cs,
+		   msg->procid, msg->nodecount, msg->outsize, msg->insize,
+		   msg->nodecount * msg->outsize );
+
+    if (ret > 0 || !Param.theSchedulePrintErrorCheckFlag) {
+	ret = 0;
+    } else {  /* ret <= 0 && Param.theSchedulePrintErrorCheckFlag */
+	perror( "Warning! fprintf(...) failed" );
+	fprintf(stderr, "PE id = %d, ret = %d, out = 0x%p\n", Global.myID, ret, out);
+	fflush( stderr );
+    }
+
+    return ret;
+}
+
+
+/**
+ * Print the messenger list for a scheduler
+ *
+ * \note Printing is not synchronized accross PEs, so lines can be out of
+ * order / interleaved
+ */
+static int
+schedule_print_messenger_list( schedule_t* sched, messenger_t* msg, int count,
+			       char type, char cs, FILE* out )
+{
+    messenger_t* m_p;
+    int my_count;
+    int ret = 0;
+
+    assert( NULL != sched );
+
+    m_p = msg;
+
+
+    for (my_count = 0; m_p != NULL && ret >= 0; my_count++, m_p = m_p->next) {
+	ret += messenger_print( msg, type, cs, out );
+    }
+
+
+    if (ret < 0) {
+	return -1;
+    }
+
+    if (my_count != count) {
+	fprintf( stderr, "Warning! schedule list count does not match: "
+		 "%u %c %c %d %d\n", Global.myID, type, cs, count, my_count );
+    }
+
+    return ret;
+}
+
+
+/**
+ * Print scheduler communication to a given output stream.
+ *
+ * Print a line per entry in the schedule_t structure, i.e., an line
+ * per messenger_t entry in the list.
+ *
+ * Each line has the following format:
+ * "pe_id type c/s rpe nodecount outsize insize"
+ */
+static int
+schedule_print_detail( schedule_t* sched, char type, FILE* out )
+{
+    int ret = 0;
+
+    ret += schedule_print_messenger_list( sched, sched->first_c,
+					  sched->c_count, type, 'c', out );
+    ret += schedule_print_messenger_list( sched, sched->first_s,
+					  sched->s_count, type, 's', out );
+
+    return ret;
+}
+
+
+/**
+ * Print scheduler communication to a given output stream.
+ *
+ * Print a line per entry in the schedule_t structure, i.e., an line
+ * per messenger_t entry in the list.
+ *
+ * Each line has the following format:
+ * "pe_id type s_count c_count"
+ *
+ * \note Printing is not synchronized accross PEs, so lines can be out of
+ * order / interleaved
+ */
+static int
+schedule_print( schedule_t* sched, char type, FILE* out )
+{
+    int ret;
+
+    assert( NULL != sched );
+    assert( NULL != out );
+
+    ret = fprintf( out, "sch_info: %u %c %d %d\n", Global.myID, type, sched->c_count,
+		   sched->s_count );
+
+
+    if (ret > 0 || !Param.theSchedulePrintErrorCheckFlag) {
+	ret = 0;
+    }
+
+    return ret;
+}
+
+
+/**
+ * \note Printing is not synchronized accross PEs, so lines can be out of
+ * order / interleaved
+ */
+static int
+solver_print_schedules_imp( mysolver_t* solver, FILE* out )
+{
+    int ret = 0;
+
+    assert( solver != NULL );
+    assert( out != NULL );
+
+    MPI_Barrier(comm_solver);
+
+    /* print the high-level schedule per PE */
+    if (Global.myID == 0) { /* print some header information */
+	fputs( "# ----------------------------------------------------------\n"
+	       "# Content: Solver schedule information\n"
+	       "# pe_id d/a s_count c_count\n", out );
+    }
+    fflush( out );
+    fdatasync( fileno( out ) );
+
+    MPI_Barrier( comm_solver );
+
+    /* this is not synchronized, so it might be out of order */
+    ret += schedule_print( solver->an_sched, 'a', out );
+    ret += schedule_print( solver->dn_sched, 'd', out );
+
+    fflush( out );
+    fdatasync( fileno( out ) );
+    MPI_Barrier( comm_solver );
+
+    /* print the schedule detail */
+    if (Global.myID == 0) { /* print some header information */
+	fputs( "\n\n"
+	       "# ----------------------------------------------------------\n"
+	       "# Content: Solver schedule detail\n"
+	       "# pe_id d/a c/s rpe nodecount outsize insize msgsize\n", out );
+	fflush( out );
+	fdatasync( fileno( out ) );
+    }
+
+    MPI_Barrier( comm_solver );
+
+    /* this is not synchronized, so it might be out of order */
+    ret += schedule_print_detail( solver->an_sched, 'a', out );
+    ret += schedule_print_detail( solver->dn_sched, 'd', out );
+
+    fflush( out );
+    fdatasync( fileno( out ) );
+    MPI_Barrier( comm_solver );
+
+    if (Global.myID == 0) {
+	fputs( "# ----------------------------------------------------------\n"
+	       "\n", out );
+	fflush( out );
+	fdatasync( fileno( out ) );
+    }
+
+    MPI_Barrier( comm_solver );
+
+    return ret;
+}
+
+
+/**
+ * Wrapper to print the solver schedules to stdout and a file with
+ * the given name.
+ *
+ * \note Printing is not synchronized accross PEs, so lines can be out of
+ * order / interleaved
+ */
+static int
+solver_print_schedules( mysolver_t* solver )
+{
+    FILE* out;
+    int ret = 0;
+
+    if (Param.theSchedulePrintToStdout) {
+	/* print schedules to standard output */
+	ret += solver_print_schedules_imp( solver, stdout );
+
+	if (ret < 0) {
+	    fprintf( stderr, "Warning! printing schedules to standard output "
+		     "failed for PE %d\n", Global.myID );
+	}
+    }
+
+    if (Param.theSchedulePrintToFile && (Param.theSchedulePrintFilename != NULL)) {
+	/* print schedules to the given file */
+	out = fopen( Param.theSchedulePrintFilename, "a" );
+
+	if (NULL == out) { /* this is not fatal */
+	    fprintf( stderr, "Warning!, PE# %d failed to open output file for "
+		     "printing the communication schedule\n", Global.myID );
+	    return -1;
+	}
+
+	ret = solver_print_schedules_imp( solver, out );
+
+	if (ret < 0) {
+	    fprintf( stderr, "Warning! PE %d could not print schedules "
+		     "to file\n", Global.myID );
+	}
+
+	fclose( out );
+    }
+
+    return ret;
+}
+
+
+/**
+ * messenger_new: Allocate and initialize a messenger.
+ *
+ */
+static messenger_t *messenger_new(int32_t procid)
+{
+    messenger_t *messenger;
+
+    messenger = (messenger_t *)calloc(1, sizeof(messenger_t));
+
+    if (messenger == NULL)
+	return NULL;
+
+    messenger->procid = procid;
+
+    return messenger;
+}
+
+
+
+/**
+ * messenger_delete: Release memory used by a messenger.
+ *
+ */
+static void messenger_delete(messenger_t *messenger)
+{
+    if (messenger == NULL)
+	return;
+
+    if (messenger->outdata != NULL)
+	free(messenger->outdata);
+
+    if (messenger->indata != NULL)
+	free(messenger->indata);
+
+    free(messenger->mapping);
+
+    free(messenger);
+
+    return;
+}
+
+
+
+/**
+ * messenger_set: Free any data memory used by the messenger for
+ *                previous communication. And allocate new memory
+ *                for the new round of communication.
+ *
+ */
+static void
+messenger_set(messenger_t *messenger, int32_t outsize, int32_t insize)
+{
+    if (messenger->outdata != NULL) {
+	free(messenger->outdata);
+	messenger->outdata = NULL;
+    }
+
+    if (messenger->indata != NULL) {
+	free(messenger->indata);
+	messenger->indata = NULL;
+    }
+
+    messenger->outsize = outsize;
+    messenger->insize = insize;
+
+    if (outsize != 0) {
+	messenger->outdata = calloc(messenger->nodecount, outsize);
+	if (messenger->outdata == NULL) {
+	    fprintf(stderr, "Thread %d: messenger_set: out of memory\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+    }
+
+    if (insize != 0) {
+	messenger->indata = calloc(messenger->nodecount, insize);
+	if (messenger->indata == NULL) {
+	    fprintf(stderr, "Thread %d: messenger_set: out of memory\n",
+		    Global.myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	}
+    }
+
+    return;
+}
+
+
+
+/**
+ * messenger_countnodes: Count the total number of nodes (that need to
+ *                       be communicated) on the messenger link list.
+ *
+ */
+static int32_t
+messenger_countnodes(messenger_t *first)
+{
+    messenger_t *messenger;
+    int32_t total;
+
+    total = 0;
+    messenger = first;
+    while (messenger != NULL) {
+	total += messenger->nodecount;
+	messenger = messenger->next;
+    }
+
+    return total;
+}
+
+
+/**
+ * Compute K1, K2 and K3 for a  linear  elastic,  homogeneous
+ * and isotropic cube; and their off-diagonal matrices.
+ *
+ *            K1 = Integral(   Del(Phi(j))  * T(Del(Phi(i)))     )
+ *            K2 = Integral(   Del(Phi(i))  * T(Del(Phi(j)))     )
+ *            K3 = Integral( T(Del(Phi(i))) *   Del(Phi(j))  * I )
+ *
+ *            where:
+ *
+ *            T(W) = transpose of W.
+ *
+ * \note K offdiagonal has been commented out because is no longer needed
+ * after the changes made on the solution algorith due to the new
+ * form to handle the damping involved terms.
+ */
+static void compute_K()
+{
+    int i, j; /* indices of the block matrices, i for rows, j for columns */
+    int k, l; /* indices of 3 x 3 matrices, k for rows, l for columns     */
+
+    double x[3][8]={ {-1,  1, -1,  1, -1,  1, -1, 1} ,
+		     {-1, -1,  1,  1, -1, -1,  1, 1} ,
+		     {-1, -1, -1, -1,  1,  1,  1, 1} };
+
+    /* compute K3 first */
+    memset(Global.theK3, 0, 8 * 8 * sizeof(fmatrix_t));
+    for (i = 0 ;  i < 8; i++) {
+	for (j = 0; j <8; j++){
+	    /* for  each 3 x 3 matrix representing (node i, node j),
+               each of these matrices is diagonal, off-diagonal elements
+               have been set to 0 in memset() */
+
+	    fmatrix_t *matPtr;
+	    matPtr = &Global.theK3[i][j];
+
+	    for (k = 0; k < 3; k++) {
+		/* set the diagonal values for the 3 x 3 matrix.
+		   Note the rotation of the index */
+		double I1, I2, I3;
+
+		I1 = INTEGRAL_1
+		    (x[(k + 0) % 3][i], x[(k + 0) % 3][j],
+		     x[(k + 1) % 3][i], x[(k + 1) % 3][j],
+		     x[(k + 2) % 3][i], x[(k + 2) % 3][j]);
+
+		I2 = INTEGRAL_1
+		    (x[(k + 1) % 3][i], x[(k + 1) % 3][j],
+		     x[(k + 2) % 3][i], x[(k + 2) % 3][j],
+		     x[(k + 0) % 3][i], x[(k + 0) % 3][j]);
+
+
+		I3 = INTEGRAL_1
+		    (x[(k + 2) % 3][i], x[(k + 2) % 3][j],
+		     x[(k + 0) % 3][i], x[(k + 0) % 3][j],
+		     x[(k + 1) % 3][i], x[(k + 1) % 3][j]);
+
+		matPtr->f[k][k] = I1 + I2 + I3;
+	    } /* k*/
+	} /* j*/
+    } /* i */
+
+    /* compute K1 and K2. They are not diagonal either, but they are
+       indeed symmetric globablly */
+    for (i = 0; i < 8; i++) {
+	for (j = 0; j < 8; j++) {
+	    /* for  each 3 x 3 matrix representing (node i, node j)*/
+
+	    fmatrix_t *matPtr0, *matPtr1;
+	    matPtr0 = &Global.theK1[i][j];
+	    matPtr1 = &Global.theK2[i][j];
+
+	    for (k = 0; k <  3; k++)
+		for (l = 0; l < 3; l++) {
+		    if (k == l) {
+			/* Initialize the diagnoal elements */
+			matPtr0->f[k][k] =
+			    INTEGRAL_1
+			    (x[(k + 0) % 3][i], x[(k + 0) % 3][j],
+			     x[(k + 1) % 3][i], x[(k + 1) % 3][j],
+			     x[(k + 2) % 3][i], x[(k + 2) % 3][j]);
+
+
+			matPtr1->f[k][k] =
+			    INTEGRAL_1
+			    (x[(k + 0) % 3][j], x[(k + 0) % 3][i],
+			     x[(k + 1) % 3][j], x[(k + 1) % 3][i],
+			     x[(k + 2) % 3][j], x[(k + 2) % 3][i]);
+
+		    } else {
+			/* Initialize off-diagonal elements */
+
+			matPtr0->f[k][l] =
+			    INTEGRAL_2
+			    (x[k][j], x[l][i],
+			     x[3 - (k + l)][j], x[3 - (k + l)][i]);
+
+			matPtr1->f[k][l] =
+			    INTEGRAL_2
+			    (x[k][i], x[l][j],
+			     x[3 - (k + l)][i], x[3 - (k + l)][j]);
+
+		    } /* else */
+		} /* for l */
+	} /* for j */
+    } /* i */
+
+    /* Old code for damping                                    */
+    /* Create the off-diagonal matrices                        */
+    /* memcpy(theK1_offdiag, Global.theK1, sizeof(double) * 24 * 24); */
+    /* memcpy(theK2_offdiag, Global.theK2, sizeof(double) * 24 * 24); */
+    /* memcpy(theK3_offdiag, Global.theK3, sizeof(double) * 24 * 24); */
+    /* for (i = 0; i <8; i++) {                                */
+    /*     theK1_offdiag[i][i].f[0][0] = 0;                    */
+    /*     theK1_offdiag[i][i].f[1][1] = 0;                    */
+    /*     theK1_offdiag[i][i].f[2][2] = 0;                    */
+    /*     theK2_offdiag[i][i].f[0][0] = 0;                    */
+    /*     theK2_offdiag[i][i].f[1][1] = 0;                    */
+    /*     theK2_offdiag[i][i].f[2][2] = 0;                    */
+    /*     theK3_offdiag[i][i].f[0][0] = 0;                    */
+    /*     theK3_offdiag[i][i].f[1][1] = 0;                    */
+    /*     theK3_offdiag[i][i].f[2][2] = 0;                    */
+    /* }                                                       */
+
+    /* New code:
+     * First option to solve double K1 K3 computation in the
+     * time steps is to merge both of them in K1 only
+     */
+    for ( i = 0; i < 8; i++ )
+    {
+	for ( j = 0; j < 8; j++ )
+	{
+	    for ( k = 0; k < 3; k++ )
+	    {
+		for ( l = 0; l < 3; l++ )
+		{
+		    Global.theK1[i][j].f[k][l] += Global.theK3[i][j].f[k][l];
+		}
+	    }
+	}
+    }
+
+    return;
+}
+
+static void constract_Quality_Factor_Table()
+{
+int i,j;
+double local_QTABLE[26][6] = {{ 5.,	0.211111102, 0.236842104, 0.032142857, 0.271428571,	0.14},
+		{6.25,	0.188888889,	0.184210526,	0.039893617,	0.336879433,	0.10152},
+		{8.33,	0.157777778,	0.139473684,	0.045,	0.38,	0.07},
+		{10., 0.137777765, 0.12105263, 0.032942899, 0.27818448, 0.0683},
+		{15., 0.097777765,	0.08105263,	0.032942899,	0.27818448,	0.045},
+		{20., 0.078139527, 0.060526314,	0.031409788, 0.277574872, 0.034225},
+		{25., 0.064285708, 0.049999999,	0.031578947, 0.285714286, 0.0266},
+		{30.,	0.053658537,	0.044736842,	0.026640676,	0.24691358,	0.023085},
+		{35.,	0.046341463,	0.038157895,	0.02709848,	0.251156642,	0.019669},
+		{40.,	0.040487805,	0.034210526,	0.025949367,	0.240506329,	0.01738},
+		{45.,	0.036585366,	0.028947368,	0.031393568,	0.290964778,	0.014366},
+		{50.,	0.032926829,	0.026315789,	0.032488114,	0.30110935,	0.01262},
+		{60.,     0.0279,    0.0223,    0.0275,    0.2545,    0.0114},
+		{70.,   0.024,			0.019,			0.032488114,    0.30110935, 0.0083},
+		{80.,  0.0207,    0.0174,    0.0251,    0.2326,    0.0088},
+		{90.,    0.0187,    0.0154,    0.0244,    0.2256,    0.0079},
+		{100.,	0.017,	0.014,	0.028021016,	0.288966725,	0.006281},
+		{120.,     0.0142,    0.0115,    0.0280,   0.2700,    0.0052},
+		{150.,  0.0114,    0.0094,    0.0240,    0.2316,    0.0047},
+		{200.,	0.0085,	0.00705,	0.022603978,	0.226039783,	0.0035392},
+		{250., 0.0069,    0.0055,    0.0269,    0.2596,    0.0027},
+		{300.,	0.0057,	0.0047,	0.027072758,	0.279187817,	0.0021276},
+		{350,  0.0048,    0.0040,    0.0242,    0.2339,    0.0020},
+		{400.,	0.0043,	0.0036,	0.021425572,	0.214255718,	0.0017935},
+		{450., 0.0039,    0.0030,   0.0280,    0.2710,    0.0015},
+		{500.,	0.0035,	0.00285,	0.023408925,	0.241404535,	0.001367}
+};
+
+for(i = 0; i < 18; i++)
+{
+	for(j = 0; j < 6; j++)
+	{
+		Global.theQTABLE[i][j] = local_QTABLE[i][j];
+//		printf("%f ",theQTABLE[i][j]);
+	}
+//	printf("\n");
+}
+return;
+}
+
+
+/**
+ * compute_setflag:
+ *
+ * - results from the discussion with Leo
+ * - set flags as if in the full space.
+ * - the main() routine will set the flag properly in case half-space
+ *   is desired.
+ *
+ */
+#ifdef BOUNDARY
+static char
+compute_setflag(tick_t ldb[3], tick_t ruf[3], tick_t p1[3], tick_t p2[3])
+{
+    char flag;
+
+    flag = 13; /* indicate internal element */
+
+    if (ldb[0] == p1[0])
+	flag = 12;
+    if (ldb[1] == p1[1])
+	flag = 10;
+    if (ldb[2] == p1[2])
+	flag = 4;
+
+    if (ruf[0] == p2[0])
+	flag = 14;
+    if (ruf[1] == p2[1])
+	flag = 16;
+    if (ruf[2] == p2[2])
+	flag = 22;
+
+
+    if(ldb[0] == p1[0] && ldb[1] == p1[1])
+	flag = 9;
+
+    if(ruf[0] == p2[0] && ldb[1] == p1[1])
+	flag = 11;
+
+    if(ldb[0] == p1[0] && ruf[1] == p2[1])
+	flag = 15;
+
+    if(ruf[0] == p2[0] &&   ruf[1] == p2[1])
+	flag = 17;
+
+
+    if (ldb[0] == p1[0] && ldb[2] == p1[2])
+	flag = 3;
+
+    if (ruf[0] == p2[0] && ldb[2] == p1[2])
+	flag = 5;
+
+    if (ldb[0] == p1[0] && ruf[2] == p2[2])
+	flag = 21;
+
+    if (ruf[0] == p2[0] && ruf[2] == p2[2])
+	flag = 23;
+
+
+    if (ldb[1] == p1[1] && ldb[2] == p1[2])
+	flag = 1;
+
+    if (ruf[1] == p2[1] && ldb[2] == p1[2])
+	flag = 7;
+
+    if (ldb[1] == p1[1] && ruf[2] == p2[2])
+	flag = 19;
+
+    if (ruf[1] == p2[1] && ruf[2] == p2[2])
+	flag = 25;
+
+    if (ldb[0] == p1[0] && ldb[1] == p1[1] && ldb[2] == p1[2])
+	flag = 0;
+
+    if (ruf[0] == p2[0] && (ldb[1] == p1[1]) && ldb[2] == p1[2])
+	flag = 2;
+
+    if (ldb[0] == p1[0] && ruf[1] == p2[1] && ldb[2] == p1[2])
+	flag = 6;
+
+    if (ruf[0] == p2[0] && ruf[1] == p2[1] && ldb[2] == p1[2])
+	flag = 8;
+
+    if (ldb[0] == p1[0] && ldb[1] == p1[1] && ruf[2] == p2[2])
+	flag = 18;
+
+    if (ruf[0] == p2[0] && ldb[1] == p1[1] && ruf[2] == p2[2])
+	flag = 20;
+
+    if (ldb[0] == p1[0] && ruf[1] == p2[1] && ruf[2] == p2[2])
+	flag = 24;
+
+    if (ruf[0] == p2[0] && ruf[1] == p2[1] && ruf[2] == p2[2])
+	flag = 26;
+
+    return flag;
+}
+
+
+
+static const int theIDBoundaryMatrix[27][8] = {
+    { 7, 6, 5, 4, 3, 2, 1, 0},
+    { 6, 6, 4, 4, 2, 2, 0, 0},
+    { 6, 7, 4, 5, 2, 3, 0, 1},
+    { 5, 4, 5, 4, 1, 0, 1, 0},
+    { 4, 4, 4, 4, 0, 0, 0, 0},
+    { 4, 5, 4, 5, 0, 1, 0, 1},
+    { 5, 4, 7, 6, 1, 0, 3, 2},
+    { 4, 4, 6, 6, 0, 0, 2, 2},
+    { 4, 5, 6, 7, 0, 1, 2, 3},
+    { 3, 2, 1, 0, 3, 2, 1, 0},
+    { 2, 2, 0, 0, 2, 2, 0, 0},
+    { 2, 3, 0, 1, 2, 3, 0, 1},
+    { 1, 0, 1, 0, 1, 0, 1, 0},
+    { 0, 0, 0, 0, 0, 0, 0, 0}, /* 13: internal elements */
+    { 0, 1, 0, 1, 0, 1, 0, 1},
+    { 1, 0, 3, 2, 1, 0, 3, 2},
+    { 0, 0, 2, 2, 0, 0, 2, 2},
+    { 0, 1, 2, 3, 0, 1, 2, 3},
+    { 3, 2, 1, 0, 7, 6, 5, 4},
+    { 2, 2, 0, 0, 6, 6, 4, 4},
+    { 2, 3, 0, 1, 6, 7, 4, 5},
+    { 1, 0, 1, 0, 5, 4, 5, 4},
+    { 0, 0, 0, 0, 4, 4, 4, 4},
+    { 0, 1, 0, 1, 4, 5, 4, 5},
+    { 1, 0, 3, 2, 5, 4, 7, 6},
+    { 0, 0, 2, 2, 4, 4, 6, 6},
+    { 0, 1, 2, 3, 4, 5, 6, 7},
+};
+
+
+
+
+
+static void
+compute_setboundary(float size, float Vp, float Vs, float rho, int flag,
+		    double dashpot[8][3])
+{
+    int whichNode;
+    double scale;
+
+    /* init the damping vector to all zeroes */
+    memset(dashpot, 0, sizeof(double) * 8 * 3);
+
+#ifdef HALFSPACE
+    flag = (flag < 9) ? flag + 9 : flag;
+#endif /* HALFSPACE */
+
+    scale = rho * (size / 2) * (size / 2);
+
+    for (whichNode = 0 ; whichNode < 8; whichNode++) {
+	int bitmark, component;
+
+	bitmark = theIDBoundaryMatrix[flag][whichNode];
+
+	switch (bitmark) {
+	case 0:
+	    break;
+	case 7:
+	    /* Three contributing faces */
+	    dashpot[whichNode][0] = dashpot[whichNode][1]
+		= dashpot[whichNode][2] = (Vp + 2 * Vs) * scale;
+	    break;
+	case 3:
+	case 5:
+	case 6:
+	    /* Two contributing faces */
+	    for (component = 0; component < 3; component++)
+		dashpot[whichNode][component] =
+		    (Vs + ((bitmark & (1<< component)) ? Vp : Vs)) * scale;
+	    break;
+	case 1:
+	case 2:
+	case 4:
+	    /* One contributing face */
+	    for (component = 0; component < 3; component++)
+		dashpot[whichNode][component] =
+		    ((bitmark & (1<<component)) ? Vp : Vs) * scale;
+	    break;
+	default:
+	    fprintf(stderr, "SetBoundary: Unknown bitmark. Panic!\n");
+	    exit(1);
+	}
+    }
+
+    return;
+}
+#endif /* BOUNDARY */
+
+
+
+/**
+ * compute_setab: the base a and b values will be scaled by zeta
+ *                specific to each element.
+ */
+static void compute_setab(double freq, double *aBasePtr, double *bBasePtr)
+{
+    /* old version which caused overflow because of the aproximation in
+     * the derivative */
+
+    double w1, w2, lw1, lw2, sw1, sw2, cw1, cw2;
+    double numer, denom;
+
+    if (Param.theTypeOfDamping == RAYLEIGH)
+    {
+	/* the factors 0.2 and 1 were calibrated heuristically by LEO */
+	w1 = 2 * PI * freq *.2;
+	w2 = 2 * PI * freq * 1;
+
+	/* logs */
+	lw1 = log(w1);
+	lw2 = log(w2);
+
+	/* squares */
+	sw1 = w1 * w1;
+	sw2 = w2 * w2;
+
+	/* cubes */
+	cw1 = w1 * w1 * w1;
+	cw2 = w2 * w2 * w2;
+
+	/* numerator */
+	numer = w1 * w2 *
+	    ( -2 * sw1 * lw2 + 2 * sw1 * lw1 - 2 * w1 * w2 * lw2
+	      + 2 * w1 * w2 * lw1 + 3 * sw2 - 3 * sw1
+		  - 2 * sw2 * lw2 + 2 * sw2 * lw1);
+
+	/* denominator */
+	denom = (cw1 - cw2 + 3 * sw2 * w1 - 3 * sw1 * w2);
+
+	/* the a over zeta target is... */
+	*aBasePtr = numer / denom;
+
+	/* new numerator */
+	numer = 3 * (2 * w1 * w2 * lw2 - 2 * w1 * w2 * lw1 + sw1 - sw2);
+
+	/* the b over zeta target is... */
+	*bBasePtr = numer / denom;
+
+    }
+    else if ( Param.theTypeOfDamping == MASS )
+    {
+	w1 = 2 * PI * freq * .1;  /* these .1 and 8 heuristics */
+	w2 = 2 * PI * freq * 8;
+
+	numer = 2 * w2 * w1 * log(w2 / w1);
+	denom = w2 - w1;
+
+	*aBasePtr = 1.3*numer / denom;  /* this 1.3 comes out from heuristics */
+	*bBasePtr = 0;
+    }
+    else if ( Param.theTypeOfDamping == NONE || Param.theTypeOfDamping == BKT )
+    {
+	*aBasePtr = 0;
+	*bBasePtr = 0;
+    }
+
+    return;
+}
+
+
+
+int
+is_nodeloaded( int32_t iNode, char* onoff )
+{
+    /* \todo use a general bitmap data structure for this */
+    /* \todo move the routine declaration to the source generation file */
+
+    int32_t whichByte, whichBit;
+
+    char mask,test;
+
+    whichByte = iNode/8;
+    whichBit = 7 - iNode % 8;
+
+    mask = ( char )pow(2,whichBit);
+
+    test = onoff[whichByte] & mask;
+
+    return (test == mask);  /* 1 if equal, 0 otherwise */
+}
+
+
+/**
+ * Add the force due to earthquake source.
+ *
+ * Globals accessed:
+ * - Global.mySolver->force (W)
+ * - Param.theDeltaTSquared (R)
+ * - Global.myForces (R)
+ *
+ * Iterates over the nodes that are loaded by the source and set the
+ * respective forces for those nodes.
+ */
+static void
+compute_addforce_s( int32_t timestep )
+{
+    int i;	/* index for loaded nodes (from the source) */
+
+    for (i = 0; i <  Global.theNodesLoaded; i++) {
+	int lnid = Global.theNodesLoadedList[i];	/* local node id */
+
+	/* node's force vector */
+	fvector_t* nodalForce =	Global.mySolver->force + lnid;
+
+	/* vector-scalar multiply */
+	nodalForce->f[0] = ( Global.myForces [ i ].x [0] ) * Param.theDeltaTSquared;
+	nodalForce->f[1] = ( Global.myForces [ i ].x [1] ) * Param.theDeltaTSquared;
+	nodalForce->f[2] = ( Global.myForces [ i ].x [2] ) * Param.theDeltaTSquared;
+    }
+}
+
+/**
+ * compute_adjust: Either distribute the values from LOCAL dangling nodes
+ *                 to LOCAL anchored nodes, or assign values from LOCAL
+ *                 anchored nodes to LOCAL dangling nodes.
+ *
+ */
+static void
+compute_adjust(void *valuetable, int32_t itemsperentry, int32_t how)
+{
+    solver_float *vtable = (solver_float *)valuetable;
+    int32_t dnindex;
+
+    if (how == DISTRIBUTION) {
+	for (dnindex = 0; dnindex < Global.myMesh->ldnnum; dnindex++) {
+	    dnode_t *dnode;
+	    solver_float *myvalue, *parentvalue;
+	    solver_float darray[7]; /* A hack to avoid memory allocation */
+	    int32link_t *int32link;
+	    int32_t idx, parentlnid;
+#ifdef DEBUG
+	    int32_t deps = 0;
+#endif /* DEBUG */
+
+	    dnode = &Global.myMesh->dnodeTable[dnindex];
+	    myvalue = vtable + dnode->ldnid * itemsperentry;
+
+	    for (idx = 0; idx < itemsperentry; idx++) {
+		darray[idx] = (*(myvalue + idx)) / dnode->deps;
+	    }
+
+	    /* Distribute my darray value to my anchors */
+	    int32link = dnode->lanid;
+	    while (int32link != NULL) {
+
+#ifdef DEBUG
+		deps++;
+#endif
+
+		parentlnid = int32link->id;
+		parentvalue = vtable + parentlnid * itemsperentry;
+
+		for (idx = 0; idx < itemsperentry; idx++) {
+		    /* Accumulation the distributed values */
+		    *(parentvalue + idx) += darray[idx];
+		}
+
+		int32link = int32link->next;
+	    }
+
+#ifdef DEBUG
+	    if (deps != (int)dnode->deps) {
+		fprintf(stderr, "Thread %d: compute_adjust distri: ", Global.myID);
+		fprintf(stderr, "deps don't match\n");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+#endif /* DEBUG */
+	} /* for all my LOCAL dangling nodes */
+
+    } else {
+	/* Assign the value of the anchored parents to the dangling nodes*/
+
+	for (dnindex = 0; dnindex < Global.myMesh->ldnnum; dnindex++) {
+	    dnode_t *dnode;
+	    solver_float *myvalue, *parentvalue;
+	    int32link_t *int32link;
+	    int32_t idx, parentlnid;
+#ifdef DEBUG
+	    int32_t deps = 0;
+#endif /* DEBUG */
+
+	    dnode = &Global.myMesh->dnodeTable[dnindex];
+	    myvalue = vtable + dnode->ldnid * itemsperentry;
+
+	    /* Zero out the residual values the dangling node might
+	       still hold */
+	    memset(myvalue, 0, sizeof(solver_float) * itemsperentry);
+
+	    /* Assign prorated anchored values to a dangling node */
+	    int32link = dnode->lanid;
+	    while (int32link != NULL) {
+
+#ifdef DEBUG
+		deps++;
+#endif
+
+		parentlnid = int32link->id;
+		parentvalue = vtable + parentlnid * itemsperentry;
+
+		for (idx = 0; idx < itemsperentry; idx++) {
+		    *(myvalue + idx) += (*(parentvalue + idx) / dnode->deps);
+		}
+
+		int32link = int32link->next;
+	    }
+
+#ifdef DEBUG
+	    if (deps != (int)dnode->deps) {
+		fprintf(stderr, "Thread %d: compute_adjust assign: ", Global.myID);
+		fprintf(stderr, "deps don't match\n");
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+#endif /* DEBUG */
+
+	} /* for all my LOCAL dangling nodes */
+    }
+
+    return;
+}
+
+static void print_timing_stat()
+{
+
+    double TotalMeshingTime;
+    TotalMeshingTime = Timer_Value("Octor Newtree"          , (TimerKind)0)
+                     + Timer_Value("Octor Refinetree"       , (TimerKind)0)
+                     + Timer_Value("Octor Balancetree"      , (TimerKind)0)
+                     + Timer_Value("Octor Partitiontree"    , (TimerKind)0)
+                     + Timer_Value("Octor Extractmesh"      , (TimerKind)0)
+                     + Timer_Value("Mesh correct properties", (TimerKind)0)
+                     + Timer_Value("Mesh Stats Print"       , (TimerKind)0);
+
+    if ( Param.includeBuildings == YES ) {
+        TotalMeshingTime += Timer_Value("Carve Buildings", (TimerKind)0);
+    }
+
+    printf("\n\n__________________________Raw Timers__________________________\n\n");
+    Timer_PrintAll(comm_solver);
+    printf("\n\n\n\n\n");
+
+
+    printf("\n\n__________________________Timer Statistics__________________________\n\n");
+
+
+    printf("\n_____________Summary_____________\n");
+    printf("Max Frequency             : %.2f\n", Param.theFreq);
+    printf("Vs                        : %.2f\n", Param.theVsCut);
+    printf("Total elements            : %" INT64_FMT "\n", Global.theETotal);
+    printf("Elements/PE               : %" INT64_FMT "\n", Global.theETotal/Global.theGroupSize);
+    printf("Simulation duration       : %.2f seconds\n", Param.theEndT - Param.theStartT);
+    printf("Total steps               : %d\n", Param.theTotalSteps);
+    printf("DeltaT used               : %.6f seconds\n", Param.theDeltaT);
+    printf("Critical deltaT           : %.6f seconds\n", Global.theCriticalT);
+    printf("\n");
+    printf("Total Wall Clock          : %.2f seconds\n", Timer_Value("Total Wall Clock",(TimerKind)0));
+    printf("Time/step                 : %.6f seconds\n", Timer_Value("Solver",(TimerKind)0)/Param.theTotalSteps);
+    printf("Time/step/(elem/PE)       : %.6f millisec\n",Timer_Value("Solver",(TimerKind)0) * 1000.0 / Param.theTotalSteps /
+	   (Global.theETotal * 1.0 / Global.theGroupSize));
+    printf("Simulation Rate Variation : %.3f (Average)   %.3f (Min)   %.3f (Max)  (sec/%d timesteps)\n",
+	   (Timer_Value("Solver",(TimerKind)0)/Param.theTotalSteps)*Param.monitor_stats_rate,
+	   Global.fastestTimeSteps, Global.slowestTimeSteps, Param.monitor_stats_rate);
+    printf("\n");
+
+
+    printf("\n____________Breakdown____________\n");
+    printf("TOTAL MESHING                       : %.2f seconds\n", TotalMeshingTime);
+    printf("    Octor Newtree                   : %.2f seconds\n", Timer_Value("Octor Newtree",(TimerKind)0) );
+    printf("    Octor Refinetree                : %.2f seconds\n", Timer_Value("Octor Refinetree",(TimerKind)0));
+    printf("    Octor Balancetree               : %.2f seconds\n", Timer_Value("Octor Balancetree",(TimerKind)0));
+    if ( Timer_Exists("Carve Buildings") )
+        printf("    Octor Carve Buildings           : %.2f seconds\n", Timer_Value("Carve Buildings",(TimerKind)0));
+    printf("    Octor Partitiontree             : %.2f seconds\n", Timer_Value("Octor Partitiontree",(TimerKind)0));
+    printf("    Octor Extractmesh               : %.2f seconds\n", Timer_Value("Octor Extractmesh",(TimerKind)0));
+    printf("    Mesh correct properties         : %.2f seconds\n", Timer_Value("Mesh correct properties",(TimerKind)0));
+    printf("    Mesh Stats Print                : %.2f seconds\n", Timer_Value("Mesh Stats Print",(TimerKind)0));
+    printf("\n");
+
+    if(Param.drmImplement == YES) {
+
+    	printf("DRM INIT PARAMETERS                 : %.2f (Max) %.2f (Min) seconds\n",
+    			Timer_Value("Init Drm Parameters",MAX), Timer_Value("Init Drm Parameters",MIN));
+    	printf("\n");
+
+    	printf("DRM INITIALIZATION                  : %.2f (Max) %.2f (Min) seconds\n",
+    			Timer_Value("Drm Init",MAX), Timer_Value("Drm Init",MIN));
+
+    	if(Param.theDrmPart == PART2) {
+
+    		printf("    Find Drm File To Readjust       : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    				Timer_Value("Find Drm File To Readjust",AVERAGE),
+    				Timer_Value("Find Drm File To Readjust",MAX),
+    				Timer_Value("Find Drm File To Readjust",MIN));
+
+    		printf("    Fill Drm Struct                 : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    				Timer_Value("Fill Drm Struct",AVERAGE),
+    				Timer_Value("Fill Drm Struct",MAX),
+    				Timer_Value("Fill Drm Struct",MIN));
+
+    		printf("    Comm of Drm Coordinates         : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    				Timer_Value("Comm of Drm Coordinates",AVERAGE),
+    				Timer_Value("Comm of Drm Coordinates",MAX),
+    				Timer_Value("Comm of Drm Coordinates",MIN));
+
+    		printf("    Find Which Drm Files To Print   : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    				Timer_Value("Find Which Drm Files To Print",AVERAGE),
+    				Timer_Value("Find Which Drm Files To Print",MAX),
+    				Timer_Value("Find Which Drm Files To Print",MIN));
+
+    		printf("    Read And Rearrange Drm Files    : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    				Timer_Value("Read And Rearrange Drm Files",AVERAGE),
+    				Timer_Value("Read And Rearrange Drm Files",MAX),
+    				Timer_Value("Read And Rearrange Drm Files",MIN));
+
+    		printf("    Find Which Drm Files To Read    : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    				Timer_Value("Find Which Drm Files To Read",AVERAGE),
+    				Timer_Value("Find Which Drm Files To Read",MAX),
+    				Timer_Value("Find Which Drm Files To Read",MIN));
+
+    		printf("    Locate where I am in file       : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    				Timer_Value("Locate where I am in file",AVERAGE),
+    				Timer_Value("Locate where I am in file",MAX),
+    				Timer_Value("Locate where I am in file",MIN));
+
+    	}
+    	printf("\n");
+    }
+
+    printf("SOURCE INITIALIZATION               : %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Source Init",MAX), Timer_Value("Source Init",MIN));
+    printf("\n");
+    printf("TOTAL SOLVER                        : %.2f seconds\n", Timer_Value("Solver",(TimerKind)0));
+    printf("    Read My Forces                  : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Read My Forces",AVERAGE),
+	   Timer_Value("Read My Forces",MAX),
+	   Timer_Value("Read My Forces",MIN));
+    printf("    Compute addforces s             : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Compute addforces s",AVERAGE),
+	   Timer_Value("Compute addforces s",MAX),
+	   Timer_Value("Compute addforces s",MIN));
+    printf("    Compute addforces e             : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Compute addforces e",AVERAGE),
+	   Timer_Value("Compute addforces e",MAX),
+	   Timer_Value("Compute addforces e",MIN));
+    printf("    Compute Damping addforce        : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Damping addforce",AVERAGE),
+	   Timer_Value("Damping addforce",MAX),
+	   Timer_Value("Damping addforce",MIN));
+    if ( Timer_Exists("Compute Non-linear Entities") )
+        printf("    Compute Non-linear Entities     : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+                Timer_Value("Compute Non-linear Entities",AVERAGE),
+                Timer_Value("Compute Non-linear Entities",MAX),
+                Timer_Value("Compute Non-linear Entities",MIN));
+    if ( Timer_Exists("Compute addforces Non-linear") ) {
+        printf("    Compute addforces Non-linear    : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+                Timer_Value("Compute addforces Non-linear",AVERAGE),
+                Timer_Value("Compute addforces Non-linear",MAX),
+                Timer_Value("Compute addforces Non-linear",MIN));
+        printf("    Compute addforces gravity       : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+                Timer_Value("Compute addforces gravity",AVERAGE),
+                Timer_Value("Compute addforces gravity",MAX),
+                Timer_Value("Compute addforces gravity",MIN));
+    }
+
+    if ( Timer_Exists("Solver drm force compute") ) {
+    	printf("    Solver drm force compute        : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    			Timer_Value("Solver drm force compute",AVERAGE),
+    			Timer_Value("Solver drm force compute",MAX),
+    			Timer_Value("Solver drm force compute",MIN));
+    }
+    printf("    1st schedule send data          : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("1st schedule send data (contribution)",AVERAGE),
+	   Timer_Value("1st schedule send data (contribution)",MAX),
+	   Timer_Value("1st schedule send data (contribution)",MIN));
+    printf("    1st compute adjust              : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("1st compute adjust (distribution)",AVERAGE),
+	   Timer_Value("1st compute adjust (distribution)",MAX),
+	   Timer_Value("1st compute adjust (distribution)",MIN));
+    printf("    2nd schedule send data          : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("2nd schedule send data (contribution)",AVERAGE),
+	   Timer_Value("2nd schedule send data (contribution)",MAX),
+	   Timer_Value("2nd schedule send data (contribution)",MIN));
+    printf("    Compute new displacement        : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Compute new displacement",AVERAGE),
+	   Timer_Value("Compute new displacement",MAX),
+	   Timer_Value("Compute new displacement",MIN));
+    printf("    3rd schedule send data          : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("3rd schedule send data (sharing)",AVERAGE),
+	   Timer_Value("3rd schedule send data (sharing)",MAX),
+	   Timer_Value("3rd schedule send data (sharing)",MIN));
+    printf("    2nd compute adjust              : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("2nd compute adjust (assignment)",AVERAGE),
+	   Timer_Value("2nd compute adjust (assignment)",MAX),
+	   Timer_Value("2nd compute adjust (assignment)",MIN));
+    printf("    4th schadule send data          : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("4th schadule send data (sharing)",AVERAGE),
+	   Timer_Value("4th schadule send data (sharing)",MAX),
+	   Timer_Value("4th schadule send data (sharing)",MIN));
+    printf("    IO\n");
+
+    if ( Timer_Exists("Solver drm output") ) {
+    	printf("        Drm Output                  : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    			Timer_Value("Solver drm output",AVERAGE),
+    			Timer_Value("Solver drm output",MAX),
+    			Timer_Value("Solver drm output",MIN));
+    }
+    if ( Timer_Exists("Solver drm read displacements") ) {
+    	printf("        Solver drm read disp        : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+    			Timer_Value("Solver drm read displacements",AVERAGE),
+    			Timer_Value("Solver drm read displacements",MAX),
+    			Timer_Value("Solver drm read displacements",MIN));
+    }
+    printf("        Solver Stats Print          : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Solver Stats Print",AVERAGE),
+	   Timer_Value("Solver Stats Print",MAX),
+	   Timer_Value("Solver Stats Print",MIN));
+    if( Timer_Exists("Print Planes") )
+	printf("        Planes                      : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	       Timer_Value("Print Planes",AVERAGE),
+	       Timer_Value("Print Planes",MAX),
+	       Timer_Value("Print Planes",MIN));
+    if( Timer_Exists("Print Stations") )
+	printf("        Stations                    : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	       Timer_Value("Print Stations",AVERAGE),
+	       Timer_Value("Print Stations",MAX),
+	       Timer_Value("Print Stations",MIN));
+    if( Timer_Exists("Checkpoint") )
+	printf("        Checkpoint                  : %.2f\n",
+	       Timer_Value("Checkpoint",(TimerKind)0));
+    printf("\n");
+    printf("TOTAL WALL CLOCK                    : %.2f seconds\n", Timer_Value("Total Wall Clock",(TimerKind)0));
+    printf("\n");
+    printf("\n____________Analysis_____________\n");
+    printf("Solver I/O                 : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Solver I/O",      AVERAGE),Timer_Value("Solver I/O",      MAX), Timer_Value("Solver I/O",      MIN));
+    printf("Solver Compute             : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Compute Physics", AVERAGE),Timer_Value("Compute Physics", MAX), Timer_Value("Compute Physics", MIN));
+    printf("Solver Communicate         : %.2f (Average)   %.2f (Max) %.2f (Min) seconds\n",
+	   Timer_Value("Communication",   AVERAGE),Timer_Value("Communication",   MAX), Timer_Value("Communication",   MIN));
+    printf("Compute/Communicate Ratio  : %.2f \n",
+	   Timer_Value("Compute Physics", AVERAGE) / Timer_Value("Communication",   AVERAGE) );
+    printf("\n\n\n\n");
+
+    fflush (stdout);
+
+    return;
+}
+
+
+
+
+/**
+ * Prepare data to compute the myForce vector.  It calls compute_force.
+ */
+static void
+source_init( const char* physicsin )
+{
+	if(( Param.drmImplement == NO )||( Param.drmImplement == YES && Param.theDrmPart == PART1 )){
+
+		double globalDelayT = 0;
+		double surfaceShift = 0;
+
+		/* Load to Global.theMPIInformation */
+		Global.theMPIInformation.myid      = Global.myID;
+		Global.theMPIInformation.groupsize = Global.theGroupSize;
+
+		/* Load to theNumericsInforamation */
+		Global.theNumericsInformation.numberoftimesteps = Param.theTotalSteps;
+		Global.theNumericsInformation.deltat	     = Param.theDeltaT;
+		Global.theNumericsInformation.validfrequency    = Param.theFreq;
+
+		Global.theNumericsInformation.xlength = Param.theDomainX;
+		Global.theNumericsInformation.ylength = Param.theDomainY;
+		Global.theNumericsInformation.zlength = Param.theDomainZ;
+
+		if ( Param.includeNonlinearAnalysis == YES ) {
+			globalDelayT = get_geostatic_total_time();
+		}
+
+		if ( Param.includeBuildings == YES ) {
+			surfaceShift = get_surface_shift();
+		}
+
+		/* it will create the files to be read each time step to
+       load (force) the mesh */
+		if ( compute_print_source( physicsin, Global.myOctree, Global.myMesh,
+				Global.theNumericsInformation, Global.theMPIInformation,
+				globalDelayT, surfaceShift ) )
+		{
+			fprintf(stdout,"Err:cannot create source forces");
+			MPI_Abort(MPI_COMM_WORLD, ERROR);
+			exit(1);
+		}
+
+		Global.theNodesLoaded = source_get_local_loaded_nodes_count();
+
+		if (Global.theNodesLoaded != 0) {
+			size_t ret;
+			int32_t node_count;
+
+			Global.fpsource = source_open_forces_file( "r" );
+
+			hu_fread( &node_count, sizeof(int32_t), 1, Global.fpsource );
+
+			/* \todo add assertion for node_count == Global.theNodesLoaded */
+
+			Global.theNodesLoadedList = (int32_t *)malloc( sizeof(int32_t) * Global.theNodesLoaded );
+			Global.myForces	   = (vector3D_t *)calloc( Global.theNodesLoaded, sizeof(vector3D_t) );
+
+			if (Global.myForces == NULL || Global.theNodesLoadedList == NULL) {
+				solver_abort( "source_init", "memory allocation failed",
+						"Cannot allocate memory for Global.myForces or "
+						"loaded nodes list arrays\n" );
+			}
+
+			ret = hu_fread( Global.theNodesLoadedList, sizeof(int32_t), Global.theNodesLoaded,
+					Global.fpsource );
+
+			if (ret != Global.theNodesLoaded) {
+				solver_abort( "source_init(", "fread failed",
+						"Could not read nodal force file");
+			}
+		}
+	}
+}
+
+
+
+/**
+ * Search a point in the domain of the local mesh.
+ *
+ *   input: coordinates
+ *  output: 0 fail 1 success
+ */
+int32_t search_point( vector3D_t point, octant_t **octant )
+{
+    tick_t  xTick, yTick, zTick;
+
+    xTick = point.x[0] / Global.myMesh->ticksize;
+    yTick = point.x[1] / Global.myMesh->ticksize;
+    zTick = point.x[2] / Global.myMesh->ticksize;
+
+    *octant = octor_searchoctant( Global.myOctree, xTick, yTick, zTick,
+            PIXELLEVEL, AGGREGATE_SEARCH );
+
+    if ( (*octant == NULL) || ((*octant)->where == REMOTE) ) {
+        return 0;
+    }
+
+    return 1;
+}
+
+/**
+ * \param octant where the point is located.
+ * \param pointcoords coordinates of the point.
+ * \param localcoords[out] the displacment.
+ */
+extern int
+compute_csi_eta_dzeta( octant_t* octant, vector3D_t pointcoords,
+		       vector3D_t* localcoords, int32_t* localNodeID )
+{
+    tick_t  edgeticks;
+    int32_t eindex;
+    double  center_x, center_y, center_z;
+
+    /* various convienient variables */
+    double xGlobal = pointcoords.x[0];
+    double yGlobal = pointcoords.x[1];
+    double zGlobal = pointcoords.x[2];
+    double h;
+
+    edgeticks = (tick_t)1 << (PIXELLEVEL - octant->level);
+    h =  Global.myMesh->ticksize * edgeticks;
+
+    /* Calculate the center coordinate of the element */
+    center_x = Global.myMesh->ticksize * (octant->lx + edgeticks / 2);
+    center_y = Global.myMesh->ticksize * (octant->ly + edgeticks / 2);
+    center_z = Global.myMesh->ticksize * (octant->lz + edgeticks / 2);
+
+
+    /* Go through my local elements to find which one matches the
+     * containing octant. I should have a better solution than this.
+     */
+    for (eindex = 0; eindex < Global.myMesh->lenum; eindex++) {
+        int32_t lnid0 = Global.myMesh->elemTable[eindex].lnid[0];
+
+        if ((Global.myMesh->nodeTable[lnid0].x == octant->lx) &&
+                (Global.myMesh->nodeTable[lnid0].y == octant->ly) &&
+                (Global.myMesh->nodeTable[lnid0].z == octant->lz)) {
+
+            /* Sanity check */
+            if (Global.myMesh->elemTable[eindex].level != octant->level) {
+                fprintf(stderr, "Thread %d: source_init: internal error\n",
+                        Global.myID);
+                MPI_Abort(MPI_COMM_WORLD, ERROR);
+                exit(1);
+            }
+
+            /* Fill in the local node ids of the containing element */
+            memcpy( localNodeID, Global.myMesh->elemTable[eindex].lnid,
+                    sizeof(int32_t) * 8 );
+
+            break;
+        }
+    }  /* for all the local elements */
+
+
+    if (eindex == Global.myMesh->lenum) {
+        fprintf(stderr, "Thread %d: source_init: ", Global.myID);
+        fprintf(stderr, "No element matches the containing octant.\n");
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    /* Derive the local coordinate of the source inside the element */
+    localcoords->x[0] =  2*(xGlobal- center_x)/h;
+    localcoords->x[1] =  2*(yGlobal- center_y)/h;
+    localcoords->x[2] =  2*(zGlobal- center_z)/h;
+
+    return 1;
+}
+
+
+/**
+ * Read stations info.  This is called by PE 0.
+ */
+static void
+read_stations_info( const char* numericalin )
+{
+    static const char* fname = __FUNCTION_NAME;
+
+    int    iStation, iCorner;
+    double lon, lat, depth, *auxiliar;
+    FILE*  fp;
+
+    vector3D_t coords;
+
+    /* obtain the stations specifications */
+    if ( (fp = fopen ( numericalin, "r")) == NULL ) {
+	solver_abort (fname, numericalin,
+		      "Error opening numerical.in configuration file");
+    }
+
+    auxiliar = (double *)malloc(sizeof(double)*8);
+
+    if ( parsedarray( fp, "domain_surface_corners", 8, auxiliar ) != 0) {
+	solver_abort( fname, NULL,
+		      "Error parsing domain_surface_corners field from %s\n",
+		      numericalin);
+    }
+
+    for ( iCorner = 0; iCorner < 4; iCorner++){
+	Param.theSurfaceCornersLong[ iCorner ] = auxiliar [ iCorner * 2 ];
+	Param.theSurfaceCornersLat [ iCorner ] = auxiliar [ iCorner * 2 +1 ];
+    }
+    free(auxiliar);
+
+
+    if (parsetext( fp, "output_stations_print_rate", 'i',
+		   &Param.theStationsPrintRate ) != 0) {
+	solver_abort( fname, NULL,
+		      "Error parsing output_planes_print_rate field from %s\n",
+		      numericalin );
+    }
+
+    auxiliar    = (double*)malloc( sizeof(double) * Param.theNumberOfStations * 3 );
+    Param.theStationX = (double*)malloc( sizeof(double) * Param.theNumberOfStations );
+    Param.theStationY = (double*)malloc( sizeof(double) * Param.theNumberOfStations );
+    Param.theStationZ = (double*)malloc( sizeof(double) * Param.theNumberOfStations );
+
+    if (Param.theStationX == NULL || Param.theStationY == NULL || Param.theStationZ == NULL) {
+	fprintf( stdout,
+		 "Err alloc theStations arrays in output_stations_init" );
+	fflush( stdout );
+	MPI_Abort(MPI_COMM_WORLD, ERROR );
+	exit( 1 );
+    }
+
+    if (parsedarray( fp, "output_stations", Param.theNumberOfStations * 3,
+		     auxiliar ) != 0) {
+	solver_abort (fname, NULL,
+		      "Err parsing output_stations from %s\n", numericalin);
+    }
+
+    for (iStation = 0; iStation < Param.theNumberOfStations; iStation++) {
+	lat    = auxiliar [ iStation * 3 ];
+	lon    = auxiliar [ iStation * 3 +1 ];
+	depth  = auxiliar [ iStation * 3 +2 ];
+	coords = compute_domain_coords_linearinterp(lon,lat,
+						    Param.theSurfaceCornersLong,
+						    Param.theSurfaceCornersLat,
+						    Param.theDomainY,Param.theDomainX);
+	Param.theStationX [ iStation ] = coords.x[0];
+	Param.theStationY [ iStation ] = coords.x[1];
+	Param.theStationZ [ iStation ] = depth;
+
+	if ( Param.includeBuildings == YES ) {
+	    Param.theStationZ [ iStation ] += get_surface_shift();
+	}
+    }
+
+    free( auxiliar );
+
+    if ( parsetext(fp, "output_stations_directory",'s',Param.theStationsDirOut)!= 0)
+	solver_abort (fname, NULL, "Error parsing fields from %s\n",
+		      numericalin);
+
+    return;
+}
+
+
+/**
+ * Broadcast info about the stations.
+ */
+void
+broadcast_stations_info()
+{
+    /*initialize the local structures */
+    if ( Global.myID != 0 ) {
+	Param.theStationX = (double*)malloc( sizeof(double) * Param.theNumberOfStations);
+	Param.theStationY = (double*)malloc( sizeof(double) * Param.theNumberOfStations);
+	Param.theStationZ = (double*)malloc( sizeof(double) * Param.theNumberOfStations);
+
+	if (Param.theStationX == NULL ||  Param.theStationY == NULL || Param.theStationZ==NULL) {
+	    solver_abort( "broadcast_stations_info", NULL,
+			  "Error: Unable to create stations arrays" );
+	}
+    }
+
+    MPI_Barrier( comm_solver );
+
+    MPI_Bcast(Param.theStationX, Param.theNumberOfStations, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(Param.theStationY, Param.theNumberOfStations, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(Param.theStationZ, Param.theNumberOfStations, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(&Param.theStationsPrintRate, 1, MPI_INT, 0, comm_solver);
+
+    broadcast_char_array( Param.theStationsDirOut, sizeof(Param.theStationsDirOut), 0,
+			  comm_solver );
+
+    return;
+}
+
+
+
+/**
+ * Prepare all the info every station needs once it is located in a processor
+ */
+void setup_stations_data()
+{
+    static char stationFile[256];
+
+    int32_t    iStation, iLCStation = 0; /* LC local count */
+    vector3D_t stationCoords;
+    octant_t*  octant;
+
+    /* look for the stations in the domain each processor has */
+    for (iStation = 0; iStation < Param.theNumberOfStations; iStation++) {
+        stationCoords.x[0] = Param.theStationX[iStation];
+        stationCoords.x[1] = Param.theStationY[iStation];
+        stationCoords.x[2] = Param.theStationZ[iStation];
+
+        if (search_point( stationCoords, &octant ) == 1) {
+            Param.myNumberOfStations++;
+        }
+    }
+
+    /* allocate memory if necessary and generate the list of stations per
+     * processor */
+    if (Param.myNumberOfStations != 0) {
+	monitor_print( "PE=%d local_stations=%d total_station_count=%d\n",
+		       Global.myID, Param.myNumberOfStations, Param.theNumberOfStations );
+
+	XMALLOC_VAR_N( Param.myStations, station_t, Param.myNumberOfStations );
+    }
+
+    for (iStation = 0; iStation < Param.theNumberOfStations; iStation++) {
+	stationCoords.x[0] = Param.theStationX[iStation];
+	stationCoords.x[1] = Param.theStationY[iStation];
+	stationCoords.x[2] = Param.theStationZ[iStation];
+
+	if (search_point( stationCoords, &octant ) == 1) {
+	    Param.myStations[iLCStation].id = iStation;
+	    Param.myStations[iLCStation].coords=stationCoords;
+	    sprintf(stationFile, "%s/station.%d",Param.theStationsDirOut,iStation);
+	    Param.myStations[iLCStation].fpoutputfile = hu_fopen( stationFile,"w" );
+	    compute_csi_eta_dzeta( octant, Param.myStations[iLCStation].coords,
+				   &(Param.myStations[iLCStation].localcoords),
+				   Param.myStations[iLCStation].nodestointerpolate);
+
+	    /*
+	     * This section now enclosed in a DEBUG def because its information
+	     * is only useful for debugging purposes and otherwise it just
+	     * introduce noise to the post-processing.
+	     */
+#ifdef DEBUG
+	    fprintf( Param.myStations[iLCStation].fpoutputfile,
+		     "# Node identifiers:\n" );
+
+	    int iNode;
+
+	    for (iNode = 0; iNode < 8; iNode++) {
+		fprintf( Param.myStations[iLCStation].fpoutputfile,
+			 "#  %13" INT64_FMT "\n",
+			 Global.myMesh->nodeTable[Param.myStations[iLCStation].nodestointerpolate[iNode]].gnid );
+	    }
+#endif /* DEBUG */
+
+	    /*
+	     * This is a one line heading for the station files. Spacing is
+	     * such that it aligns with data.
+	     *
+	     * The lines after X and Y represent the actual orientation of the
+	     * axes if one looks at the domain's surface on a screen. Zeta's dot
+	     * means the Z axis goes in(+) and out(-) of the screen.
+	     */
+
+	    fputs( "#  Time(s)         X|(m)         Y-(m)         Z.(m)",
+	            Param.myStations[iLCStation].fpoutputfile );
+
+	    if ( ( Param.printStationVelocities    == YES ) ||
+	         ( Param.printStationAccelerations == YES ) ) {
+	        fputs( "       X|(m/s)       Y-(m/s)       Z.(m/s)",
+	                Param.myStations[iLCStation].fpoutputfile );
+	    }
+
+            if ( Param.printStationAccelerations == YES ) {
+                fputs( "      X|(m/s2)      Y-(m/s2)      Z.(m/s2)",
+                        Param.myStations[iLCStation].fpoutputfile );
+            }
+
+            /*
+	     * Additional headings for nonlinear data.
+	     */
+	    if ( Param.includeNonlinearAnalysis == YES ) {
+	        fputs(  "    Epsilon_XX      Sigma_XX"
+	                "    Epsilon_YY      Sigma_YY"
+                        "    Epsilon_ZZ      Sigma_ZZ"
+                        "    Epsilon_KK      Sigma_KK"
+	                "    Epsilon_XY      Sigma_XY"
+	                "    Epsilon_YZ      Sigma_YZ"
+	                "    Epsilon_XZ      Sigma_XZ"
+	                "        lambda            Fs"
+	                "             k",
+	                Param.myStations[iLCStation].fpoutputfile );
+	    }
+
+	    iLCStation += 1;
+	}
+    }
+
+    free( Param.theStationX );
+    free( Param.theStationY );
+    free( Param.theStationZ );
+}
+
+
+/**
+ * Interpolate the displacements for the stations.
+ */
+static int
+interpolate_station_displacements( int32_t step )
+{
+    int iPhi;
+
+    /* Auxiliary array to handle shape functions in a loop */
+    double  xi[3][8]={ {-1,  1, -1,  1, -1,  1, -1, 1} ,
+                       {-1, -1,  1,  1, -1, -1,  1, 1} ,
+                       {-1, -1, -1, -1,  1,  1,  1, 1} };
+
+    double     phi[8];
+    double     dis_x, dis_y, dis_z;
+    double     vel_x, vel_y, vel_z;
+    double     acc_x, acc_y, acc_z;
+    int32_t    iStation,nodesToInterpolate[8];;
+    vector3D_t localCoords; /* convenient renaming */
+
+    for (iStation=0;iStation<Param.myNumberOfStations; iStation++) {
+
+        localCoords = Param.myStations[iStation].localcoords;
+
+        for (iPhi=0; iPhi<8; iPhi++) {
+            nodesToInterpolate[iPhi]
+                    = Param.myStations[iStation].nodestointerpolate[iPhi];
+        }
+
+        /* Compute interpolation function (phi) for each node and
+         * load the displacements
+         */
+        dis_x = 0;
+        dis_y = 0;
+        dis_z = 0;
+
+        for (iPhi = 0; iPhi < 8; iPhi++) {
+            phi[ iPhi ] = ( 1 + xi[0][iPhi]*localCoords.x[0] )
+		                * ( 1 + xi[1][iPhi]*localCoords.x[1] )
+		                * ( 1 + xi[2][iPhi]*localCoords.x[2] ) / 8;
+
+            dis_x += phi[iPhi] * Global.mySolver->tm1[ nodesToInterpolate[iPhi] ].f[0];
+            dis_y += phi[iPhi] * Global.mySolver->tm1[ nodesToInterpolate[iPhi] ].f[1];
+            dis_z += phi[iPhi] * Global.mySolver->tm1[ nodesToInterpolate[iPhi] ].f[2];
+        }
+
+        double time = Param.theDeltaT * step;
+
+        /*
+         * Please DO NOT CHANGE the format for printing the displacements.
+         * It has to be *this* one because it goes in hand with the printing
+         * format for the nonlinear information.
+         */
+        fprintf( Param.myStations[iStation].fpoutputfile,
+                 "\n%10.6f % 8e % 8e % 8e",
+                 time, dis_x, dis_y, dis_z );
+
+        /*
+         * Addition for printing velocities on the fly
+         */
+
+        if ( ( Param.printStationVelocities    == YES ) ||
+             ( Param.printStationAccelerations == YES ) ) {
+
+            for (iPhi = 0; iPhi < 8; iPhi++) {
+
+                phi[ iPhi ] = ( 1 + xi[0][iPhi]*localCoords.x[0] )
+                                    * ( 1 + xi[1][iPhi]*localCoords.x[1] )
+                                    * ( 1 + xi[2][iPhi]*localCoords.x[2] ) / 8;
+
+                dis_x -= phi[iPhi] * Global.mySolver->tm2[ nodesToInterpolate[iPhi] ].f[0];
+                dis_y -= phi[iPhi] * Global.mySolver->tm2[ nodesToInterpolate[iPhi] ].f[1];
+                dis_z -= phi[iPhi] * Global.mySolver->tm2[ nodesToInterpolate[iPhi] ].f[2];
+            }
+
+            vel_x = dis_x / Param.theDeltaT;
+            vel_y = dis_y / Param.theDeltaT;
+            vel_z = dis_z / Param.theDeltaT;
+
+            fprintf( Param.myStations[iStation].fpoutputfile,
+                     " % 8e % 8e % 8e", vel_x, vel_y, vel_z );
+        }
+
+        /*
+         * Addition for printing accelerations on the fly
+         */
+
+        if ( Param.printStationAccelerations == YES ) {
+
+            for (iPhi = 0; iPhi < 8; iPhi++) {
+
+                phi[ iPhi ] = ( 1 + xi[0][iPhi]*localCoords.x[0] )
+                                            * ( 1 + xi[1][iPhi]*localCoords.x[1] )
+                                            * ( 1 + xi[2][iPhi]*localCoords.x[2] ) / 8;
+
+                dis_x -= phi[iPhi] * Global.mySolver->tm2[ nodesToInterpolate[iPhi] ].f[0];
+                dis_y -= phi[iPhi] * Global.mySolver->tm2[ nodesToInterpolate[iPhi] ].f[1];
+                dis_z -= phi[iPhi] * Global.mySolver->tm2[ nodesToInterpolate[iPhi] ].f[2];
+
+                dis_x += phi[iPhi] * Global.mySolver->tm3[ nodesToInterpolate[iPhi] ].f[0];
+                dis_y += phi[iPhi] * Global.mySolver->tm3[ nodesToInterpolate[iPhi] ].f[1];
+                dis_z += phi[iPhi] * Global.mySolver->tm3[ nodesToInterpolate[iPhi] ].f[2];
+            }
+
+            acc_x = dis_x / Param.theDeltaTSquared;
+            acc_y = dis_y / Param.theDeltaTSquared;
+            acc_z = dis_z / Param.theDeltaTSquared;
+
+            fprintf( Param.myStations[iStation].fpoutputfile,
+                     " % 8e % 8e % 8e", acc_x, acc_y, acc_z );
+        }
+
+	/* TODO: Have this 10 as a parameter with a default value */
+        if ( (step % (Param.theStationsPrintRate*10)) == 0 ) {
+            fflush(Param.myStations[iStation].fpoutputfile);
+        }
+    }
+
+    return 1;
+}
+
+
+/**
+ * Init stations info and data structures
+ */
+void output_stations_init( const char* numericalin )
+{
+    if (Global.myID == 0) {
+	read_stations_info( numericalin );
+    }
+
+    broadcast_stations_info();
+    setup_stations_data();
+
+    MPI_Barrier( comm_solver );
+
+    return;
+}
+
+
+
+/**
+ * \note This function should only be called by PE with rank 0.
+ */
+static int
+load_output_parameters (const char* numericalin, output_parameters_t* params)
+{
+    FILE* fp;
+    int   ret, value;
+    char  filename[LINESIZE];
+
+    assert (NULL != numericalin);
+    assert (NULL != params);
+    assert (Global.myID == 0);
+
+     /* Read output parameters from numerical.in */
+    fp = fopen (numericalin, "r");
+
+    if (NULL == fp) {
+	solver_abort ("load_output_parameters", "fopen", "numerical.in=\"%s\"",
+		      numericalin);
+    }
+
+    params->do_output		= 0;
+    params->parallel_output     = 0;
+    params->output_displacement = 0;
+    params->output_velocity     = 0;
+    params->output_debug	= 0;
+
+    params->displacement_filename = NULL;
+    params->velocity_filename     = NULL;
+
+
+    /* read parameters from configuration file */
+
+    value = 0;
+    ret = parsetext (fp, "output_parallel", 'i', &value);
+
+    if (0 == ret && 0 != value) {
+	value = 0;
+	ret = parsetext (fp, "output_displacement", 'i', &value);
+
+	if (0 == ret && 0 != value) { /* output_displacement = 1 in config */
+	    ret = read_config_string (fp, "output_displacement_file",
+				      filename, LINESIZE);
+
+	    if (1 == ret && filename[0] != '\0') {
+		params->displacement_filename = strdup (filename);
+		params->output_displacement = 1;
+	    } else {
+		solver_abort ("load_output_parameters", NULL,
+			      "Output displacement file name not specified in "
+			      "numerical.in=\"%s\"",
+			      numericalin);
+	    }
+	}
+
+	value = 0;
+	ret   = parsetext (fp, "output_velocity", 'i', &value);
+
+	if (0 == ret && 0 != value) { /* output_displacement = 1 in config */
+	    ret = read_config_string (fp, "output_velocity_file",
+				      filename, LINESIZE);
+
+	    if (1 == ret && filename[0] != '\0') {
+		params->velocity_filename = strdup (filename);
+		params->output_velocity = 1;
+	    } else {
+		solver_abort ("load_output_parameters", NULL,
+			      "Output velocity file name not specified in "
+			      "numerical.in=\"%s\"",
+			      numericalin);
+	    }
+	}
+
+	params->stats_filename = "output-stats.txt"; /* default value */
+
+	ret = read_config_string (fp, "output_stats_file", filename, LINESIZE);
+
+	if (1 == ret && filename[0] != '\0') {
+	    params->stats_filename = strdup (filename);
+	}
+
+	params->debug_filename = "output-debug.txt"; /* default value */
+	ret = read_config_string (fp, "output_debug_file", filename, LINESIZE);
+
+	if (1 == ret && filename[0] != '\0') {
+	    params->debug_filename = strdup (filename);
+	}
+
+
+	if (params->output_velocity || params->output_displacement) {
+	    params->do_output = 1;
+	}
+
+	params->parallel_output = 1;
+
+	ret = parsetext (fp, "output_debug", 'i', &value);
+	if (0 == ret && 0 != value) { /* output_debug = 1 in config */
+	    params->output_debug = 1;
+	}
+    }
+
+    ret = 0;
+
+    fclose (fp);
+
+    return ret;
+}
+
+
+
+/**
+ * Initialize output structures, including the opening of 4D output files.
+ *
+ * \param numericsin Name of the file with the solver and output parameters
+ *	i.e., "numerical.in".
+ * \param[out] params output parameters, including filenames.
+ *
+ * \pre The following global variables should be initialized:
+ *	- Global.myID.
+ *	- Global.theGroupSize.
+ *
+ * \post On a successful return, the output argument \c params will be
+ *	properly initialized.  If the routine fails, the state of the
+ *	\c param struct is undefined.
+ *
+ * \return 0 on success, -1 on error.
+ */
+static int
+output_init_parameters (const char* numericalin, output_parameters_t* params)
+{
+    /* jc: this ugly #define here is because the catamount compiler does not
+     * like static const  */
+#define VALUES_COUNT    4
+    int ret;
+    int32_t values[VALUES_COUNT];
+    off_t output_steps;
+
+    /* sanity cleanup */
+    memset (params, 0, sizeof (output_parameters_t));
+
+    params->do_output		  = 0;
+    params->displacement_filename = NULL;
+    params->velocity_filename     = NULL;
+    params->stats_filename	  = NULL;
+
+    if (Global.myID == 0) {
+	ret = load_output_parameters (numericalin, params);
+
+	if (0 != ret) {
+	    solver_abort ("output_init_parameters", NULL, NULL);
+	    return -1;
+	}
+    }
+
+    /* parameters that can be initialized from global variables */
+    params->pe_id	   = Global.myID;
+    params->pe_count       = Global.theGroupSize;
+    params->total_nodes    = Global.theNTotal;
+    params->total_elements = Global.theETotal;
+    params->output_rate	   = Param.theRate;
+    params->domain_x	   = Param.theDomainX;
+    params->domain_y	   = Param.theDomainY;
+    params->domain_z	   = Param.theDomainZ;
+    params->mesh	   = Global.myMesh;
+    params->solver	   = (solver_t*)Global.mySolver;
+    params->delta_t	   = Param.theDeltaT;
+    params->total_time_steps = Param.theTotalSteps;
+
+    output_steps	   = (Param.theTotalSteps - 1) / Param.theRate + 1;
+
+
+    values[0] = params->parallel_output;
+    values[1] = params->output_displacement;
+    values[2] = params->output_velocity;
+    values[3] = params->output_debug;
+
+
+    MPI_Bcast (values, VALUES_COUNT, MPI_INT, 0, comm_solver);
+    MPI_Bcast (&params->total_nodes, 1, MPI_INT64, 0, comm_solver);
+
+    params->parallel_output     = values[0];
+    params->output_displacement = values[1];
+    params->output_velocity	= values[2];
+    params->output_debug	= values[3];
+    params->output_size		= (output_steps * params->total_nodes
+				   * sizeof(fvector_t) + sizeof(out_hdr_t));
+    Global.theNTotal = params->total_nodes;
+
+
+    if (params->parallel_output) {
+	if (params->output_displacement) {
+	    broadcast_string(&params->displacement_filename, 0,comm_solver);
+	}
+
+	if (params->output_velocity) {
+	    broadcast_string( &params->velocity_filename, 0, comm_solver );
+	}
+
+	if (params->output_debug) {
+	    broadcast_string( &params->debug_filename, 0, comm_solver );
+	}
+
+	/* set the expected file size */
+	Param.the4DOutSize = params->output_size;
+    }
+
+    return 0;
+#undef VALUES_COUNT
+}
+
+
+/**
+ * Intialize parallel output structures according to config file
+ * parameters.
+ *
+ * \note params parameter could be a local var instead, it doesn't need
+ * to be global, since this is not really used after the initialization
+ * except for the stats file name.
+ *
+ * \return 0 on success, -1 on error (probably aborts instead).
+ */
+static int
+output_init( const char* numericalin, output_parameters_t* params )
+{
+    int ret = -1;
+
+    assert (NULL != numericalin);
+    assert (NULL != params);
+
+    ret = output_init_parameters( numericalin, params );
+
+    if (ret != 0) {
+	return -1;
+    }
+
+    /* initialize structures, open files, etc */
+    ret = output_init_state( params );
+
+    /* these aren't needed anymore after this point */
+    xfree_char( &params->displacement_filename );
+    xfree_char( &params->velocity_filename );
+
+    return ret;
+}
+
+
+static int
+output_get_stats( void )
+{
+    output_stats_t disp_stats, vel_stats;
+    int    ret      = 0;
+    double avg_tput = 0;
+
+
+    if (Param.theOutputParameters.parallel_output) {
+	ret = output_collect_io_stats( Param.theOutputParameters.stats_filename,
+				       &disp_stats, &vel_stats, Timer_Value("Total Wall Clock",(TimerKind)0) );
+
+	/* magic trick so print_timing_stat() prints something sensible
+	 * for the 4D output time in the parallel case.
+	 *
+	 * if both displacement and velocity where written out, prefer
+	 * the displacement stat.
+	 */
+	if (Param.theOutputParameters.output_velocity) {
+	    avg_tput = vel_stats.tput_avg;
+	}
+
+	if (Param.theOutputParameters.output_displacement) {
+	    avg_tput = disp_stats.tput_avg;
+	}
+    }
+
+    return ret;
+}
+
+
+
+/**
+ * Adjust the values of the properties (Vp, Vs, Rho) for the mesh elements.
+ * Initial implementation (by Leo) querying the middle point.1D.
+ * Modified implementation (Ricardo) querying the 27 points and averaging.
+ *
+ * \param cvm the material model database (CVM etree).
+ */
+static void
+mesh_correct_properties( etree_t* cvm )
+{
+    elem_t*  elemp;
+    edata_t* edata;
+    int32_t  eindex;
+    double   east_m, north_m, depth_m, VpVsRatio, RhoVpRatio;
+    int	     res, iNorth, iEast, iDepth, numPoints = 3;
+    double   vs, vp, rho;
+    double   points[3];
+    int32_t  lnid0;
+
+    // INTRODUCE BKT MODEL
+
+    double Qs, Qp, Qk, L, vs_vp_Ratio, vksquared, w;
+    int index_Qs, index_Qk;
+    int QTable_Size = (int)(sizeof(Global.theQTABLE)/( 6 * sizeof(double)));
+
+    points[0] = 0.005;
+    points[1] = 0.5;
+    points[2] = 0.995;
+
+//    if (Global.myID == 0) {
+//        fprintf( stdout,"mesh_correct_properties  ... " );
+//        fflush( stdout );
+//    }
+
+    /* iterate over mesh elements */
+    for (eindex = 0; eindex < Global.myMesh->lenum; eindex++) {
+
+        elemp = &Global.myMesh->elemTable[eindex];
+        edata = (edata_t*)elemp->data;
+        lnid0 = Global.myMesh->elemTable[eindex].lnid[0];
+
+        if ( Param.includeBuildings == YES ) {
+            if( bldgs_correctproperties( Global.myMesh, edata, lnid0) ) {
+                continue;
+            }
+        }
+
+        vp  = 0;
+        vs  = 0;
+        rho = 0;
+
+        for (iNorth = 0; iNorth < numPoints; iNorth++) {
+
+        	north_m = (Global.myMesh->ticksize) * (double)Global.myMesh->nodeTable[lnid0].x
+        			+ edata->edgesize * points[iNorth] + Global.theXForMeshOrigin ;
+
+        	for (iEast = 0; iEast < numPoints; iEast++) {
+
+        		east_m = ( (Global.myMesh->ticksize)
+        				* (double)Global.myMesh->nodeTable[lnid0].y
+        				+ edata->edgesize * points[iEast] + Global.theYForMeshOrigin  );
+
+        		for (iDepth = 0; iDepth < numPoints; iDepth++) {
+        			cvmpayload_t g_props; /* ground properties record */
+
+        			depth_m = ( (Global.myMesh->ticksize)
+        					* (double)Global.myMesh->nodeTable[lnid0].z
+        					+ edata->edgesize * points[iDepth] + Global.theZForMeshOrigin );
+
+        			/* NOTE: If you want to see the carving process,
+        			 *       activate this and comment the query below */
+        			if ( Param.includeBuildings == YES ) {
+        				//                        if ( depth_m < get_surface_shift() ) {
+        				//                            g_props.Vp  = NAN;
+        				//                            g_props.Vs  = NAN;
+        				//                            g_props.rho = NAN;
+        				//                        } else {
+        				depth_m -= get_surface_shift();
+        				//                            res = cvm_query( Global.theCVMEp, east_m, north_m,
+        				//                                             depth_m, &g_props );
+        				//                        }
+        			}
+
+        			res = cvm_query( Global.theCVMEp, east_m, north_m,
+        					depth_m, &g_props );
+
+        			if (res != 0) {
+        				fprintf(stderr, "Cannot find the query point\n");
+        				exit(1);
+        			}
+
+        			vp  += g_props.Vp;
+        			vs  += g_props.Vs;
+        			rho += g_props.rho;
+                }
+            }
+        }
+
+        edata->Vp  =  vp / 27;
+        edata->Vs  =  vs / 27;
+        edata->rho = rho / 27;
+
+        /* Auxiliary ratios for adjustments */
+        VpVsRatio  = edata->Vp  / edata->Vs;
+        RhoVpRatio = edata->rho / edata->Vp;
+
+        /* Adjust material properties according to the element size and
+         * softening factor.
+         *
+         * A factor of 1 means perfect compliance between the mesh and the
+         * elements' material properties resulting in strong changes to the
+         * results. A factor of 4 tends to double the simulation delta_t
+         * without affecting too much the results. Testing is needed but for
+         * now I recommend factors > 4.
+         */
+        if ( Param.theSofteningFactor > 0 ) {
+
+            double idealVs, factoredVs;
+
+            idealVs    = edata->edgesize * Param.theFactor;
+            factoredVs = idealVs * Param.theSofteningFactor;
+
+            if ( edata->Vs > factoredVs ) {
+                edata->Vs  = factoredVs;
+                edata->Vp  = factoredVs * VpVsRatio;
+                edata->rho = edata->Vp  * RhoVpRatio;
+            }
+        }
+
+        /* Readjust Vs, Vp and Density according to VsCut */
+        if ( edata->Vs < Param.theVsCut ) {
+            edata->Vs  = Param.theVsCut;
+            edata->Vp  = Param.theVsCut  * VpVsRatio;
+            /* edata->rho = edata->Vp * RhoVpRatio; */ /* Discuss with Jacobo */
+        }
+
+
+        // IMPLEMENT BKT MODEL
+
+        /* CALCULATE QUALITY FACTOR VALUES AND READ CORRESPONDING VISCOELASTICITY COEFFICIENTS FROM THE TABLE */
+
+        	/* L IS THE COEFFICIENT DEFINED BY "SHEARER-2009" TO RELATE QK, QS AND QP */
+
+        if(Param.theTypeOfDamping == BKT)
+        {
+
+            vksquared = edata->Vp * edata->Vp - 4. / 3. * edata->Vs * edata->Vs;
+        	vs_vp_Ratio = edata->Vs / edata->Vp;
+        	vs = edata->Vs * 0.001;
+        	L = 4. / 3. * vs_vp_Ratio * vs_vp_Ratio;
+
+          	//Qs = 0.02 * edata->Vs;
+
+        	// Ricardo's Formula based on Brocher's paper (2008) on the subject. In the paper Qp = 2*Qs is given.
+        	//TODO : Make sure Qp Qs relation is correct...
+
+        	Qs = 10.5 + vs * (-16. + vs * (153. + vs * (-103. + vs * (34.7 + vs * (-5.29 + vs * 0.31)))));
+        	Qp = 2. * Qs;
+
+        	if (Param.useInfQk == YES) {
+        	    Qk = 1000;
+        	} else {
+                Qk = (1. - L) / (1. / Qp - L / Qs);
+        	}
+
+        	index_Qs = Search_Quality_Table(Qs, &(Global.theQTABLE[0][0]), QTable_Size);
+
+//        	printf("Quality Factor Table\n Qs : %lf \n Vs : %lf\n",Qs,edata->Vs);
+
+        	if(index_Qs == -2 || index_Qs >= QTable_Size)
+        	{
+        		fprintf(stderr,"Problem with the Quality Factor Table\n Qs : %lf \n Vs : %lf\n",Qs,edata->Vs);
+        		exit(1);
+        	}
+        	else if(index_Qs == -1)
+        	{
+        		edata->a0_shear = 0;
+        		edata->a1_shear = 0;
+        		edata->g0_shear = 0;
+        		edata->g1_shear = 0;
+        		edata->b_shear  = 0;
+        	}
+        	else
+        	{
+        		edata->a0_shear = Global.theQTABLE[index_Qs][1];
+        		edata->a1_shear = Global.theQTABLE[index_Qs][2];
+        		edata->g0_shear = Global.theQTABLE[index_Qs][3];
+        		edata->g1_shear = Global.theQTABLE[index_Qs][4];
+        		edata->b_shear  = Global.theQTABLE[index_Qs][5];
+        	}
+
+        	index_Qk = Search_Quality_Table(Qk, &(Global.theQTABLE[0][0]), QTable_Size);
+
+//        	printf("Quality Factor Table\n Qs : %lf \n Vs : %lf\n",Qs,edata->Vs);
+
+        	if(index_Qk == -2 || index_Qk >= QTable_Size)
+        	{
+        		fprintf(stderr,"Problem with the Quality Factor Table\n Qk : %lf \n Vs : %lf\n",Qk,edata->Vs);
+        		exit(1);
+        	}
+        	else if(index_Qk == -1)
+        	{
+        		edata->a0_kappa = 0;
+        		edata->a1_kappa = 0;
+        		edata->g0_kappa = 0;
+        		edata->g1_kappa = 0;
+        		edata->b_kappa  = 0;
+        	}
+        	else
+        	{
+        		edata->a0_kappa = Global.theQTABLE[index_Qk][1];
+        		edata->a1_kappa = Global.theQTABLE[index_Qk][2];
+        		edata->g0_kappa = Global.theQTABLE[index_Qk][3];
+        		edata->g1_kappa = Global.theQTABLE[index_Qk][4];
+        		edata->b_kappa  = Global.theQTABLE[index_Qk][5];
+        	}
+
+        	if(Param.theFreq_Vel != 0.)
+        	{
+        		w = Param.theFreq_Vel / Param.theFreq;
+
+        		if ( (edata->a0_shear != 0) && (edata->a1_shear != 0) ) {
+        		    double shear_vel_corr_factor;
+        		    shear_vel_corr_factor = sqrt(1. - (edata->a0_shear * edata->g0_shear * edata->g0_shear / (edata->g0_shear * edata->g0_shear + w * w) + edata->a1_shear * edata->g1_shear * edata->g1_shear / (edata->g1_shear * edata->g1_shear + w * w)));
+                    edata->Vs = shear_vel_corr_factor * edata->Vs;
+        		}
+
+        		if ( (edata->a0_kappa != 0) && (edata->a0_kappa != 0) ) {
+        		    double kappa_vel_corr_factor;
+        		    kappa_vel_corr_factor = sqrt(1. - (edata->a0_kappa * edata->g0_kappa * edata->g0_kappa / (edata->g0_kappa * edata->g0_kappa + w * w) + edata->a1_kappa * edata->g1_kappa * edata->g1_kappa / (edata->g1_kappa * edata->g1_kappa + w * w)));
+                    edata->Vp = sqrt(kappa_vel_corr_factor * kappa_vel_corr_factor * vksquared + 4. / 3. * edata->Vs * edata->Vs);
+        		}
+        	}
+        }
+    }
+}
+
+
+/*** Program's standard entry point. ***/
+int main( int argc, char** argv )
+{
+
+#ifdef DEBUG
+    int32_t flag;
+    MPI_Status status;
+#endif /* DEBUG */
+
+    /* Parameters init */
+    Param.FourDOutFp = NULL;
+    Param.theMonitorFileFp = NULL;
+    Param.theMonitorFileName = NULL;
+    Param.theFreq_Vel = 0;
+    Param.monitor_stats_rate = 50;
+    Param.theSchedulePrintErrorCheckFlag = 0;
+    Param.theSchedulePrintToStdout = 0;
+    Param.theSchedulePrintToFile = 0;
+    strcpy(Param.theSchedulePrintFilename, "schedule_info.txt");
+    Param.theScheduleStatFilename = NULL;
+    Param.theMeshStatFilename = NULL;
+    Param.theSofteningFactor = 0;
+    Param.theStepMeshingFactor = 0;
+    Param.myNumberOfStations = 0;
+    Param.theUseCheckPoint = 0;
+    Param.theTimingBarriersFlag = 0;
+    Param.the4DOutSize = 0;
+    Param.theMeshOutFlag = DO_OUTPUT;
+
+    /* Global init */
+    Global.myID = -1;
+    Global.theGroupSize = -1;
+    Global.myOctree = NULL;
+    Global.myMesh = NULL;
+    Global.theETotal = 0;
+    Global.theNTotal = 0;
+    Global.mySolver = NULL;
+    Global.myVelocityTable = NULL;
+    Global.theCriticalT = 0;
+    Global.fastestTimeSteps = 10000000;
+    Global.slowestTimeSteps = 0;
+    Global.theNodesLoaded = -1;
+    Global.theNodesLoadedList = NULL;
+    Global.myForces = NULL;
+    Global.fpsource = NULL;
+    Global.theCVMRecordSize = sizeof(cvmrecord_t);
+
+    /* MPI initialization */
+    MPI_Init(&argc, &argv);
+    Timer_Start("Total Wall Clock");
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Comm_rank(MPI_COMM_WORLD, &Global.myID);
+    MPI_Comm_size(MPI_COMM_WORLD, &Global.theGroupSize);
+
+    /* Make sure using correct input arguments */
+    if (argc != 2) {
+        if (Global.myID == 0) {
+            fputs ( "Usage: psolve <parameters.in>\n", stderr);
+        }
+        MPI_Finalize();
+        exit(1);
+    }
+
+    /*Read in and verify IO Pool Configuration */
+    char * IO_PES_ENV_VAR;
+    IO_PES_ENV_VAR = getenv("IO_PES");
+    if (IO_PES_ENV_VAR==NULL)
+        Param.IO_pool_pe_count = 0;
+    else
+        Param.IO_pool_pe_count = atoi(IO_PES_ENV_VAR);
+    if (Param.IO_pool_pe_count >= Global.theGroupSize)
+    {
+        Param.IO_pool_pe_count = 0;
+        if (Global.myID==0)
+            printf("Warning: IO_PES too large.  Set to 0.\n");
+    }
+
+    /* Split off PEs into IO Pool */
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm_IO);
+    int in_io_pool, color;
+    Global.theGroupSize -= Param.IO_pool_pe_count;
+    if (Global.myID >= Global.theGroupSize)
+        in_io_pool = 1;
+    else
+        in_io_pool=0;
+    if (in_io_pool)
+        color = MPI_UNDEFINED;
+    else
+        color = 0;
+    MPI_Comm_split(MPI_COMM_WORLD, color, Global.myID, &comm_solver);
+    if (in_io_pool) {
+        planes_IO_PES_main(Global.myID);
+        goto IO_PES_REJOIN;
+    }
+
+    if (Global.myID == 0) {
+        printf( "Starting psolve $Revision: 1.166 $ on %d PEs (%d IO Pool PEs).\n\n",
+                Global.theGroupSize, Param.IO_pool_pe_count );
+        fflush( stdout );
+    }
+
+    /* Read input parameters from file */
+    read_parameters(argc, argv);
+
+    /* Create and open database */
+    open_cvmdb();
+
+    /* Initialize nonlinear parameters */
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        nonlinear_init(Global.myID, Param.parameters_input_file, Param.theDeltaT, Param.theEndT);
+    }
+
+    if ( Param.includeBuildings == YES ){
+        bldgs_init( Global.myID, Param.parameters_input_file );
+    }
+
+    if ( Param.drmImplement == YES ){
+    	Timer_Start("Init Drm Parameters");
+    	Param.theDrmPart = drm_init(Global.myID, Param.parameters_input_file , Param.includeBuildings);
+    	Timer_Stop("Init Drm Parameters");
+    	Timer_Reduce("Init Drm Parameters", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+    }
+
+    // INTRODUCE BKT MODEL
+    /* Init Quality Factor Table */
+    constract_Quality_Factor_Table();
+
+    /* Generate, partition and output unstructured octree mesh */
+    mesh_generate();
+
+    if ( Param.includeBuildings == YES ){
+        if ( get_fixedbase_flag() == YES ) {
+            bldgs_fixedbase_init( Global.myMesh, Param.theEndT-Param.theStartT );
+        }
+        bldgs_finalize();
+    }
+
+    if ( Param.drmImplement == YES ) {
+    	Timer_Start("Drm Init");
+    	if ( Param.theDrmPart == PART0 ) {
+    		find_drm_nodes(Global.myMesh, Global.myID, Param.parameters_input_file,
+    				Global.myOctree->ticksize, Global.theGroupSize);
+    	}
+    	if (Param.theDrmPart == PART1) {
+    		setup_drm_data(Global.myMesh, Global.myID, Global.theGroupSize);
+    	}
+    	if (Param.theDrmPart == PART2) {
+    		proc_drm_elems(Global.myMesh, Global.myID, Global.theGroupSize, Param.theTotalSteps);
+    	}
+    	drm_stats(Global.myID, Global.theGroupSize, Global.theXForMeshOrigin,
+    			 Global.theYForMeshOrigin, Global.theZForMeshOrigin);
+    	Timer_Stop("Drm Init");
+    	Timer_Reduce("Drm Init", (TimerKind)(MAX | MIN | AVERAGE) , comm_solver);
+    }
+
+    if (Param.theMeshOutFlag && DO_OUTPUT) {
+        mesh_output();
+    }
+
+    if ( Param.storeMeshCoordinatesForMatlab == YES ) {
+        saveMeshCoordinatesForMatlab( Global.myMesh, Global.myID, Param.parameters_input_file,
+				      Global.myOctree->ticksize,Param.theTypeOfDamping,Global.theXForMeshOrigin,
+				      Global.theYForMeshOrigin,Global.theZForMeshOrigin, Param.includeBuildings);
+    }
+
+    Timer_Start("Mesh Stats Print");
+    mesh_print_stat(Global.myOctree, Global.myMesh, Global.myID, Global.theGroupSize,
+		    Param.theMeshStatFilename);
+    Timer_Stop("Mesh Stats Print");
+    Timer_Reduce("Mesh Stats Print", (TimerKind)(MAX | MIN), comm_solver);
+
+    /* Initialize the output planes */
+    if ( Param.theNumberOfPlanes != 0 ) {
+        planes_setup(Global.myID, &Param.thePlanePrintRate, Param.IO_pool_pe_count,
+		     Param.theNumberOfPlanes, Param.parameters_input_file, get_surface_shift(),
+		     Param.theSurfaceCornersLong, Param.theSurfaceCornersLat,
+		     Param.theDomainX, Param.theDomainY, Param.theDomainZ,
+		     Param.planes_input_file);
+    }
+
+    if ( Param.theNumberOfStations !=0 ){
+        output_stations_init(Param.parameters_input_file);
+    }
+
+    /* Initialize the GPU */
+    gpu_init();
+
+    /* Initialize the solver, source and output structures */
+    solver_init();
+    Timer_Start("Solver Stats Print");
+    solver_printstat( Global.mySolver );
+    Timer_Stop("Solver Stats Print");
+    Timer_Reduce("Solver Stats Print", (TimerKind)(MAX | MIN), comm_solver);
+
+    /* Initialize nonlinear solver analysis structures */
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        nonlinear_solver_init(Global.myID, Global.myMesh, Param.theDomainZ);
+        if ( Param.theNumberOfStations !=0 ){
+            nonlinear_stations_init(Global.myMesh, Param.myStations, Param.myNumberOfStations);
+        }
+        nonlinear_stats(Global.myID, Global.theGroupSize);
+    }
+
+    Timer_Start("Source Init");
+    source_init(Param.parameters_input_file);
+    Timer_Stop("Source Init");
+    Timer_Reduce("Source Init", (TimerKind)(MAX | MIN), comm_solver);
+
+    /* Mapping element indices for stiffness
+     * This is for compatibility with nonlinear
+     * \TODO a more clever way should be possible
+     */
+    stiffness_init(Global.myID, Global.myMesh);
+
+    /* this is a little too late to check for output parameters,
+     * but let's do this in the mean time
+     */
+    output_init (Param.parameters_input_file, &Param.theOutputParameters);
+
+    /* Run the solver and output the results */
+    MPI_Barrier(comm_solver);
+    Timer_Start("Solver");
+    solver_run();
+    Timer_Stop("Solver");
+    MPI_Barrier(comm_solver);
+
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        nonlinear_yield_stats( Global.myMesh, Global.myID, Param.theTotalSteps,
+			       Global.theGroupSize );
+    }
+
+    output_fini();
+
+#ifdef DEBUG
+    /* Does the OS page out my resident set ? */
+    if ((Global.myID % PROCPERNODE) == 0) {
+        /* system("ps xl"); */
+    }
+
+    /* Are there pending messages that I haven't processed */
+    MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, comm_solver, &flag, &status);
+    if (flag != 0) {
+        fprintf(stderr, "Thread %d: MPI error: unreceived incoming message\n",
+                Global.myID);
+    }
+#endif /* DEBUG */
+
+    local_finalize();
+
+    output_get_stats();
+
+    MPI_Barrier(comm_solver);
+    Timer_Stop("Total Wall Clock");
+
+    /* Print out the timing stat */
+    if (Global.myID == 0) {
+        print_timing_stat();
+    }
+
+    /* TODO: Think of a better place for this */
+    if ( Param.includeNonlinearAnalysis == YES ) {
+        if ( get_geostatic_total_time() > 0 ) {
+            check_balance(Global.myID);
+        }
+    }
+
+    /* Send a message to IO pool PEs to close output files and goto here */
+    if (Param.theNumberOfPlanes != 0) {
+        planes_close(Global.myID, Param.IO_pool_pe_count, Param.theNumberOfPlanes);
+    }
+    IO_PES_REJOIN:
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/quake/forward_gpu/psolve.h
+++ b/quake/forward_gpu/psolve.h
@@ -1,0 +1,408 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ *
+ * psolve.h: Generate an unstructured mesh and solve the linear system
+ *           thereof derived and output the results.
+ *
+ * Input:    material database (cvm etree), physics.in, numerical.in.
+ * Output:   mesh database (mesh.e) and 4D output.
+ *
+ *
+ * Notes:
+ *   For a history of changes see the ChangeLog file.  Also, if you
+ *   perform any changes to the source code, please document the changes
+ *   by adding the appropriate entry in the ChangeLog file and a descriptive
+ *   message during CVS commit.  Thanks!
+ */
+
+#ifndef PSOLVE_H
+#define PSOLVE_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <mpi.h>
+
+#include "octor.h"
+
+#define ERROR       HERC_ERROR
+
+#ifndef DO_DEBUG
+# ifdef  DEBUG
+#  define DO_DEBUG        1
+# else
+#  define DO_DEBUG        0
+# endif /* DEBUG */
+#endif /* DO_DEBUG */
+
+/* GPU specification */
+typedef struct {
+  int32_t device;
+  int32_t max_threads;
+  int32_t max_block_dim[3];
+  int32_t max_grid_dim[3];
+} gpu_spec_t;
+
+/* Reverse node->element table lookup entry */
+typedef struct rev_elem_t {
+  int32_t elemid;
+  int32_t offset;
+} rev_elem_t;
+
+typedef struct rev_entry_t {
+  int32_t count;
+  rev_elem_t elements[8];
+} rev_entry_t;
+
+
+extern MPI_Comm comm_solver;
+extern MPI_Comm comm_IO;
+
+/* Sets solver to use single or double precision in main variables */
+#ifdef  SINGLE_PRECISION_SOLVER
+   typedef float solver_float;
+#else
+   typedef double solver_float;
+#endif
+
+typedef int32_t     local_id_t;		/**< Local element and node id type  */
+typedef local_id_t  lnid_t;		/**< Local node id type		     */
+typedef local_id_t  leid_t;		/**< Local element id type	     */
+typedef int64_t     global_id_t;	/**< Global element and node id type */
+typedef global_id_t gnid_t;		/**< Global node id type	     */
+typedef global_id_t geid_t;		/**< Global element id type	     */
+
+
+struct corner_ref_t {
+    lnid_t corner_lnid[8];              /**< Corners local node ids */
+    double min_value, max_value;
+};
+
+typedef struct corner_ref_t corner_ref_t;
+
+/**
+ * Mesh database (element) record payload.
+ */
+struct mdata_t {
+    int64_t nid[8];
+    float edgesize, Vp, Vs, rho;
+};
+
+typedef struct mdata_t mdata_t;
+
+
+/**
+ * Mesh element data fields
+ */
+typedef struct edata_t {
+    float edgesize, Vp, Vs, rho, a0_shear, a1_shear, b_shear, g0_shear, g1_shear, a0_kappa, a1_kappa, b_kappa, g0_kappa, g1_kappa;
+} edata_t;
+
+
+
+/** 3-ary double vector */
+struct fvector_t {
+    solver_float f[3];
+};
+
+typedef struct fvector_t fvector_t;
+
+
+union df3_t {
+    struct {
+        double x, y, z;
+    };
+    double f[3];
+};
+
+
+/**
+ * out_hdr_t: 4D output file header.
+ */
+struct out_hdr_t {
+    /** file type string identifier: "Hercules 4D output vnnn"  */
+    char    file_type_str[29];
+    int8_t  format_version;	/**< File format version		*/
+    int8_t  endiannes;		/**< File endianess: 0=little, 1=big	*/
+
+    /** Identifier of the platform where the file was generated */
+    int8_t   platform_id;
+    unsigned char ufid[16];	/**< "Unique" file identifier		*/
+    int64_t  total_nodes;	/**< Node count.			*/
+    int32_t  output_steps;	/**< Number of output time steps.	*/
+
+    /** Number of components per (node) record, e.g., 1 vs. 3 */
+    int32_t  scalar_count;
+    int8_t   scalar_size;	/**< size (in bytes) of each scalar value  */
+
+    /**<
+     * Type of scalar, it can take one of the following values
+     * - INVALID:		 0
+     * - FLOAT32 (float):	 1
+     * - FLOAT64 (double):	 2
+     * - FLOAT128 (long double): 3
+     * - INT8:			 4
+     * - UINT8:			 5
+     * - INT16:			 6
+     * - UINT16:		 7
+     * - INT32:			 8
+     * - UINT32:		 9
+     * - INT64:			 10
+     * - UINT64:		 11
+     */
+    int8_t  scalar_type;
+
+    /**<
+     * scalar class, it can take one of the following values:
+     * - INVALID:		 0
+     * - FLOAT_CLASS		 1
+     * - INT_CLASS		 2
+     */
+    int8_t  scalar_class;
+
+    int8_t  quantity_type;	/* 0: unknown, 1: displacement, 2: velocity */
+
+
+    /** Mesh parameters: extent of the simulated region in meters */
+    double  domain_x, domain_y, domain_z;
+
+    /**
+     * Mesh parameter: tick size, factor for converting from domain units (m)
+     * to etree units.
+     */
+    double  mesh_ticksize;
+
+    /** Simulation parameter: delta t (time) */
+    double  delta_t;
+
+    /** Mesh parameter: total number of elements */
+    int64_t total_elements;
+
+    /** 4D Output parameter: how often is an output time step written out */
+    int32_t output_rate;
+
+    /** Simulation parameter: total number of simulation time steps */
+    int32_t total_time_steps;
+
+    int64_t generation_date;	/**< Time in seconds since the epoch	*/
+};
+
+typedef struct out_hdr_t out_hdr_t;
+
+
+/*---------------- Solver data structures -----------------------------*/
+
+/**
+ * Constants initialized element structure.
+ */
+struct e_t {
+    double c1, c2, c3, c4;
+};
+
+typedef struct e_t e_t;
+
+
+/**
+ * Constants initialized node structure.
+ *
+ * This structure has been changed as a result of the new algorithm
+ * for the terms involved with the damping in the solution for the
+ * next time step.
+ */
+struct n_t {
+    solver_float mass_simple;
+    solver_float mass2_minusaM[3];
+    solver_float mass_minusaM[3];
+};
+
+typedef struct n_t n_t;
+
+/**
+ * Data type to represent stiffness matrices
+ */
+struct fmatrix_t {
+    double f[3][3];
+};
+
+typedef struct fmatrix_t fmatrix_t;
+
+
+/* Solver computation and communication routines */
+
+typedef struct messenger_t messenger_t;
+
+/**
+ * A messenger keeps track of the data exchange.
+ */
+struct messenger_t {
+    int32_t  procid;        /**< Remote PE id.     */
+
+    int32_t  outsize;       /**< Outgoing record size. */
+    int32_t  insize;        /**< Incoming record size. */
+
+    void*    outdata;
+    void*    indata;
+
+    int32_t  nodecount;     /**< Number of mesh nodes involved.         */
+    int32_t  nidx;          /**< Current index into the mapping table.  */
+    int32_t* mapping;       /**< Array of local ids for involved nodes. */
+
+    messenger_t* next;
+};
+
+
+/**
+ * Communication schedule structure.
+ */
+struct schedule_t {
+    /**
+     * Number of PEs this PE contributes to or retrieves data from because
+     * this PE harbors their nodes.
+     */
+    int32_t       c_count;
+    messenger_t*  first_c;
+    messenger_t** messenger_c;  /**< Fast lookup table to build c-list. */
+    MPI_Request*  irecvreqs_c;  /**< control for non-blocking receives. */
+    MPI_Status*   irecvstats_c;
+
+    /** Number of processors who share nodes owned by me. */
+    int32_t       s_count;
+    messenger_t*  first_s;
+    messenger_t** messenger_s;  /* Fast lookup table to build s-list.      */
+    MPI_Request*  irecvreqs_s;  /* controls for non-blocking MPI receives. */
+    MPI_Status*   irecvstats_s;
+};
+
+typedef struct schedule_t schedule_t;
+
+
+/**
+ * Solver data structure.
+ */
+struct solver_t {
+    e_t *eTable;            /* Element computation-invariant table */
+    n_t *nTable;            /* Node computation-invariant table */
+
+    fvector_t *tm1;         /* Displacements at timestep t - 1 */
+    fvector_t *tm2;         /* Displacements at timestep t - 2 */
+    fvector_t *force;       /* Force accumulation at timestep t */
+};
+
+typedef struct solver_t solver_t;
+
+
+/**
+ * \todo Document this struct.
+ */
+struct mysolver_t {
+    e_t* eTable;            /* Element computation-invariant table  */
+    n_t* nTable;            /* Node computation-invariant table     */
+
+    /* \TODO Explain better what is tm1,2,3 */
+    fvector_t* tm1;         /* Displacements at timestep t - 1      */
+    fvector_t* tm2;         /* Displacements at timestep t - 2      */
+    fvector_t* tm3;         /* Displacements at timestep t - 3      */
+    fvector_t* force;       /* Force accumulation at timestep t     */
+
+    schedule_t* dn_sched;   /* Dangling node communication schedule */
+    schedule_t* an_sched;   /* Anchored node communication schedule */
+
+    fvector_t* conv_shear_1;      /* Approximate Convolution Calculation */
+    fvector_t* conv_shear_2;
+    fvector_t* conv_kappa_1;
+    fvector_t* conv_kappa_2;
+
+    /* GPU device data structures */
+    gpu_spec_t* gpu_spec;
+
+    elem_t*     elemTableDevice; // this should be declared in mesh_t struct
+    e_t*        eTableDevice;
+    fvector_t*  tm1Device;
+    fvector_t*  forceDevice;
+};
+
+typedef struct mysolver_t mysolver_t;
+
+
+/* This structures was copied from geometrics.h
+ * \todo We need to unify this structure because is used in several
+ *       parts of the code and with different names, see above, for
+ *       example, fvector_t
+ */
+struct vector3D_t {
+    double x[3];
+};
+
+typedef struct vector3D_t vector3D_t;
+
+
+/* ------------------------------------------------------------------------- *
+ *               Output stations data structures
+ * ------------------------------------------------------------------------- */
+
+struct station_t {
+    int32_t    id, nodestointerpolate[8];
+    double*    displacementsX;
+    double*    displacementsY;
+    double*    displacementsZ;
+
+    vector3D_t coords;        /* cartesian */
+    vector3D_t localcoords;   /* csi, eta, dzeta in (-1,1) x (-1,1) x (-1,1) */
+    FILE*      fpoutputfile;
+};
+
+typedef struct station_t station_t;
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int  solver_abort (const char* function_name, const char* error_msg,
+			  const char* format, ...);
+extern void solver_output_seq (void);
+extern int  parsetext (FILE* fp, const char* querystring, const char type,
+		       void* result);
+
+
+
+/**
+ * mu_and_lambda: Calculates mu and lambda according to the element values
+ *                of Vp, Vs, and Rho and verifies/applies some rules defined
+ *                by Jacobo, Leonardo and Ricardo.  It was originally within
+ *                solver_init but was moved out because it needs to be used
+ *                in other places as well (nonlinear)
+ */
+void mu_and_lambda(double *theMu, double *theLambda, edata_t *edata, int32_t eindex);
+
+/**
+ * Search a point in the domain of the local mesh.
+ *
+ *   input: coordinates
+ *  output: 0 fail 1 success
+ */
+int32_t search_point( vector3D_t point, octant_t **octant );
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PSOLVE_H */

--- a/quake/forward_gpu/quake_util.cu
+++ b/quake/forward_gpu/quake_util.cu
@@ -1,0 +1,246 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <math.h>
+#include <string.h>
+
+#include "psolve.h"
+#include "quake_util.h"
+
+#include <cuda_runtime.h>
+
+
+/**
+ * For regular simulations use 1e-20.  For performance and scalability,
+ * uncomment the immediate return in vector_is_zero() and vector_is_all_zero().
+ * Alternatives with each platform underflow precision limit for 'double'
+ * may also work, though this have not been thoroughly tested.
+ *
+ * Known underflow limits:
+ * - NICS' Kraken: Limit is ~2.2e-308 --> use 1e-200
+ *
+ */
+#define UNDERFLOW_CAP 1e-20
+
+
+/**
+ * Return minimum of two int32_t integers.
+ */
+int32_t imin(int32_t x, int32_t y)
+{
+  if (x < y) {
+    return(x);
+  } else {
+    return(y);
+  }
+}
+
+
+/**
+ * For effective stiffness method:
+ *
+ * Check whether all components of a 3D vector are close to zero,
+ * i.e., less than a small threshold.
+ *
+ * \return 1 when there is at least one "non-zero" component;
+ *         0 when all the components are "zero".
+ */
+//int vector_is_zero( const fvector_t* v )
+//{
+//    /*
+//     * For scalability studies, uncomment the immediate return.
+//     */
+//
+//    /* return 1; */
+//
+//    int i,j;
+//
+//    for (i = 0; i < 8; i++) {
+//        for(j = 0; j < 3; j++){
+//            if (fabs( v[i].f[j] ) > UNDERFLOW_CAP) {
+//                return 1;
+//            }
+//        }
+//    }
+//
+//    return 0;
+//}
+
+/**
+ * For conventional stiffness method:
+ *
+ * Check whether all components of a 3D vector are close to zero,
+ * i.e., less than a small threshold.
+ *
+ * \return 1 when there is at least one "non-zero" component;
+ *         0 when all the components are "zero".
+ */
+int vector_is_all_zero( const fvector_t* v )
+{
+    /*
+     * For scalability studies, uncomment the immediate return.
+     */
+
+    /* return 1; */
+
+    int i;
+
+    for (i = 0; i < 3; i++) {
+        if (fabs( v->f[i] ) > UNDERFLOW_CAP) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+/**
+ * MultAddMatVec: Multiply a 3 x 3 Matrix (M) with a 3 x 1 vector (V1)
+ *                and a constant (c). Then add the result to the same
+ *                target vector (V2)
+ *
+ *  V2 = V2 + M * V1 * c
+ *
+ */
+void MultAddMatVec( fmatrix_t* M, fvector_t* V1, double c, fvector_t* V2 )
+{
+    int row, col;
+    fvector_t tmpV;
+
+    tmpV.f[0] = tmpV.f[1] = tmpV.f[2] = 0;
+
+    for (row = 0; row < 3; row++)
+        for (col = 0; col < 3; col++)
+            tmpV.f[row] += M->f[row][col] * V1->f[col];
+
+    for (row = 0; row < 3; row++)
+        V2->f[row] += c * tmpV.f[row];
+
+    return;
+}
+
+/**
+ * Search Quality Table to find the corresponding coefficients for the implementation of BKT model
+ */
+
+int Search_Quality_Table(double Q, double *theQTABLE, int QTable_Size)
+{
+
+	if(Q <= 500)
+	{
+		int i, range;
+		double diff, min;
+
+		range = Q / 5.;
+		min = 1000.;
+
+		for(i = 0; i < QTable_Size; i++)
+		{
+			diff = Q - theQTABLE[ i * 6 ];
+
+			diff = (diff < 0) ? -diff : diff;
+
+			if(diff < min){
+				min = diff;
+			}
+			else
+			{
+				return (i-1);
+			}
+		}
+
+		return (-2);
+	}
+	else
+	{
+		return (-1);
+	}
+
+	// statement is unreachable
+	// return (-2);
+
+}
+
+/**
+ * Parse an array of doubles.
+ *
+ * \return 0 on success, -1 on error
+ */
+int
+parsedarray( FILE* fp, const char* querystring, int size, double* array )
+{
+    static const char delimiters[] = " =\n\t";
+
+    int iSize;
+    int found = 0;
+
+    rewind( fp );
+
+    while (!found) {
+        char* name;
+        char  line[LINESIZE];
+
+        /* Read in one line */
+        if (fgets(line, LINESIZE, fp) == NULL) {
+            break;
+        }
+
+        name = strtok(line, delimiters);
+
+        if ((name != NULL) && (strcmp( name, querystring ) == 0)) {
+            found = 1;
+
+            for (iSize = 0; iSize < size; iSize++) {
+                if (fscanf( fp," %lf ", &(array[iSize]) )  == 0) {
+                    fprintf( fp,"\nUnable to read %s", querystring );
+                    return -1;
+                }
+            }
+
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+
+
+/**
+ * Checks whether a leaf octant needs to be expanded or not according to Vs Rule
+ *
+ *\Return 1 if true, 0 otherwise.
+ */
+int vsrule( edata_t *edata, double theFactor )
+{
+
+    if (edata->edgesize <= edata->Vs / theFactor) {
+
+        return 0;
+
+    } else {
+
+        return 1;
+    }
+}
+
+
+
+

--- a/quake/forward_gpu/quake_util.h
+++ b/quake/forward_gpu/quake_util.h
@@ -1,0 +1,50 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef QUAKE_UTIL_H_
+#define QUAKE_UTIL_H_
+
+
+/* -------------------------------------------------------------------------- */
+/*                        Structures and definitions                          */
+/* -------------------------------------------------------------------------- */
+
+#define LINESIZE        512
+
+typedef enum {
+    NO = 0, YES
+} noyesflag_t;
+
+/* -------------------------------------------------------------------------- */
+/*                                  Methods                                   */
+/* -------------------------------------------------------------------------- */
+
+int32_t  imin(int32_t x, int32_t y);
+//int  vector_is_zero( const fvector_t* v );
+int  vector_is_all_zero( const fvector_t* v );
+
+void MultAddMatVec( fmatrix_t* M, fvector_t* V1, double c, fvector_t* V2 );
+
+int  Search_Quality_Table(double Q, double *theQTABLE, int QTable_Size);
+
+int  parsedarray( FILE *fp, const char *querystring,int size, double *array );
+
+int  vsrule( edata_t  *edata, double theFactor );
+
+#endif /* QUAKE_UTIL_H_ */

--- a/quake/forward_gpu/quakesource.cu
+++ b/quake/forward_gpu/quakesource.cu
@@ -1,0 +1,4072 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ *
+ * quakesource.c: source definition of earthquakes HERCULES version.
+ *
+ *
+ *          Input: physics.in, numerics.in source.in
+ *
+ * Optional input: slip.in, rake.in and genericfault.in.
+ *
+ *         Output: array of time dependant forces for each node
+ *
+ *
+ * Definitions:
+ *
+ *
+ *              global coordinates - N-S   = X
+ *                                   E-W   = Y
+ *                                   Depth = Z
+ *
+ *              domain coordinates - They could be the same as global
+ *                                   if there is no azimutal rotation
+ *                                   of the rectangular prism. Other-
+ *                                   wise the are the coordinates of
+ *                                   the prism, where the left edge is
+ *                                   x.
+ *
+ *                local coordinate - Local to the fault surface
+ *
+ *
+ *
+ *
+ * Notes:
+ *        Any modification comment should be made in the functions not at the
+ *        begining of the code.
+ *
+ * Copyright (c) 2005 Leonardo Ramirez-Guzman
+ * Supported by the Mexican National Council of Science and Technology
+ * Scholarship program.
+ *
+ * Created as part of the Quake project (tools for earthquake simulation).
+ * There is no warranty whatsoever.
+ *
+ * All rights reserved. May not be used, modified, or copied without
+ * permission.
+ *
+ * Contact:
+ * Leonardo Ramirez Guzman
+ * Civil and Environmental Engineering
+ * Carnegie Mellon University
+ * 5000 Forbes Avenue
+ * Pittsburgh, PA 15213
+ * lramirez@andrew.cmu.edu
+ *
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <math.h>
+#include <mpi.h>
+
+#include "cvm.h"
+#include "commutil.h"
+#include "etree.h"
+#include "nrutila.h"
+#include "octor.h"
+#include "psolve.h"
+#include "quakesource.h"
+#include "quake_util.h"
+#include "util.h"
+
+
+
+#define    SRCNEEDED_MSG  100
+#define NUMSRCNEEDED_MSG  101
+#define       SRC_STATM0  102
+#define       SRC_STATFO  103
+#define       SRC_STATNO  104
+#define      SRC_STATMEM  105
+
+
+#define INT32_ARRAY_LENGTH(array)	(sizeof((array))/sizeof(int32_t))
+#define INT64_ARRAY_LENGTH(array)	(sizeof((array))/sizeof(int64_t))
+#define FLOAT_ARRAY_LENGTH(array)	(sizeof((array))/sizeof(float))
+#define DOUBLE_ARRAY_LENGTH(array)	(sizeof((array))/sizeof(double))
+
+
+/* convenience shortcut macros */
+#define ABORT_PROGRAM(msg)			\
+    do {					\
+	if (NULL != msg) {			\
+	    fputs( msg, stderr );		\
+	}					\
+	MPI_Abort(MPI_COMM_WORLD, ERROR );	\
+	exit( 1 );				\
+    } while (0)
+
+#define WAIT		MPI_Barrier( comm_solver )
+#define ABORTEXIT	MPI_Abort(MPI_COMM_WORLD, ERROR); exit(1)
+
+
+
+
+static int32_t myNumberOfForces = 0;
+static int32_t myNumberOfNodesLoaded = 0;
+static int myNumberOfCycles = 0;
+static double myMemoryAllocated = 0;
+
+
+/* Static global variables. */
+
+/* Mesh related variables */
+static octree_t *myOctree;
+static mesh_t *myMesh;
+
+static vector3D_t **myForces;
+
+static double theSurfaceCornersLong[4], theSurfaceCornersLat[4];
+static double theDomainX, theDomainY, theDomainZ;
+
+static double theMinimumEdge;
+
+/* MPI related variables */
+static int32_t myID;
+static int32_t theGroupSize;
+
+/* General variables */
+static double theRegionOriginLatDeg,
+    theRegionOriginLongDeg,
+    theRegionAzimuthDeg;
+static double theRegionDepthShallowM, theRegionLengthEastM;
+static double theRegionLengthNorthM, theRegionDepthDeepM;
+static double theDeltaT,theValidFreq;
+
+static int32_t	      theNumberOfTimeSteps;
+static int32_t	      theSourceIsFiltered;
+static source_type_t  theTypeOfSource;
+
+/* Filter related */
+static double theThresholdFrequency;
+static int theNumberOfPoles;
+
+/* Point and plane variables */
+static int32_t theSourceFunctionType;
+static double theAverageRisetimeSec, theMomentMagnitude, theMomentAmplitude;
+static double theRickerTs, theRickerTp;
+
+static int32_t theNumberOfTimeWindows;
+static double *theWindowDelay;
+
+/* Point variables */
+static int theLonlatOrCartesian;
+static double theHypocenterLatDeg, theHypocenterLongDeg, theHypocenterDepthM;
+static double theSourceStrikeDeg, theSourceDipDeg, theSourceRakeDeg;
+
+/* Plane variables */
+static double theExtendedCellSizeAlongStrikeM, theExtendedCellSizeDownDipM;
+static double theExtendedLatDeg, theExtendedLongDeg;
+static double theExtendedDepthM,     theExtendedAlongStrikeDistanceM;
+static double theExtendedDownDipDistanceM,   theExtendedHypocenterAlongStrikeM;
+static double theExtendedHypocenterDownDipM, theExtendedAverageRuptureVelocity;
+static double theExtendedStrikeDeg, theExtendedDipDeg;
+static double theExtendedMinimumEdge;
+
+static vector3D_t theExtendedHypLocCart;
+
+static int32_t theExtendedColumns, theExtendedRows;
+static double ***theSlipMatrix, ***theRakeMatrix;
+
+static vector3D_t theExtendedCorner [4];
+
+static int32_t numStepsNecessary;
+
+
+/* Plane with kinks variables */
+static double *theKinkLonArray, *theKinkLatArray;
+static double *theTraceLengthAccumulated;
+static double theTotalTraceLength;
+
+static int32_t theNumberOfKinks;
+static vector3D_t *theTraceVectors;
+
+vector3D_t  theKinksDomainCoord[6];
+
+
+/* General source type variables SRFH */
+static int     theNumberOfPointSources;
+static int*    theSourceNt1Array;
+static double* theSourceLonArray,*theSourceLatArray,*theSourceDepthArray;
+static double* theSourceAreaArray,*theSourceStrikeArray,*theSourceDipArray,
+  *theSourceRakeArray,*theSourceSlipArray;
+static double *theSourceTinitArray,*theSourceDtArray,**theSourceSlipFunArray ;
+
+/* Statistics variables and total moment ampitude*/
+static double  myM0 =0;
+
+/* I/O variables */
+static int32_t *myForcesCycle;
+
+/* Time statistic variables */
+static double theForceGenerationTime = 0;
+static double theConcatTime = 0;
+static double theIOInitTime = 0;
+
+static char*  theSourceOutputDir = NULL;
+
+
+/** Exported global configuration variable.  Default value = 100 MB */
+int theForcesBufferSize = 104857600;
+
+/*------------------------FUNCTIONS-------------------------------------------*/
+
+static int read_planewithkinks (FILE *fp);
+
+
+static void compute_point_source_strike (ptsrc_t* ps);
+
+
+
+/**
+ * Get the name of the output directory for the source files
+ */
+const char*
+source_get_output_dir()
+{
+    return theSourceOutputDir;
+}
+
+int
+source_get_local_loaded_nodes_count()
+{
+    return myNumberOfNodesLoaded;
+}
+
+
+
+/**
+ * Interpolate linearly a function if the time is larger than the one
+ * supported by the function the last value will be assigned
+ */
+static double
+interpolate_linear( double time, int numsamples, double samplingtime,
+		    double* discretefunction )
+{
+    double maxtime, m, b;
+    int    interval;
+
+    maxtime = (numsamples-1) * samplingtime;
+
+    if (time >= maxtime) {
+	return discretefunction[numsamples-1];
+    }
+
+    else {
+
+	/* locate the interval */
+	interval = floor(time/samplingtime);
+
+	/* y = mx +b */
+	m = discretefunction[interval + 1] - discretefunction[interval];
+	m = m / samplingtime;
+	b = discretefunction[interval] - m * interval * samplingtime;
+
+	return m*time + b;
+    }
+}
+
+
+/**
+ *
+ * compute_source_function: compute the slip source function:
+ *
+ *        Input:
+ *                pointSource - pointer to a point source. All
+ *                              information required has to be
+ *                              loaded in it.
+ *        Output: void
+ *
+ *        Notes:
+ *               numStepsNecessary  is the number of steps required
+ *               to reach the maximum value of the slip.
+ *
+ */
+void
+compute_source_function (ptsrc_t* pointSource)
+{
+  double  decay, t1, T, tao;
+  int     iTime;
+
+  /*  printf("\n sourcefunctiontype = %d ",  pointSource->sourceFunctionType);
+      exit(1);*/
+
+  /* for ( iTime=0; iTime < pointSource->numberOfTimeSteps; iTime++) { */
+  for (iTime=0; iTime < numStepsNecessary; iTime++) {
+
+    T = pointSource->dt * iTime;
+    tao= T / pointSource->T0;
+
+    if (pointSource->delayTime < T) {
+      T =  T -pointSource->delayTime;
+
+      switch (pointSource->sourceFunctionType) {
+
+      case RAMP:
+	  decay = (T < pointSource->T0) ? T / pointSource->T0 : 1;
+	  break;
+
+      case SINE:
+	  decay = ((T < pointSource->T0)
+		 ? ( T / pointSource->T0
+		     - sin ( 2 * PI * T / pointSource->T0) / PI / 2)
+		 : 1);
+	break;
+
+      case QUADRATIC:
+	if ( T < pointSource->T0 / 2 ) {
+	  decay = 2 * pow (T / pointSource->T0, 2);
+	}
+	else if (T <= pointSource->T0) {
+	  decay = (-2 * pow (T / pointSource->T0, 2)
+		   + 4 * T / pointSource->T0 - 1);
+	}
+	else {
+	  decay = 1;
+	}
+	break;
+
+      case RICKER:  /* Ricker's function */
+	t1 = pow ((T - pointSource->Ts) * PI / pointSource->Tp, 2);
+	decay = (t1 - 0.5) * exp (-t1);
+	break;
+
+      case EXPONENTIAL:
+	/* decay = 1-(1 + T/pointSource->T0)*exp(-T/pointSource->T0); */
+	decay = 1 - (1 + tao) * exp(-tao);
+	break;
+
+      case DISCRETE:
+	decay = interpolate_linear(T, pointSource->nt1,
+				   pointSource->dtfunction,
+				   pointSource->slipfundiscrete);
+
+	break;
+
+      default:
+	fprintf (stderr, "Unknown source type %d\n",
+		 pointSource->sourceFunctionType);
+	ABORT_PROGRAM ("Cannot compute source function");
+	return;
+      };
+    }
+    else {
+      decay =0;
+    }
+
+    pointSource->displacement[ iTime ] += decay * pointSource->maxSlip;
+
+  }
+
+  return;
+}
+
+
+
+
+/**
+ * search_source: search a point in the domain of the local mesh
+ *
+ *   input: coordinates
+ *  output: 0 fail 1 success
+ */
+//static int32_t search_point( vector3D_t point, octant_t **octant  )
+//{
+//    tick_t  xTick, yTick, zTick;
+//
+//    xTick = point.x[0] / myMesh->ticksize;
+//    yTick = point.x[1] / myMesh->ticksize;
+//    zTick = point.x[2] / myMesh->ticksize;
+//
+//    *octant = octor_searchoctant(myOctree, xTick, yTick, zTick,
+//            PIXELLEVEL, AGGREGATE_SEARCH);
+//
+//    if ( (*octant == NULL) || ((*octant)->where == REMOTE) ) {
+//        return 0;
+//    }
+//
+//    return 1;
+//
+//}
+
+
+/**
+ * Initialize the wighting force vector for an element due to a point
+ * source.
+ */
+static void source_initnodalforce ( ptsrc_t *sourcePtr )
+{
+    /* Normal vector n, tangent vector t, moment tensor v*/
+    double n[3], t[3], v[3][3];
+
+    /* Auxiliar array to handle shapefunctions in a loop */
+    double  xi[3][8]={ {-1,  1, -1,  1, -1,  1, -1, 1} ,
+		       {-1, -1,  1,  1, -1, -1,  1, 1} ,
+		       {-1, -1, -1, -1,  1,  1,  1, 1} };
+
+    /* various convienient variables */
+    int j, k;
+    double dx, dy, dz;
+    double s = sourcePtr->strike / 180.0 * PI;
+    double d = sourcePtr->dip / 180.0 * PI;
+    double r = sourcePtr->rake / 180.0 * PI;
+    double x = sourcePtr->x;
+    double y = sourcePtr->y;
+    double z = sourcePtr->z;
+    double h = sourcePtr->edgesize;
+    double hcube = h * h * h;
+
+    /* the fault normal unit vector */
+    n[0] = - sin(s) * sin(d);
+    n[1] =   cos(s) * sin(d);
+    n[2] = - cos(d);
+
+    /* the fault tangential unit vector */
+    t[0] =   cos(r) * sin(PI / 2 - s) + sin(r) * sin(s) * cos(d);
+    t[1] =   cos(r) * sin(s) - sin(r) * cos(s) * cos(d);
+    t[2] = - sin(r) * sin(d);
+
+    for (j = 0; j < 3; j++) {
+	for ( k = 0; k < 3; k++) {
+	    v[j][k] = n[j] * t[k] + n[k] * t[j];
+	}
+    }
+
+    /* calculate equivalent force on each node */
+    for (j = 0; j < 8 ; j++) {
+	dx= (2 * xi[0][j]) * (h + 2 * xi[1][j] * y) * (h + 2 * xi[2][j] * z)
+	    / (8 * hcube) ;
+
+	dy= (2 * xi[1][j]) * (h + 2 * xi[2][j] * z) * (h + 2 * xi[0][j] * x)
+	    / (8 * hcube);
+
+	dz= (2 * xi[2][j]) * (h + 2 * xi[0][j] * x) * (h + 2 * xi[1][j] * y)
+	    / (8 * hcube);
+
+	sourcePtr->nodalForce[j][0] = v[0][0]*dx + v[0][1]*dy + v[0][2]*dz;
+	sourcePtr->nodalForce[j][1] = v[1][0]*dx + v[1][1]*dy + v[1][2]*dz;
+	sourcePtr->nodalForce[j][2] = v[2][0]*dx + v[2][1]*dy + v[2][2]*dz;
+    }
+
+    return;
+}
+
+
+/**
+ * Computes the time when the rupture is initiated in the given
+ * station. It assumes a homogeneous radial dependent rupture time.
+ */
+double
+compute_initial_time( vector3D_t station, vector3D_t hypocenter,
+		      double rupturevelocity )
+{
+    double travelTime;
+
+    int32_t i;
+
+    travelTime = 0;
+
+    for (i = 0; i < 3;  i++) {
+	travelTime += pow( station.x[i] - hypocenter.x[i], 2 );
+    }
+
+    travelTime = sqrt( travelTime );
+    travelTime = travelTime / rupturevelocity;
+
+    return travelTime;
+}
+
+
+/**
+ * Compute cartesian coordinates.
+ *
+ * \param lat Latitude in degrees.
+ * \param lon Longitude in degrees.
+ * \param depth Depth in meters.
+ *
+ * \return a vector3D_t with the point in cartesian coordinates.
+ */
+static vector3D_t
+compute_cartesian_coords( double lat, double lon, double depth )
+{
+    vector3D_t pointInCartesian;
+
+    pointInCartesian.x[0] = ( lat - theRegionOriginLatDeg )  * DIST1LAT;
+    pointInCartesian.x[1] = ( lon - theRegionOriginLongDeg ) * DIST1LON;
+    pointInCartesian.x[2] = depth - theRegionDepthShallowM ;
+
+    return pointInCartesian;
+}
+
+
+/*
+ * compute_local_coords: computes the coordinates of a station in the fault
+ *                       plane related to the origin of the fault
+ *
+ *  input: point
+ *         totalNodes
+ *         gridx, gridy
+ *
+ * output: vector3D_t pointInCartesian
+ *
+ */
+vector3D_t
+compute_local_coords( int32_t point, int32_t totalNodes, double* gridx,
+		      double *gridy )
+{
+    vector3D_t pointVector;
+
+    pointVector.x[ 0 ] = gridx [ point % totalNodes ];
+    pointVector.x[ 1 ] = gridy [ ( int32_t ) point / totalNodes ];
+    pointVector.x[ 2 ] =  0;
+
+    return pointVector;
+}
+
+
+static int32_t source_compute_print_stat(){
+
+    /* Compute the total M0 and Mw */
+    if ( myID == 0 ){
+
+	int32_t fromWhom;
+	int32_t rcvNumberOfForces, rcvNumberOfNodesLoaded;
+	int rcvNumberOfCycles;
+    
+	double rcvMemoryAllocated,theTotalM0=0,rcvM0, Mw;
+	double theTotalMemoryAllocated =0 ;
+    
+	int iCorner, iCoord;
+
+	MPI_Status status;
+	theTotalM0=myM0;
+	theTotalMemoryAllocated += myMemoryAllocated;
+
+	if ( theTypeOfSource == PLANE ) {
+	    fprintf(stdout,"\n\n Extended Fault Information \n ");
+	    fprintf(stdout,"\n Fault's Corners Global Coordinates (X,Y,Z)\n");
+
+	    for ( iCorner = 0; iCorner < 4; iCorner++){
+		fprintf(stdout,"\n");
+
+		for( iCoord = 0; iCoord < 3; iCoord++)
+		    fprintf(stdout," %f ",theExtendedCorner[iCorner].x[iCoord]);
+	    }
+	}
+
+	fprintf( stdout,"\n\n Process       M0   myNumOfForces" );
+	fprintf( stdout,"     myCycles  myNumNodesLoaded  myMemAlloc");
+	fprintf( stdout,"\n    %-4d   %-10e   %-10d    %-5d    %-10d   %e",myID,myM0,
+		 myNumberOfForces,myNumberOfCycles, myNumberOfNodesLoaded, myMemoryAllocated);
+
+	for ( fromWhom=1; fromWhom< theGroupSize ; fromWhom++ ) {
+	    MPI_Recv ( &rcvNumberOfCycles, 1,   MPI_INT,fromWhom ,
+		       SRC_STATM0,  comm_solver, &status);
+	    MPI_Recv ( &rcvM0, 1,   MPI_DOUBLE,fromWhom ,
+		       SRC_STATM0,  comm_solver, &status);
+	    MPI_Recv ( &rcvNumberOfForces, 1, MPI_INT,fromWhom ,
+		       SRC_STATFO,  comm_solver, &status);
+	    MPI_Recv ( &rcvNumberOfNodesLoaded, 1, MPI_INT,fromWhom ,
+		       SRC_STATNO,  comm_solver, &status);
+	    MPI_Recv ( &rcvMemoryAllocated, 1, MPI_DOUBLE,fromWhom ,
+		       SRC_STATMEM, comm_solver, &status);
+
+	    theTotalM0+=rcvM0;
+	    theTotalMemoryAllocated += rcvMemoryAllocated;
+
+	    if ( rcvNumberOfForces != 0)
+		fprintf ( stdout,"\n    %-4d   %-10e   %-10d    %-5d    %-10d   %e" ,fromWhom,rcvM0,
+			  rcvNumberOfForces,rcvNumberOfCycles, rcvNumberOfNodesLoaded, rcvMemoryAllocated);
+
+	}
+
+	if ( theSourceIsFiltered == 1 )
+	    fprintf( stdout,"\n  Filtered  Threshold frequency = %lf Poles =%d \n",
+		     theThresholdFrequency, theNumberOfPoles);
+	else
+	    fprintf(stdout,"\n  Non Filtered \n");
+
+	Mw=(log10 ( theTotalM0*pow(10,7))/1.5)-10.73;
+
+	fprintf ( stdout,"\n   M0  =  %e Nm  \n Mw = %f",theTotalM0, Mw );
+	fprintf ( stdout,"\n Total Memory Allocated = %e\n",
+		  theTotalMemoryAllocated );
+    }
+
+    else {
+	MPI_Ssend( &myNumberOfCycles, 1, MPI_INT, 0, SRC_STATM0, comm_solver);
+	MPI_Ssend( &myM0,          1, MPI_DOUBLE, 0, SRC_STATM0, comm_solver);
+	MPI_Ssend( &myNumberOfForces, 1, MPI_INT, 0, SRC_STATFO, comm_solver);
+	MPI_Ssend( &myNumberOfNodesLoaded,1,MPI_INT,0,SRC_STATNO,comm_solver);
+	MPI_Ssend( &myMemoryAllocated,1,MPI_DOUBLE,0,SRC_STATMEM,comm_solver);
+    }
+
+    return 1;
+}
+
+
+/**
+ * compute an in-place complex-to-complex FFT. x and y are the real and
+ * imaginary arrays of 2^m points.  dir = 1 gives forward transform dir =
+ * -1 gives reverse transform
+ */
+int FFT( short int dir, long m, double* x, double* y )
+{
+    long   n, i, i1, j, k, i2, l, l1, l2;
+    double c1, c2, tx, ty, t1, t2, u1, u2, z;
+
+    /* Calculate the number of points */
+    n = 1;
+    for (i=0;i<m;i++) {
+	n *= 2;
+    }
+
+    /* Do the bit reversal */
+    i2 = n >> 1;
+    j = 0;
+    for (i = 0; i < n-1; i++) {
+	if (i < j) {
+	    tx = x[i];
+	    ty = y[i];
+	    x[i] = x[j];
+	    y[i] = y[j];
+	    x[j] = tx;
+	    y[j] = ty;
+	}
+	k = i2;
+	while (k <= j) {
+	    j -= k;
+	    k >>= 1;
+	}
+	j += k;
+    }
+
+    /* Compute the FFT */
+    c1 = -1.0;
+    c2 = 0.0;
+    l2 = 1;
+    for (l = 0; l < m; l++) {
+	l1 = l2;
+	l2 <<= 1;
+	u1 = 1.0;
+	u2 = 0.0;
+	for (j = 0; j < l1; j++) {
+	    for (i = j; i < n; i += l2) {
+		i1 = i + l1;
+		t1 = u1 * x[i1] - u2 * y[i1];
+		t2 = u1 * y[i1] + u2 * x[i1];
+		x[i1] = x[i] - t1;
+		y[i1] = y[i] - t2;
+		x[i] += t1;
+		y[i] += t2;
+	    }
+	    z =  u1 * c1 - u2 * c2;
+	    u2 = u1 * c2 + u2 * c1;
+	    u1 = z;
+	}
+	c2 = sqrt((1.0 - c1) / 2.0);
+	if (dir == 1)
+	    c2 = -c2;
+	c1 = sqrt((1.0 + c1) / 2.0);
+    }
+
+    /* Scaling for forward transform */
+    if (dir == 1) {
+	for (i=0;i<n;i++) {
+	    x[i] /= n;
+	    y[i] /= n;
+	}
+    }
+
+    return 1;
+}
+
+
+/**
+ * Compute Butterworth filter value for a given frequency.
+ *
+ * \param f0	Filter's threshold frequency.
+ * \param m	Filter's order.
+ * \param f	Frequency for which the coefficient is to be computed.
+ */
+static double
+bw_filter_coeffient( double f0, int m, double f )
+{
+    return sqrt( 1.0 / (pow (f / f0, 2 * m) + 1) );
+}
+
+
+static int
+print_filter(
+	     const char*  filename,
+	     unsigned int signal_length,
+	     double       sampling_frequency,
+	     double       threshold_frequency,
+	     unsigned int m
+	     )
+{
+  unsigned int filter_length, i;
+  double	 delta_frequency;
+  double	 f0 = threshold_frequency;	/* alias for threshold freq */
+
+  FILE* fp = fopen (filename, "w");
+
+  if (NULL == fp) {
+    return -1;
+  }
+
+  /* n = ( int ) ( log ( signal_size ) / log( 2 ) ) + 1 ;  */
+  /* filter_length = pow ( 2 , n ); */
+
+  /* rely on integer arithmetic for this to work */
+  filter_length = (signal_length / 2) + 1;
+
+  fputs ("0  1\n", fp);
+
+  delta_frequency = sampling_frequency / filter_length;
+
+  for (i = 1; i <= filter_length; i++) {
+    double f      = delta_frequency * i;	/* current frequency */
+    double filter = bw_filter_coeffient (f0, m, f);
+    fprintf (fp, "%lf %lf\n", f, filter);
+  }
+
+  fflush (fp);
+  fclose (fp);
+
+  return 0;
+}
+
+
+/**
+ * Print the slip function for the "average" source function.
+ */
+static int
+print_slip_function (const char* filename)
+{
+  int i;
+  double* p_disp;	/* pointer to the displacement array */
+  ptsrc_t src;	/* point source */
+
+  FILE* fp = fopen (filename, "w");
+
+  if (NULL == fp) {
+    perror ("Could not open file");
+    fprintf (stderr, "Filename: %s\n", filename);
+    return -1;
+  }
+
+  /* Compute the "average" source function */
+  src.dt		   = theDeltaT;
+  src.numberOfTimeSteps  = theNumberOfTimeSteps;
+  src.delayTime	   = 0;
+  src.sourceFunctionType = (source_function_t)theSourceFunctionType;
+  src.T0		   = theAverageRisetimeSec;
+  src.maxSlip		   = 1;
+
+  p_disp = (double*) calloc (sizeof (double), theNumberOfTimeSteps);
+
+  if (NULL == p_disp) { /* memory allocation failed */
+    fprintf (stderr, "Could not allocate memory for point source "
+	     "displacement\nTrying to allocate %d doubles, size = %zu\n",
+	     theNumberOfTimeSteps, theNumberOfTimeSteps * sizeof (double));
+    fclose (fp);
+    return -1;
+  }
+
+  src.displacement = p_disp;
+  compute_source_function (&src);
+
+  for (i = 0; i < theNumberOfTimeSteps; i++) {
+    fprintf (fp, "%lf %lf\n", i * src.dt, src.displacement[i]);
+  }
+
+  free (p_disp);
+  fclose (fp);
+
+  return 0;
+}
+
+
+/**
+ * Print the filter values (for the given parameters) and the values
+ * of the "average" source function.
+ */
+int
+print_filter_and_signal(
+			int    signalsize,
+			double samplingfrequency,
+			double thresholdfrequency,
+			int    m
+			)
+{
+  int r1, r2;
+
+  r1 = print_filter ("filter.dat", signalsize, samplingfrequency,
+		     thresholdfrequency, m);
+  if (0 != r1) {
+    ABORT_PROGRAM ("Could not print filter data");
+    return -1;
+  }
+
+  r2 = print_slip_function ("slipfunc.dat");
+  if (0 != r2) {
+    ABORT_PROGRAM ("Could not print source slip function");
+    return -1;
+  }
+
+  return 1;
+}
+
+
+/**
+ * print_myForce_filepercycle:
+ *
+ */
+static void
+print_myForces_filepercycle( const char *filenameroot, int cycle )
+{
+    int32_t lnid, j;
+    char forcefile[256];
+    int32_t numberOfNodes=0, tmpNumberOfNodes=0;
+    FILE *fp;
+
+    sprintf(forcefile, "%s.%d", filenameroot, cycle);
+
+    fp = fopen(forcefile,"w");
+
+    for ( lnid = 0; lnid <  myMesh->nharbored; lnid++){
+	if ( myForcesCycle [ lnid ] == cycle ){
+	    numberOfNodes+=1;
+	}
+    }
+
+    /* Checking */
+    tmpNumberOfNodes=0;
+    for ( lnid = 0; lnid <  myMesh->nharbored; lnid++){
+	if ( myForces[ lnid ] != NULL ){
+	    tmpNumberOfNodes+=1;
+	}
+    }
+
+    /* to debug */
+    if (tmpNumberOfNodes != numberOfNodes) {
+	fprintf( stderr, "\n n =%d l=%d", tmpNumberOfNodes, numberOfNodes);
+	ABORT_PROGRAM( "number of nodes did not match" );
+    }
+
+    fwrite( &numberOfNodes, sizeof(int32_t), 1, fp );
+
+    for (j = 0; j < theNumberOfTimeSteps; j++) {
+	for (lnid = 0; lnid <  myMesh->nharbored; lnid++) {
+	    if (myForcesCycle[ lnid ] ==  cycle) {
+		fwrite( myForces[lnid][j].x, sizeof(double), 3, fp );
+	    }
+	}
+    }
+
+    fclose(fp);
+}
+
+
+/**
+ * print_myForce:
+ *
+ * This method is not being used anywhere.  It will remain commented out
+ * until I am convinced it can be erased completely (RICARDO).
+ *
+ * static void print_myForces(FILE *fp) {
+ *
+ *     int32_t lnid, i, j;
+ *
+ *     for ( lnid = 0; lnid <  myMesh->nharbored; lnid++){
+ *         if ( myForces [ lnid ] !=  NULL ){
+ *             for ( i = 0; i < 3;  i++ ){
+ *                 fprintf( fp,"\n" );
+ *                 for ( j = 0; j < theNumberOfTimeSteps; j++ ) {
+ *                     fprintf ( fp," %f ", myForces [ lnid ] [ j ].x[ i ] );
+ *                 }
+ * 	       }
+ * 	   }
+ *     }
+ *
+ *     return;
+ * }
+ *
+ */
+
+static void
+print_myForces_transposed( FILE *fp )
+{
+    int lnid, j;
+
+    for (j = 0; j < theNumberOfTimeSteps; j++) {
+	for (lnid = 0; lnid <  myMesh->nharbored; lnid++) {
+	    if (myForces [ lnid ] !=  NULL) {
+		fwrite( myForces[lnid][j].x, sizeof(double), 3, fp );
+	    }
+	}
+    }
+}
+
+
+
+/**
+ * Release memory used for the myForces vectors.
+ */
+static void free_myForces( void )
+{
+    int lnid;
+
+    for (lnid = 0; lnid < myMesh->nharbored; lnid++) {
+	if (myForces [ lnid ] !=  NULL) {
+	    free( myForces[ lnid ] );
+	}
+    }
+
+    /* initialize myForces with NULL */
+    memset( myForces, 0, myMesh->nharbored * sizeof(double*) );
+}
+
+
+/**
+ *  Filters a signal we add zeros such that newsize is 2^n
+ */
+int FilterSignal ( double *signal, int signalsize,
+		   double samplingfrequency, double thresholdfrequency,
+		   int m ) {
+
+
+    double *filter = NULL, *signalReal = NULL,  *signalImaginary = NULL;
+    double *signalFilteredReal = NULL , *signalFilteredImaginary = NULL;
+    double frequency;
+
+  int i, n,  newSize;
+
+  n = ( int ) ( log ( signalsize ) / log( 2 ) ) + 2 ;
+  newSize = pow ( 2 , n );
+
+  /* Allocate and check */
+  signalReal		  = (double*)malloc( sizeof(double) * newSize );
+  signalImaginary	  = (double*)malloc( sizeof(double) * newSize );
+  signalFilteredReal	  = (double*)malloc( sizeof(double) * newSize );
+  signalFilteredImaginary = (double*)malloc( sizeof(double) * newSize );
+  filter		  = (double*)malloc( sizeof(double) * newSize );
+
+  if ( !signalReal || !signalImaginary || !signalFilteredReal ||
+       !signalFilteredImaginary || !filter ) {
+    perror("Failed to allocate space for the filter");
+    MPI_Abort(MPI_COMM_WORLD, ERROR);
+    exit(1);
+  }
+
+
+  /* Init imaginary with zeroes and move signal to signalReal*/
+  /* We will filter the derivative of the signal, notice that this is not
+     exactly correct but it allows you to introduce zeroes without a big
+     jump in the slip function */
+  /* Take derivative of the signal onsistent with the 2 order polynomial
+     you are using for the time interpolation */
+
+  for (i = 0 ; i < signalsize; i++) {
+
+      if (i == 0) {
+	  signalReal[i] = .5 * samplingfrequency
+	      * ( -3 * signal[i] + 4 * signal[i+1] - 1 * signal[i+2] );
+      }
+      else if( i == signalsize-1) {
+	  signalReal [ i ] = .5 * samplingfrequency
+	      * ( signal[i-2] - 4*signal[i-1] + 3*signal[i]);
+      }
+      else {
+	  signalReal [ i ] = .5 * samplingfrequency
+	      * ( -signal[i-1] + signal[i+1]);
+      }
+  }
+
+  for ( i = 0 ; i < newSize; i++) {
+    signalImaginary [ i ] = 0;
+  }
+
+  for ( i = signalsize ; i < newSize; i++) {
+    signalReal [ i ] = 0;
+  }
+
+  FFT( 1,( long ) n, signalReal , signalImaginary);
+
+  /* calculate the filter, multiply and obtain the conjugate */
+
+  /* frequency = 0 */
+  frequency = 0;
+  filter [ 0 ] = 1;
+  signalFilteredReal [ 0 ] = filter [ 0 ] * signalReal [ 0 ];
+  signalFilteredImaginary [ 0 ] = filter [ 0 ] * signalImaginary [ 0 ];
+
+  for ( i = 1; i <= newSize / 2 ; i++ ) {
+      frequency   = samplingfrequency * i / newSize;
+      filter[ i ] = 1 / ( 1 + pow( frequency / thresholdfrequency, 2 * m ));
+      filter[ i ] = pow( filter [ i ] , .5 );
+      signalFilteredReal[ i ] = filter [ i ] * signalReal [ i ];
+      signalFilteredImaginary[ i ] = filter [ i ] * signalImaginary [ i ];
+      signalFilteredReal[ newSize-i ]      = signalFilteredReal [ i ];
+      signalFilteredImaginary[ newSize-i ] = -signalFilteredImaginary [ i ];
+  }
+
+  FFT( -1, (long)n, signalFilteredReal, signalFilteredImaginary );
+
+  /* move signalFilteredReal to signal and integrate */
+  for (i = 0 ; i < signalsize; i++) {
+      if (i == 0) {
+	  signal [ i ] = 0;
+      }
+      else if ( i == 1 ) {
+	  signal [ i ] = .5 * ( 1/samplingfrequency ) *
+	      ( signalFilteredReal[ i-1 ] + signalFilteredReal[ i ] );
+      }
+      else {
+	  signal[ i ] = signal[i - 1] + .5 * ( 1/samplingfrequency ) *
+	      ( signalFilteredReal[i - 1] + signalFilteredReal[i] );
+      }
+  }
+
+  free(signalReal);
+  free(signalImaginary);
+  free(signalFilteredReal);
+  free(signalFilteredImaginary);
+  free(filter);
+
+  return 1;
+}
+
+
+/**
+ * filter_myForce:
+ *
+ */
+static void
+filter_myForce()
+{
+    int32_t lnid, i, j;
+    double* signal;
+
+    signal = (double*)malloc( sizeof(double) * theNumberOfTimeSteps );
+
+    if ( !signal ) {
+	perror( "Failed to allocate space for the signal" );
+	MPI_Abort(MPI_COMM_WORLD, ERROR );
+	exit( 1 );
+    }
+
+    for (lnid = 0; lnid <  myMesh->nharbored; lnid++) {
+	if (myForces[ lnid ] !=  NULL) {
+	    for (i = 0; i < 3;  i++) {
+
+		for (j = 0; j < theNumberOfTimeSteps; j++) {
+		    signal[ j ] = myForces[ lnid ][ j ].x[ i ];
+		}
+
+		FilterSignal( signal, theNumberOfTimeSteps, 1/theDeltaT,
+			      theThresholdFrequency, theNumberOfPoles );
+		for (j = 0; j < theNumberOfTimeSteps; j++) {
+		    myForces[ lnid ][ j ].x[ i ] = signal[ j ];
+		}
+	    }
+	}
+    }
+
+    free( signal );
+
+    return;
+}
+
+
+/**
+ * Computes the force vector for a point source and updates myForces
+ * vector.
+ *
+ *   input: octant where the source is located
+ *          the pointer of the displacement array (time dependant)
+ *  output: 0 fails 1 success
+ */
+static int
+load_myForces_with_point_source(
+	octant_t* octant,
+	ptsrc_t*  pointSource,
+	char*     is_force_in_processor,
+	int32_t   cycle,
+	int32_t   iForce
+	)
+{
+
+    int32_t eindex;
+    int j,iTime, iCoord, iNode;
+
+    double mu, center_x, center_y, center_z;
+
+    double nodalForceArea;
+
+    elem_t *elemp;
+    edata_t *edata;
+    tick_t edgeticks;
+    edgeticks = (tick_t)1 << (PIXELLEVEL - octant->level);
+
+    /* calculate the center coordinate of the element */
+    center_x = myMesh->ticksize * (octant->lx + edgeticks / 2);
+    center_y = myMesh->ticksize * (octant->ly + edgeticks / 2);
+    center_z = myMesh->ticksize * (octant->lz + edgeticks / 2);
+
+    /* go through my local elements to find which one matches the
+     * containing octant. I should have a better solution than this.
+     */
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+	int32_t lnid0;
+	lnid0 = myMesh->elemTable[eindex].lnid[0];
+
+	if ( ( myMesh->nodeTable[lnid0].x == octant->lx ) &&
+	     ( myMesh->nodeTable[lnid0].y == octant->ly ) &&
+	     ( myMesh->nodeTable[lnid0].z == octant->lz ) ) {
+
+	    /* sanity check */
+	    if (myMesh->elemTable[eindex].level != octant->level) {
+		fprintf(stderr, "Thread %d: source_init: error\n",myID);
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+
+	    /* Fill in the local node ids of the containing element */
+	    memcpy( pointSource->lnid, myMesh->elemTable[eindex].lnid,
+		    sizeof(int32_t) * 8 );
+	    break;
+	}
+    }  /* for all the local elements */
+
+    if (eindex == myMesh->lenum) {
+	fprintf ( stderr, "Thread %d: source_init: ", myID );
+	fprintf ( stderr, "No element matches the containing octant.\n" );
+	MPI_Abort(MPI_COMM_WORLD, ERROR );
+	exit(1);
+    }
+
+    /* derive the local coordinate of the source inside the element */
+    pointSource->x = pointSource->domainCoords.x[ 0 ] - center_x;
+    pointSource->y = pointSource->domainCoords.x[ 1 ] - center_y;
+    pointSource->z = pointSource->domainCoords.x[ 2 ] - center_z;
+
+    /* obtain the value of mu to get the moment in the case of extended fault*/
+    elemp = &myMesh->elemTable[eindex];
+    edata = (edata_t*)elemp->data;
+    mu    = edata->rho * edata->Vs * edata->Vs;
+
+    if (theTypeOfSource == POINT) {
+	if (pointSource->M0 == 0) {
+	    pointSource->M0 = pow( 10, 1.5 * theMomentMagnitude + 9.1);
+	}
+
+	myM0		     += pointSource->M0;
+	pointSource->muArea   = pointSource->M0;
+	/* notice that this is a fake slip to obtain the M0 given as data */
+	pointSource->maxSlip  = 1;
+    }
+    else{
+	pointSource->muArea =  mu * pointSource->area;
+
+	if(cycle == 0) {
+	    myM0 += fabs( pointSource->muArea * pointSource->maxSlip );
+	}
+    }
+
+    pointSource->edgesize = myMesh->ticksize * edgeticks;
+
+    /* set the nodal forces */
+    source_initnodalforce( pointSource );  /* get the weight for each node */
+
+    int isinprocessor = 0; /* if 8 will update the search */
+    for (iNode = 0; iNode < 8; iNode++) {
+	j = pointSource -> lnid [ iNode ];
+
+	if ( myForces [ j ] == NULL  && myForcesCycle[j] == cycle){
+	    myForces [ j ] =
+		( vector3D_t * ) malloc ( sizeof ( vector3D_t ) *
+					  theNumberOfTimeSteps);
+	    myNumberOfNodesLoaded +=1;
+	    myMemoryAllocated +=  sizeof ( vector3D_t ) * theNumberOfTimeSteps;
+
+	    if ( myForces [ j ] == NULL ) {
+		fprintf(stderr,"Thread %d: load_myForces...: out of mem\n",
+			myID);
+		MPI_Abort(MPI_COMM_WORLD, ERROR);
+		exit(1);
+	    }
+
+	    for (iCoord = 0; iCoord < 3; iCoord++) {
+		for (iTime = 0; iTime < theNumberOfTimeSteps; iTime++) {
+		    myForces [j][iTime].x[iCoord]=0;
+		}
+	    }
+	    isinprocessor+=1;
+	}
+    }
+
+    if (isinprocessor == 8) {
+	update_forceinprocessor( iForce, is_force_in_processor, 0 );
+    }
+
+    for (iNode = 0; iNode < 8; iNode++) {
+	j = pointSource -> lnid[iNode];
+	if (myForcesCycle[j] == cycle) {
+	    for (iCoord = 0; iCoord < 3; iCoord++) {
+		nodalForceArea = pointSource->nodalForce[iNode][iCoord]
+		    * pointSource->muArea;
+		/* shifted the loops */
+		for ( iTime = 0; iTime < theNumberOfTimeSteps; iTime++) {
+		    myForces [j][iTime].x[iCoord] +=
+			pointSource->displacement[iTime] * nodalForceArea;
+		}
+	    }
+	}
+    }
+
+    return 1;
+}
+
+
+/*
+ * update_point_source: updates a source in the context of an extended
+ *                      fault
+ *
+ *
+ */
+static void update_point_source (ptsrc_t *pointSource,
+				 int32_t downdipindex,
+				 int32_t alongstrikeindex,
+				 double area){
+  int iWindow, iTime;
+  double maxSlip = 0;
+
+  for(iTime=0; iTime < theNumberOfTimeSteps; iTime++)
+    pointSource->displacement[iTime]=0.;
+
+
+  for ( iWindow=0; iWindow<theNumberOfTimeWindows; iWindow++ ){
+
+    pointSource->rake =
+      theRakeMatrix [iWindow][ downdipindex] [ alongstrikeindex ];
+
+    pointSource->maxSlip = theSlipMatrix[ iWindow ] [ downdipindex] [ alongstrikeindex ];
+    maxSlip +=  pointSource->maxSlip;
+    pointSource->area = area;
+    pointSource->delayTime =
+      compute_initial_time ( pointSource->localCoords,
+			     theExtendedHypLocCart,
+			     theExtendedAverageRuptureVelocity);
+    pointSource->delayTime += theWindowDelay [ iWindow ];
+
+
+    compute_source_function( pointSource );
+
+  }
+
+  pointSource->maxSlip= maxSlip;
+
+}
+
+static void
+compute_point_source_strike_srfh (ptsrc_t* ps, int32_t iSrc)
+{
+
+  vector3D_t pivot, pointInNorth, unitVec;
+
+  double norm,fi ;
+
+
+  if( theLonlatOrCartesian == 1 )return;
+
+
+  if( theLonlatOrCartesian == 0 ){
+
+    pivot = compute_domain_coords_linearinterp(theSourceLonArray[iSrc],
+					       theSourceLatArray[iSrc],
+					       theSurfaceCornersLong ,
+		 			       theSurfaceCornersLat,
+					       theRegionLengthEastM,
+					       theRegionLengthNorthM );
+
+    pointInNorth = compute_domain_coords_linearinterp(theSourceLonArray[iSrc],
+						      theSourceLatArray[iSrc]+.1,
+						      theSurfaceCornersLong ,
+						      theSurfaceCornersLat,
+						      theRegionLengthEastM,
+						      theRegionLengthNorthM );
+
+
+    /* Compute Unit Vector */
+    unitVec.x[1]=pointInNorth.x[1]-pivot.x[1];
+    unitVec.x[0]=pointInNorth.x[0]-pivot.x[0];
+
+    norm = pow( pow( unitVec.x[0], 2)+ pow(unitVec.x[1],2), .5);
+
+    unitVec.x[1]= unitVec.x[1]/norm;
+    unitVec.x[0]= unitVec.x[0]/norm;
+
+    /* Compute the Angle North-X axis */
+    fi = atan( unitVec.x[0]/unitVec.x[1]);
+
+    if(  unitVec.x[1] < 0 ) /* in rad*/
+      fi = fi + PI;
+
+    /* Compute the strike */
+    ps->strike =90+ ps->strike-( 180*fi/PI);
+
+
+  }
+
+}
+
+
+
+/*
+ * update_point_source: updates a source in the context of an extended
+ *                      fault
+ *
+ *
+ */
+static void update_point_source_srfh (ptsrc_t *pointSource, int32_t isource){
+  int iTime;
+
+  for(iTime=0; iTime < theNumberOfTimeSteps; iTime++)
+    pointSource->displacement[iTime]=0.;
+
+  pointSource->strike =  theSourceStrikeArray[isource];
+
+  compute_point_source_strike_srfh(pointSource,isource);
+
+
+  pointSource->dip    =  theSourceDipArray[isource];
+  pointSource->rake   =  theSourceRakeArray[isource];
+  pointSource->area   =  theSourceAreaArray[isource];
+  pointSource->maxSlip=  theSourceSlipArray[isource];
+  pointSource->nt1    =  theSourceNt1Array[isource];
+  pointSource->dtfunction = theSourceDtArray[isource];
+  pointSource->delayTime  = theSourceTinitArray[isource];
+  pointSource->slipfundiscrete    = theSourceSlipFunArray[isource];
+  pointSource->sourceFunctionType = (source_function_t)theSourceFunctionType;
+
+
+  compute_source_function( pointSource );
+
+
+  return;
+}
+
+
+
+
+
+/*
+ * init_planewithkinks_mapping:
+ *
+ */
+static int init_planewithkinks_mapping(){
+
+  int iKink, iDir;
+
+  double distance;
+  double module=0;
+
+  theTraceLengthAccumulated =
+    (double *) malloc ( sizeof( double ) * theNumberOfKinks );
+
+
+  theTraceVectors =
+    ( vector3D_t * ) malloc( sizeof(vector3D_t) * (theNumberOfKinks-1) );
+
+  if ( theTraceLengthAccumulated == NULL || theTraceVectors == NULL ) {
+
+    fprintf ( stderr,
+	      "Thr. %d: Initializing planewithkinks mapping: out of memory\n",
+	      myID);
+
+    return -1;
+
+  }
+
+  /* Compute the accumulated distance along the fault trace */
+  theTraceLengthAccumulated[0] = 0;
+
+  /*------------------------------------------------------------------------*/
+
+  /*Transform theKinkLonArray and theKinkLatArray into domain coords X and Y */
+  for ( iKink=0 ; iKink < theNumberOfKinks; iKink++ ){
+
+    theKinksDomainCoord[iKink] =
+      compute_domain_coords_linearinterp(theKinkLonArray[iKink],
+       					 theKinkLatArray[iKink],
+					 theSurfaceCornersLong ,
+					 theSurfaceCornersLat,
+					 theRegionLengthEastM,
+					 theRegionLengthNorthM );
+
+  }
+
+
+  /*----------------------------------------------------------------------*/
+  for ( iKink=1 ; iKink < theNumberOfKinks; iKink++ ){
+
+    distance=
+      pow(theKinksDomainCoord[iKink].x[0]-theKinksDomainCoord[iKink-1].x[0],2)+
+      pow(theKinksDomainCoord[iKink].x[1]-theKinksDomainCoord[iKink-1].x[1],2);
+
+    theTraceLengthAccumulated [ iKink ] =
+      theTraceLengthAccumulated [ iKink-1 ] +	sqrt( distance );
+
+  }
+
+  theTotalTraceLength = theTraceLengthAccumulated [ theNumberOfKinks -1];
+
+
+  /* Compute the trace vectors given in Global Coordinate */
+  for ( iKink=0 ; iKink < theNumberOfKinks-1; iKink++) {
+    theTraceVectors[iKink].x[0] =
+      theKinksDomainCoord[iKink+1].x[0]-
+      theKinksDomainCoord[iKink].x[0];
+    theTraceVectors [ iKink ].x[1] =
+      theKinksDomainCoord[iKink+1].x[1]-
+      theKinksDomainCoord[iKink].x[1];
+    theTraceVectors [ iKink ].x[2] = 0;
+
+
+    /* make it unitary */
+
+    for ( iDir = 0; iDir < 3; iDir++)
+      module += pow(theTraceVectors [ iKink ].x[iDir],2);
+
+    module = sqrt(module);
+
+    for ( iDir = 0; iDir < 3; iDir++)
+      theTraceVectors [ iKink ].x[iDir] =
+	theTraceVectors [ iKink ].x[iDir] / module;
+
+  }
+
+
+  /* Normalize theTraceLengthAccumulated*/
+
+  for ( iKink=0 ; iKink < theNumberOfKinks; iKink++)
+    theTraceLengthAccumulated [ iKink ] =
+      theTraceLengthAccumulated [ iKink ] / theTotalTraceLength;
+
+  return 1;
+
+}
+
+
+
+
+/*
+ *
+ *  compute_global_coords_mapping: it assumes that the x[0] component is along
+ *                                 strike  and x[1] is downdip
+ *
+ */
+static vector3D_t compute_global_coords_mapping(vector3D_t point){
+
+  int iKink=-1, iKinkOrigin=-1;
+
+  double normalizedDistance;
+
+  vector3D_t origin;
+
+  vector3D_t pointMapped;
+
+  /* Normalize x[0]  value with the totalLength */
+
+  normalizedDistance = point.x[0]/theTotalTraceLength;
+
+  /* Check between which elements is this length */
+
+  /* do not make it more complex unless you really want to do something
+     more complex in geometry */
+
+  while ( iKinkOrigin < 0 ){
+
+    iKink=iKink +1;
+
+    if ( theTraceLengthAccumulated[iKink] <= normalizedDistance &&
+	 theTraceLengthAccumulated[iKink+1] >= normalizedDistance )
+      iKinkOrigin = iKink;
+
+
+  }
+
+
+  /* Using the value of the vector associated to this initial point
+     of the interval where it is located and the vector compute the
+     global coordinates */
+
+
+  /* Transform the long lat to X Y global */
+
+  origin.x[0] = theKinksDomainCoord[ iKinkOrigin].x[0];
+
+  origin.x[1] = theKinksDomainCoord[ iKinkOrigin].x[1];
+
+  origin.x[2] = point.x[1] + theExtendedDepthM;
+
+
+  /* Compute the global coordinates using the unit vector */
+
+
+  pointMapped.x[0] = origin.x[0] + ( point.x[0]-
+				     theTraceLengthAccumulated[ iKinkOrigin ] *
+                                     theTotalTraceLength ) *
+    theTraceVectors[iKinkOrigin].x[0];
+
+  pointMapped.x[1] = origin.x[1] + ( point.x[0]-
+				     theTraceLengthAccumulated[ iKinkOrigin ] *
+                                     theTotalTraceLength ) *
+    theTraceVectors[iKinkOrigin].x[1];
+
+  pointMapped.x[2] =  origin.x[2];
+
+
+
+  return pointMapped;
+
+}
+
+
+/*
+ *
+ *  compute_strike_planewithkinks:
+ *
+ */
+static double compute_strike_planewithkinks(vector3D_t point){
+
+  int iKink=-1, iKinkOrigin=-1;
+
+  double normalizedDistance, strike;
+
+  /* Normalize x[0]  value with the totalLength */
+
+  normalizedDistance = point.x[0]/theTotalTraceLength;
+
+  /* Check between which elements is this length */
+
+  /* do not make it more complex unless you really want to do something
+     more complex in geometry */
+
+  while ( iKinkOrigin < 0 ){
+
+    iKink=iKink +1;
+
+    if ( theTraceLengthAccumulated[iKink] <= normalizedDistance &&
+	 theTraceLengthAccumulated[iKink+1] >= normalizedDistance )
+
+      iKinkOrigin = iKink;
+
+
+  }
+
+  if( theTraceVectors[iKinkOrigin].x[1] >= 0)
+
+    strike = acos(theTraceVectors[iKinkOrigin].x[0]);
+
+  else if ( theTraceVectors[iKinkOrigin].x[0] < 0 &&
+	    theTraceVectors[iKinkOrigin].x[1] <= 0 )
+
+    strike = ( 3*PI/2 ) - acos(theTraceVectors[iKinkOrigin].x[0]);
+
+  else if ( theTraceVectors[iKinkOrigin].x[0] > 0 &&
+	    theTraceVectors[iKinkOrigin].x[1] < 0 )
+
+    strike = acos(theTraceVectors[iKinkOrigin].x[0]) + 3*PI/2;
+
+
+  /* compute deg that is what is take from the code */
+
+
+  strike = 180* strike / PI;
+
+
+  return strike;
+
+}
+
+
+/**
+ * tag_myForcesCycle: it assigns a number to each element of
+ *                    myForces in myForcesCycle. myForcesCycle
+ *                    will be modified to choose in wich cycle
+ *                    it should be written.
+ *
+ *  *   input: octant where the source is located
+ *             the pointer of the displacement array (time dependant)
+ *  output: -1 fails 1 success
+ *
+ */
+static int tag_myForcesCycle(octant_t *octant, ptsrc_t *pointSource){
+
+  int32_t eindex;
+
+  int j, iNode;
+
+  tick_t edgeticks;
+  edgeticks = (tick_t)1 << (PIXELLEVEL - octant->level);
+
+  /* Go through my local elements to find which one matches the
+     containing octant.*/
+  for ( eindex = 0; eindex < myMesh->lenum; eindex++ ) {
+    int32_t lnid0;
+    lnid0 = myMesh->elemTable[eindex].lnid[0];
+    if ( ( myMesh->nodeTable[lnid0].x == octant->lx ) &&
+	 ( myMesh->nodeTable[lnid0].y == octant->ly ) &&
+	 ( myMesh->nodeTable[lnid0].z == octant->lz ) ) {
+      /* Sanity check */
+      if ( myMesh->elemTable[eindex].level != octant->level ) {
+	fprintf(stderr, "Thread %d: source_init: internal error\n",
+		myID);
+	MPI_Abort(MPI_COMM_WORLD, ERROR);
+	exit(1);
+      }
+
+      /* Fill in the local node ids of the containing element */
+      memcpy ( pointSource->lnid, myMesh->elemTable[eindex].lnid,
+	       sizeof(int32_t) * 8 );
+      break;
+    }
+
+  }  /* for all the local elements */
+
+  if ( eindex == myMesh->lenum ) {
+    fprintf ( stderr, "Thread %d: source_init: ", myID );
+    fprintf ( stderr, "No element matches the containing octant.\n" );
+    return -1;
+  }
+
+  for ( iNode = 0; iNode < 8; iNode++){
+    j = pointSource -> lnid [ iNode ];
+    if ( myForcesCycle [ j ] == -1 ){
+      myForcesCycle [ j ] = 1;
+      myNumberOfNodesLoaded +=1;
+    }
+
+  }
+
+  return 1;
+
+}
+
+void update_forceinprocessor(int32_t iForce, char *inoutprocessor, int onoff){
+
+  int32_t whichByte, whichBit;
+
+  char mask;
+
+  whichByte = iForce/8;
+  whichBit = 7 - iForce % 8;
+
+  mask = ( char )(pow(2,whichBit)*onoff);
+
+  inoutprocessor[whichByte] =  inoutprocessor[whichByte] | mask;
+
+  return;
+
+}
+
+
+int is_forceinprocessor(int32_t iForce, char *inoutprocessor){
+
+  int32_t whichByte, whichBit;
+
+  char mask,test;
+
+  whichByte = iForce/8;
+  whichBit = 7 - iForce % 8;
+
+
+  mask = ( char )pow(2,whichBit);
+
+  test = inoutprocessor[whichByte] & mask;
+
+  if ( test == mask )
+
+    return 1;
+
+  else
+
+    return 0;
+
+}
+
+
+
+/**
+ * \todo move to util.c
+ */
+static char*
+str_join( const char* s1, char sep, const char* s2 )
+{
+    /* space for the two strings + separator + terminating \0 */
+    size_t len1 = strlen( s1 );
+    size_t len  = len1 + strlen( s2 ) + 2;
+    char* buf   = (char*)malloc( len * sizeof(char) );
+
+    strcpy( buf, s1 );	/* copy s1 */
+    buf[len1] = sep;	/* add separator */
+
+    /* append s2 at the end of buf */
+    strncpy( buf + len1 + 1, s2, len - len1 - 1 );
+    buf[len - 1] = '\0';
+
+    return buf;
+}
+
+
+/**
+ * Open a file in a given directory
+ *
+ * \todo move to util.c
+ */
+static FILE*
+open_file_in_dir( const char* directory, const char* file, const char* flags )
+{
+    char* path = str_join( directory, '/', file );
+    FILE* fp   = NULL;
+
+    if (NULL != path) {
+	fp = hu_fopen( path, flags );
+	free( path );
+    }
+
+    return fp;
+}
+
+
+
+/**
+ * Close a file descriptor (FILE*) and set it to NULL.
+ *
+ * \todo move to util.c
+ */
+static int
+close_file( FILE** fp )
+{
+    int ret = 0;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+
+    if (NULL != *fp) {
+	ret = fclose( *fp );
+
+	if (0 == ret) {
+	    /* nullify this handle only if the close was successful */
+	    *fp = NULL;
+	}
+    }
+
+    return ret;
+}
+
+
+/**
+ * Get the local file name for the forces.  The local file name is of the
+ * form "theSourceOutputDir/force_process.<pe_id>".
+ *
+ * \pre this requires that the following global variables be already
+ * initialized:
+ * - theSourceOutputDir
+ * - myID
+ *
+ * \return the already-initialized local file name.  The returned
+ * reference points to an already-initiliazed static variable.
+ */
+static const char*
+source_get_local_forces_filename()
+{
+    static int  initialized = 0;
+    static char local_forces_filename[256];
+
+    if (! initialized) {
+	snprintf( local_forces_filename, sizeof(local_forces_filename),
+		  "%s/force_process.%d", theSourceOutputDir, myID );
+	initialized = 1;
+    }
+
+    return local_forces_filename;
+}
+
+
+/**
+ * Open local forces file.
+ */
+FILE*
+source_open_forces_file( const char* flags )
+{
+    const char* force_filename = source_get_local_forces_filename();
+
+    return hu_fopen( force_filename, flags );
+}
+
+
+static FILE*
+open_source_description_file()
+{
+   /* open source description file */
+    return open_file_in_dir(theSourceOutputDir, "sourcedescription.out", "w");
+}
+
+
+static FILE*
+open_source_description_file_0()
+{
+    if (0 != myID) { /* only PE 0 reads physics.in */
+	return NULL;
+    }
+
+   /* PE 0: open source description file */
+    return open_source_description_file();
+}
+
+
+/**
+ * Read  domain specifications from physics.in
+ *
+ * \param fp Already opened file handle for physics.in
+ *
+ * \return -1 on ERROR, 0 on success.
+ */
+static int
+read_domain( FILE* fp )
+{
+    double origin_latitude_deg;
+    double origin_longitude_deg;
+    double azimuth_leftface_deg;
+    double depth_shallow_m;
+    double length_east_m;
+    double length_north_m;
+    double depth_deep_m;
+
+    if ((parsetext(fp, "region_origin_latitude_deg", 'd',
+		   &origin_latitude_deg) != 0) ||
+	(parsetext(fp, "region_origin_longitude_deg", 'd',
+		   &origin_longitude_deg) != 0) ||
+	(parsetext(fp, "region_depth_shallow_m", 'd',
+		   &depth_shallow_m) != 0) ||
+	(parsetext(fp, "region_length_east_m", 'd',
+		   &length_east_m) != 0) ||
+	(parsetext(fp, "region_length_north_m", 'd',
+		   &length_north_m) != 0) ||
+	(parsetext(fp, "region_depth_deep_m", 'd',
+		   &depth_deep_m) != 0) ||
+	(parsetext(fp, "region_azimuth_leftface_deg", 'd',
+		   &azimuth_leftface_deg) )) {
+
+	fprintf(stderr, "Error domain and source dir from physics.in");
+	return -1;
+    }
+
+    /* assign to global variables */
+    theRegionOriginLatDeg  = origin_latitude_deg;
+    theRegionOriginLongDeg = origin_longitude_deg;
+    theRegionDepthShallowM = depth_shallow_m;
+    theRegionLengthEastM   = length_east_m;
+    theRegionLengthNorthM  = length_north_m;
+    theRegionDepthDeepM    = depth_deep_m;
+    theRegionAzimuthDeg    = azimuth_leftface_deg;
+
+    return 0;
+}
+
+
+
+/*
+ * read_filter :  if myForce vector is going to be read extra data is required
+ *
+ *       input :  fp - to source.in
+ *
+ *
+ *      output :  -1 fail
+ *                 1 success
+ *
+ *      Notes  :  a low pass butterworth filter is used
+ *
+ */
+static int read_filter(FILE *fp){
+
+
+  int source_is_filtered, number_of_poles;
+
+  double threshold_frequency;
+
+  if ( parsetext( fp, "source_is_filtered", 'i', &source_is_filtered) != 0){
+    fprintf(stderr, "Error parsing source.in reading filter parameters\n");
+    return -1;
+  }
+  if ( source_is_filtered == 1 ){
+
+    if ( parsetext( fp, "threshold_frequency", 'd', &threshold_frequency) != 0){
+      fprintf(stderr, "Error parsing source.in reading filter parameters\n");
+      return -1;
+    }
+
+    if ( (parsetext(fp, "threshold_frequency", 'd',
+		    &threshold_frequency) != 0) ||
+	 (parsetext(fp, "number_of_poles", 'i',
+		    &number_of_poles)     != 0) ) {
+      fprintf(stderr, "Error parsing source.in reading filter parameters\n");
+      return -1;
+    }
+
+  }
+
+
+  theSourceIsFiltered   = source_is_filtered;
+  theThresholdFrequency = threshold_frequency;
+  theNumberOfPoles      = number_of_poles;
+
+  return 1;
+
+}
+
+
+/*
+ *  read_common_all_formats : read the common varibles to all formats
+ *
+ *           input : fp  - to source.in
+ *                   fpw - to windows.in
+ *
+ *          output :  -1 fail
+ *                     1 success
+ *
+ *
+ *           Notes :   window.in has the delay times of every pulse or shape
+ *                     function that we use to represent the slip function.
+ *
+ *
+ */
+static int read_common_all_formats ( FILE *fp ){
+
+
+  double average_risetime_sec, ricker_Ts, ricker_Tp;
+
+  char  source_function_type[64];
+
+  source_function_t sourceFunctionType;
+
+
+  /*
+   *  From source.in slip function parameters
+   */
+
+
+  if ( (parsetext(fp, "source_function_type", 's',
+		  &source_function_type) != 0) ) {
+    fprintf(stderr, "Error parsing files from source.in");
+    return -1;
+
+  }
+
+  if ( strcasecmp(source_function_type, "ramp") == 0 )
+    sourceFunctionType = RAMP;
+  else if ( strcasecmp(source_function_type, "sine") == 0 )
+    sourceFunctionType = SINE;
+  else if ( strcasecmp(source_function_type, "quadratic") == 0 )
+    sourceFunctionType = QUADRATIC;
+  else if ( strcasecmp(source_function_type, "ricker") == 0 )
+    sourceFunctionType = RICKER;
+  else if ( strcasecmp(source_function_type, "exponential") == 0 )
+    sourceFunctionType = EXPONENTIAL;
+  else if ( strcasecmp(source_function_type, "discrete") == 0 )
+    sourceFunctionType = DISCRETE;
+
+  else {
+    fprintf(stderr, "Unknown excitation type %s\n", source_function_type);
+    return -1;
+  }
+
+  if ( sourceFunctionType == RAMP       ||
+       sourceFunctionType == SINE       ||
+       sourceFunctionType == QUADRATIC  ||
+       sourceFunctionType == EXPONENTIAL ) {
+
+    if ( (parsetext(fp, "average_risetime_sec", 'd',
+		    &average_risetime_sec) != 0)){
+      fprintf(stderr, "Cannot get time function parameters\n");
+      return -1;
+    }
+  }
+
+  if (  sourceFunctionType == RICKER ) {
+    if ( (parsetext(fp, "ricker_Ts", 'd', &ricker_Ts) != 0)||
+	 (parsetext(fp, "ricker_Tp", 'd', &ricker_Tp) != 0)) {
+      fprintf(stderr, "Cannot get parameters to ricker's function\n");
+      return -1;
+    }
+  }
+
+  theSourceFunctionType = sourceFunctionType;
+  theAverageRisetimeSec = average_risetime_sec;
+  theRickerTs = ricker_Ts;
+  theRickerTp = ricker_Tp;;
+
+  return 1;
+
+}
+
+/*
+ *  read_point_source :
+ *
+ *                     input : fp  - to source.in
+ *
+ *                    output :  -1 fail
+ *                               1 success
+ *
+ */
+
+static int read_point_source(FILE *fp){
+
+  double hypocenter_lat_deg, hypocenter_long_deg, hypocenter_depth_m;
+  double source_strike_deg, source_dip_deg, source_rake_deg;
+  double  moment_magnitude, moment_amplitude;
+  double auxiliar[8];
+  int iCorner;
+
+  /* You can either give M0 or Mw for a point Source */
+  moment_magnitude = 0;
+  moment_amplitude = 0;
+  if ( (parsetext(fp, "moment_magnitude", 'd', &moment_magnitude) != 0) )
+    if ( ( parsetext(fp,"moment_amplitude",'d',&moment_amplitude ) != 0) ){
+      fprintf(stderr,"Error moment:read_point_source\n");
+      return -1;
+    }
+
+  if ( (parsetext(fp,"lonlat_or_cartesian", 'i',&theLonlatOrCartesian) != 0) ){
+    fprintf(stderr,
+	    "Err lonlat_or_cartesian in source.in point source parameters\n");
+    return -1;
+  }
+
+  if( theLonlatOrCartesian == 0 ){
+
+    if ( (parsetext(fp,"hypocenter_lat_deg", 'd',&hypocenter_lat_deg) != 0) ||
+	 (parsetext(fp,"hypocenter_long_deg",'d',&hypocenter_long_deg)!= 0)){
+      fprintf(stderr, "Err in hypocenter lon or lat:read_point_source\n");
+      return -1;
+    }
+
+    parsedarray( fp, "domain_surface_corners", 8 ,auxiliar);
+    for ( iCorner = 0; iCorner < 4; iCorner++){
+      theSurfaceCornersLong[ iCorner ] = auxiliar [ iCorner * 2 ];
+      theSurfaceCornersLat [ iCorner ] = auxiliar [ iCorner * 2 +1 ];
+    }
+  }
+
+  /* Here I am not defining another variable for the cartesian it will be
+     controled with lonlatorcartesian */
+  if( theLonlatOrCartesian == 1 )
+    if ( (parsetext(fp,"hypocenter_x",'d',&hypocenter_lat_deg ) != 0) ||
+	 (parsetext(fp,"hypocenter_y",'d',&hypocenter_long_deg)!= 0)  ){
+      fprintf(stderr, "Err hypocenter x or y:read_point_source\n");
+      return -1;
+    }
+
+  if ( (parsetext(fp,"hypocenter_depth_m", 'd',&hypocenter_depth_m) != 0) ||
+       (parsetext(fp,"source_strike_deg",  'd',&source_strike_deg)  != 0) ||
+       (parsetext(fp, "source_dip_deg",    'd',&source_dip_deg)     != 0) ||
+       (parsetext(fp, "source_rake_deg",   'd',&source_rake_deg)    != 0)) {
+
+    fprintf(stderr, "Err fields:read_point_source\n");
+    return -1;
+  }
+
+  theMomentMagnitude   = moment_magnitude;
+  theMomentAmplitude   = moment_amplitude;
+  theHypocenterLatDeg  = hypocenter_lat_deg;
+  theHypocenterLongDeg = hypocenter_long_deg;
+  theHypocenterDepthM  = hypocenter_depth_m;
+  theSourceStrikeDeg   = source_strike_deg;
+  theSourceDipDeg      = source_dip_deg;
+  theSourceRakeDeg     = source_rake_deg;
+
+  return 1;
+
+}
+
+
+/*
+ *  read_plane_source :
+ *
+ *           input :    fp  -  to source.in
+ *                  fpslip  -  to slip table file
+ *                  fprake  -  to rake table file
+ *
+ *
+ *          output :  -1 fail
+ *                     1 success
+ *
+ */
+
+static int  read_plane_source(FILE *fp, FILE *fpslip, FILE *fprake){
+
+  int iWindow;
+  int cells_down_dip,cells_along_strike;
+  int isminimumedgeautomatic, number_of_time_windows;
+
+  double cell_size_along_strike_m, cell_size_down_dip_m;
+  double lat_deg, long_deg, depth_m;
+  double hypocenter_along_strike_m, hypocenter_down_dip_m;
+  double average_rupture_velocity, strike_deg,dip_deg, minimum_edge_m;
+
+  if ( (parsetext(fp,"number_of_time_windows",'i',&number_of_time_windows) != 0) ) {
+    fprintf( stderr, "Error parsing fields from source.in num of windows\n");
+    return -1;
+  }
+
+  theNumberOfTimeWindows = number_of_time_windows;
+  theWindowDelay= dvector(0,theNumberOfTimeWindows);
+
+  parsedarray( fp, "time_windows", theNumberOfTimeWindows,theWindowDelay);
+
+  /* Mw and M0  will be calculated */
+  if ((parsetext(fp,"extended_cell_size_down_dip_m",  'd', &cell_size_down_dip_m)   != 0) ||
+      (parsetext(fp,"extended_isminimumedgeautomatic",'i', &isminimumedgeautomatic) != 0) ||
+      (parsetext(fp,"extended_depth_m"      ,         'd', &depth_m)                != 0) ||
+      (parsetext(fp,"extended_cells_along_strike",    'i', &cells_along_strike)     != 0) ||
+      (parsetext(fp,"extended_cells_down_dip",        'i', &cells_down_dip)         != 0) ||
+      (parsetext(fp, "extended_hypocenter_along_strike_m",
+		 'd',&hypocenter_along_strike_m) != 0) ||
+      (parsetext(fp, "extended_hypocenter_down_dip_m",'d',  &hypocenter_down_dip_m) != 0) ||
+      (parsetext(fp, "extended_average_rupture_velocity", 'd',
+		 &average_rupture_velocity) != 0) ){
+    fprintf(stderr, "Cannot query plane source\n");
+    return -1;
+  }
+
+  if( theTypeOfSource == PLANE )
+    if ((parsetext(fp,"extended_cell_size_along_strike_m",'d',&cell_size_along_strike_m) != 0)||
+	(parsetext(fp,"extended_lat_deg",               'd', &lat_deg)              != 0) ||
+	(parsetext(fp,"extended_long_deg",              'd', &long_deg)             != 0) ||
+	(parsetext(fp, "extended_strike_deg",           'd',  &strike_deg)          != 0) ||
+	(parsetext(fp, "extended_dip_deg"   ,           'd',  &dip_deg)             != 0)){
+      fprintf(stderr, "Cannot query plane source\n");
+      return -1;
+    }
+
+  if ( isminimumedgeautomatic == 0 ){
+    if ( parsetext(fp,"extended_minimum_edge_m",'d',&minimum_edge_m) != 0 ) return -1;
+  }
+  else
+    minimum_edge_m = theMinimumEdge/1; /* Denominator should be >= 1 */
+
+  /* Read slip and rake matrices */
+  theExtendedColumns = cells_along_strike;
+  theExtendedRows    = cells_down_dip;
+  theSlipMatrix = (double ***)malloc( sizeof(double **) * theNumberOfTimeWindows);
+  theRakeMatrix = (double ***)malloc( sizeof(double **) * theNumberOfTimeWindows);
+
+  for ( iWindow=0; iWindow < theNumberOfTimeWindows; iWindow++){
+    theSlipMatrix[iWindow] = dmatrix(0,theExtendedRows-1,0,
+				     theExtendedColumns-1);
+    theRakeMatrix[iWindow] = dmatrix(0,theExtendedRows-1,0,
+				     theExtendedColumns-1);
+    read_double_matrix_from_file(fpslip,theSlipMatrix[iWindow],
+				 theExtendedRows,theExtendedColumns);
+    read_double_matrix_from_file(fprake,theRakeMatrix[iWindow],
+				 theExtendedRows,theExtendedColumns);
+  }
+
+  if ( theTypeOfSource == PLANEWITHKINKS )
+    if(read_planewithkinks(fp)==-1)return -1;
+
+  theMomentMagnitude = 0;
+  theMomentAmplitude = 0;
+
+  theExtendedCellSizeAlongStrikeM   = cell_size_along_strike_m;
+  theExtendedCellSizeDownDipM       = cell_size_down_dip_m;
+  theExtendedMinimumEdge            = minimum_edge_m;
+  theExtendedLatDeg                 = lat_deg;
+  theExtendedLongDeg                = long_deg;
+  theExtendedDepthM                 = depth_m;
+  theExtendedHypocenterAlongStrikeM = hypocenter_along_strike_m;
+  theExtendedHypocenterDownDipM     = hypocenter_down_dip_m;
+  theExtendedAverageRuptureVelocity = average_rupture_velocity;
+  theExtendedStrikeDeg              = strike_deg;
+  theExtendedDipDeg                 = dip_deg;
+
+  return 1;
+
+}
+
+
+
+/**
+ *  read_planewithkinks :
+ *
+ *           input :    fp  -  to source.in
+ *                  fpslip  -  to slip table file
+ *                  fprake  -  to rake table file
+ *           output :  1 - ok -1 fail
+ *
+ */
+static int
+read_planewithkinks (FILE *fp)
+{
+
+  int iKink, iCorner;
+
+  if ( (parsetext(fp, "extended_number_of_kinks", 'i', &theNumberOfKinks) != 0) ){
+    fprintf(stderr, "Cannot query plane source\n");
+    return -1;
+  }
+
+  /* read Fault Trace description */
+  theKinkLonArray = (double *) malloc( sizeof(double) * theNumberOfKinks);
+  theKinkLatArray = (double *) malloc( sizeof(double) * theNumberOfKinks);
+  if ( theKinkLonArray == NULL || theKinkLatArray == NULL ) {
+    perror("Failed to allocate space for the fault trace description");
+    return -1;
+  }
+
+  double *auxiliar;
+
+  /* trace of the "strike-slip" fault */
+  auxiliar = (double *)malloc(sizeof(double)*theNumberOfKinks*2);
+  if ( auxiliar == NULL ) {
+    perror("Failed to allocate space in read planes");
+    return -1;
+  }
+
+  parsedarray( fp, "extended_kinks", theNumberOfKinks*2,auxiliar);
+  for ( iKink = 0; iKink < theNumberOfKinks; iKink++){
+    theKinkLonArray[ iKink ] = auxiliar [ iKink * 2 ];
+    theKinkLatArray[ iKink ] = auxiliar [ iKink * 2 +1 ];
+  }
+
+  free(auxiliar);
+
+  /* corners of the surface */
+  auxiliar = (double *)malloc(sizeof(double)*8);
+  if ( auxiliar == NULL ) {
+    perror("Failed to allocate space in read planes");
+    MPI_Abort(MPI_COMM_WORLD, ERROR );
+    return -1;
+  }
+
+  parsedarray( fp, "domain_surface_corners", 8 ,auxiliar);
+  for ( iCorner = 0; iCorner < 4; iCorner++){
+    theSurfaceCornersLong[ iCorner ] = auxiliar [ iCorner * 2 ];
+    theSurfaceCornersLat [ iCorner ] = auxiliar [ iCorner * 2 +1 ];
+  }
+
+  free(auxiliar);
+
+  return 1;
+
+}
+
+
+
+
+
+/**
+ *  read_srfh_source: read all the parameters fot the standard
+ *                    rupture format hercules version.A matlab
+ *                    file is provided (converter.m) to do the
+ *                    conversion  from the scec srf to srfh.
+ *
+ *           input :      fp  -  to source.in
+ *                  fpcoords  -  to coordinates of the fault
+ *                  fpstrike  -
+ *                     fpdip  -
+ *                    fprake  -
+ *                    fpslip  -
+ *                 fpslipfun  -  slip function discretized
+ *
+ *           output :  1 - ok -1 fail
+ *
+ */
+static int
+read_srfh_source ( FILE *fp, FILE *fpcoords, FILE *fparea, FILE *fpstrike,
+		   FILE *fpdip, FILE *fprake, FILE *fpslip, FILE *fpslipfun,
+		   double globalDelayT, double surfaceShift )
+{
+  int32_t iSrc;
+  double *auxiliar;
+  int iCorner, iTime;
+
+  if ( (parsetext(fp, "number_of_point_sources", 'i', &theNumberOfPointSources) != 0) ){
+    fprintf(stderr, "Cannot query number of point source\n");
+    return -1;
+  }
+
+  theSourceLonArray     = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceLatArray     = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceDepthArray   = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceAreaArray    = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceStrikeArray  = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceDipArray     = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceRakeArray    = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceSlipArray    = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceNt1Array     = (int *)malloc( sizeof( int )   * theNumberOfPointSources );
+  theSourceTinitArray   = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceDtArray      = (double *)malloc( sizeof( double) * theNumberOfPointSources );
+  theSourceSlipFunArray = (double **)malloc( sizeof( double* ) * theNumberOfPointSources );
+
+  if ( (theSourceLonArray    == NULL) || (theSourceLatArray     == NULL) ||
+       (theSourceDepthArray  == NULL) || (theSourceStrikeArray  == NULL) ||
+       (theSourceStrikeArray == NULL) || (theSourceDipArray     == NULL) ||
+       (theSourceRakeArray   == NULL) || (theSourceSlipArray    == NULL) ||
+       (theSourceNt1Array    == NULL) || (theSourceTinitArray   == NULL) ||
+       ( theSourceDtArray    == NULL) || (theSourceSlipFunArray == NULL) ){
+    ABORT_PROGRAM ("Error source srfh matrices: read_srfh_source");
+  }
+
+  /* read fault points description */
+  for ( iSrc = 0; iSrc < theNumberOfPointSources; iSrc++ ){
+    fscanf(fpcoords," %lf %lf %lf ", &(theSourceLonArray[iSrc]),
+	   &(theSourceLatArray[iSrc]),
+	   &(theSourceDepthArray[iSrc]));
+    fscanf(fparea,   " %lf ", &(theSourceAreaArray[iSrc]));
+    fscanf(fpstrike, " %lf ", &(theSourceStrikeArray[iSrc]));
+    fscanf(fpdip,    " %lf ", &(theSourceDipArray[iSrc]));
+    fscanf(fprake,   " %lf ", &(theSourceRakeArray[iSrc]));
+    fscanf(fpslip,   " %lf ", &(theSourceSlipArray[iSrc]));
+    fscanf(fpslipfun," %d ",  &(theSourceNt1Array[iSrc]));
+    fscanf(fpslipfun," %lf ", &(theSourceTinitArray[iSrc]));
+    fscanf(fpslipfun," %lf ", &(theSourceDtArray[iSrc]));
+
+    theSourceDepthArray[iSrc] += surfaceShift;
+    theSourceTinitArray[iSrc] += globalDelayT;
+
+    theSourceSlipFunArray[iSrc]=(double *)malloc(sizeof(double)*theSourceNt1Array[iSrc]);
+
+    for ( iTime = 0; iTime < theSourceNt1Array[iSrc]; iTime++)
+      fscanf(fpslipfun," %lf ", &(theSourceSlipFunArray[iSrc][iTime]));
+  }
+
+  /* corners of the surface */
+  auxiliar = (double *)malloc(sizeof(double)*8);
+  if ( auxiliar == NULL ) {
+    perror(" Alloc auxiliar: read_srfh_source");
+    MPI_Abort(MPI_COMM_WORLD, ERROR );
+    return -1;
+  }
+  parsedarray( fp, "domain_surface_corners", 8 ,auxiliar);
+  for ( iCorner = 0; iCorner < 4; iCorner++){
+    theSurfaceCornersLong[ iCorner ] = auxiliar [ iCorner * 2 ];
+    theSurfaceCornersLat [ iCorner ] = auxiliar [ iCorner * 2 +1 ];
+  }
+
+  free(auxiliar);
+
+  return 1;
+
+}
+
+
+/**
+ * search_nodes_octant: computes the force vector for a
+ *                      point source and updates myForeces
+ *
+ * This method is not being used anywhere.  It will remain commented out
+ * until I am convinced it can be erased completely (RICARDO).
+ *
+ * static int search_nodes_octant (octant_t *octant, ptsrc_t *pointSource){
+ *
+ *     int32_t eindex;
+ *
+ *     tick_t edgeticks;
+ *     edgeticks = (tick_t)1 << (PIXELLEVEL - octant->level);
+ *
+ *     // Go through my local elements to find which one matches the
+ *     // containing octant. I should have a better solution than this.
+ *
+ *     for ( eindex = 0; eindex < myMesh->lenum; eindex++ ) {
+ *         int32_t lnid0;
+ *         lnid0 = myMesh->elemTable[eindex].lnid[0];
+ *
+ *         if ( ( myMesh->nodeTable[lnid0].x == octant->lx ) &&
+ *                 ( myMesh->nodeTable[lnid0].y == octant->ly ) &&
+ *                 ( myMesh->nodeTable[lnid0].z == octant->lz ) ) {
+ *
+ *             // Sanity check
+ *             if ( myMesh->elemTable[eindex].level != octant->level ) {
+ *                 fprintf(stderr, "Thread %d: source_init: internal error\n",
+ *                         myID);
+ *                 MPI_Abort(MPI_COMM_WORLD, ERROR);
+ *                 exit(1);
+ *             }
+ *
+ *             // Fill in the local node ids of the containing element
+ *             memcpy ( pointSource->lnid, myMesh->elemTable[eindex].lnid,
+ *                     sizeof(int32_t) * 8 );
+ *             break;
+ *
+ *         }
+ *
+ *     }  // for all the local elements
+ *
+ *
+ *     if ( eindex == myMesh->lenum ) {
+ *         fprintf ( stderr, "Thread %d: source_init: ", myID );
+ *         fprintf ( stderr, "No element matches the containing octant.\n" );
+ *         MPI_Abort(MPI_COMM_WORLD, ERROR );
+ *         exit(1);
+ *     }
+ *
+ *     return 1;
+ *
+ * }
+ *
+ */
+
+
+/**
+ * Write the header for the local forces file.
+ * Assumes that a single PE cannot hold more than 2 billion nodes
+ */
+static void
+print_header_myForces( FILE* fptmpsrc, int32_t loaded_node_count )
+{
+    int32_t iNode;
+
+    hu_fwrite( &loaded_node_count, sizeof(int32_t), 1, fptmpsrc );
+
+    /* iterate over the myForcesCycle array and write ids for loaded nodes */
+    for (iNode = 0; iNode <  myMesh->nharbored; iNode++) {
+	if (myForcesCycle[iNode] != -1) {
+	    hu_fwrite( &iNode, sizeof(int32_t), 1, fptmpsrc );
+	    loaded_node_count--;
+	}
+    }
+
+    /* \todo add assertion here: in the end, loaded_node_count must be zero */
+}
+
+
+/*
+ *
+ *  concat_filespercylce_in_fptmpsrc:
+ *
+ *
+ */
+static void
+concat_filespercycle_in_fptmpsrc( const char *filenameroot, FILE *fptmpsrc,
+				  int numberofcycles )
+{
+    FILE **fp;
+    char forcefile[256];
+    int i, iCycle,iCycleNode, iDisk, diskAccess;
+
+    int64_t totalMemory;
+    int32_t *nodesPerCycle, nodesCheckSum=0;
+    int32_t timeSteps, *cycleTimeSteps;
+    int32_t iNode, iTime;
+    int32_t *nodesAcumulated;
+    vector3D_t **buffer;
+
+    XMALLOC_VAR_N( fp, FILE*, numberofcycles );
+    XMALLOC_VAR_N( nodesPerCycle, int32_t, numberofcycles );
+    XMALLOC_VAR_N( nodesAcumulated, int32_t, numberofcycles );
+
+    for (iCycle = 0; iCycle < numberofcycles; iCycle++) {
+	sprintf( forcefile, "%s.%d", filenameroot, iCycle );
+	fp[iCycle] = hu_fopen( forcefile, "r" );
+
+	if (fread(&(nodesPerCycle[iCycle]), sizeof(int32_t), 1, fp[iCycle])==0)
+	{
+	    solver_abort( __FUNCTION_NAME, "fread",
+			  "Error reading files per cycle in concat function\n"
+			  "Number of cycles = %d Cycle = %d\n",
+			  numberofcycles, iCycle );
+	}
+
+	/*fscanf(fp[iCycle],"%d",&(nodesPerCycle[iCycle]));    */
+	nodesCheckSum += nodesPerCycle[iCycle];
+    }
+
+    nodesAcumulated[0] = 0;
+
+    for (iCycle = 1; iCycle < numberofcycles; iCycle++) {
+	nodesAcumulated[iCycle]
+	    = nodesPerCycle[iCycle-1] + nodesAcumulated[iCycle-1];
+    }
+
+
+    if (nodesCheckSum != myNumberOfNodesLoaded) {
+	solver_abort( __FUNCTION_NAME, NULL,
+		      "Error: the number of Nodes loaded does not match"
+		      "nodesCheckSum = %d, myNumberOfNodesLoaded = %d",
+		      nodesCheckSum, myNumberOfNodesLoaded );
+    }
+
+    totalMemory = myNumberOfNodesLoaded*theNumberOfTimeSteps*sizeof(vector3D_t);
+
+    if (totalMemory < theForcesBufferSize) {
+	diskAccess = 1;
+	timeSteps  = theNumberOfTimeSteps;
+
+	XMALLOC_VAR_N( buffer, vector3D_t*, timeSteps );
+
+	for( i = 0; i < timeSteps; i++) {
+	    XMALLOC_VAR_N( buffer[i], vector3D_t, myNumberOfNodesLoaded );
+	}
+
+	XMALLOC_VAR_N( cycleTimeSteps, int32_t, diskAccess );
+	cycleTimeSteps[0] = timeSteps;
+    }
+
+    else {
+	diskAccess = (int)floor( totalMemory / theForcesBufferSize );
+	timeSteps  = (int)floor( theNumberOfTimeSteps / diskAccess );
+
+	XMALLOC_VAR_N( buffer, vector3D_t*, timeSteps );
+
+	for (i = 0; i < timeSteps; i++) {
+	    XMALLOC_VAR_N( buffer[i], vector3D_t, myNumberOfNodesLoaded );
+	}
+
+	XMALLOC_VAR_N( cycleTimeSteps, int32_t, (diskAccess + 1) );
+
+	for (i = 0; i < diskAccess; i++) {
+	    cycleTimeSteps[i] = timeSteps;
+	}
+
+	if (theNumberOfTimeSteps % diskAccess != 0) {
+	    cycleTimeSteps[ diskAccess ] = theNumberOfTimeSteps % diskAccess;
+	    diskAccess++;
+	}
+    }
+
+
+    for (iDisk = 0; iDisk < diskAccess; iDisk++) {
+	for (iCycle = 0; iCycle < numberofcycles; iCycle++) {
+	    for (iTime = 0; iTime < cycleTimeSteps[iDisk]; iTime++) {
+		for (iCycleNode = 0; iCycleNode < nodesPerCycle[iCycle];
+		     iCycleNode++)
+		{
+		    size_t ret;
+
+		    iNode = nodesAcumulated[iCycle] + iCycleNode;
+		    ret = fread( buffer[iTime][iNode].x, sizeof(double), 3,
+				 fp[iCycle] );
+		    if (3 != ret) {
+			solver_abort( "concat_filespercycle_in_fptmpsrc",
+				      "fread(...) failed",
+				      "PE id = %d, number of cycles = %d, "
+				      "cycle = %d, time= %d\n",
+				      myID, numberofcycles, iCycle, iTime );
+		    }
+		}
+	    }
+	}
+
+	for (iTime = 0; iTime < cycleTimeSteps[iDisk]; iTime++) {
+	    for (iCycle = 0; iCycle < numberofcycles; iCycle++) {
+		for (iCycleNode = 0; iCycleNode < nodesPerCycle[iCycle];
+		     iCycleNode++)
+		{
+		    iNode = nodesAcumulated[iCycle] + iCycleNode;
+		    fwrite( buffer[iTime][iNode].x, sizeof(double), 3,
+			    fptmpsrc );
+		}
+	    }
+	}
+    }
+}
+
+
+/**
+ * fill_myForces_cycle
+ *
+ */
+static void fill_myForces_cycle( int cycle )
+{
+  int32_t lnid, i, j;
+
+  for ( j = numStepsNecessary; j < theNumberOfTimeSteps; j++ ) {
+    for ( lnid = 0; lnid <  myMesh->nharbored; lnid++){
+      if ( myForcesCycle [ lnid ] ==  cycle ){
+	for ( i = 0; i < 3;  i++ ){
+	  myForces[lnid][j].x[i]= myForces[lnid][numStepsNecessary-1].x[i];
+	}
+      }
+    }
+  }
+
+  return;
+}
+
+
+/*
+ * compute_myForces_planes: compute the force vector for each
+ *                          node in myMesh
+ *
+ *
+ */
+static int
+compute_myForces_planes( const char *physicsin )
+{
+  double *grdStrk, *grdDip;
+  double minEdge, minEdgeAlongStrike, minEdgeDownDip, area;
+
+  int iWindow,i,j,currentDownDip,currentAlongStrike,iTri;
+  int strkCells, dpCells;
+  int cellPntsStrk, cellPntsDip, ndsStrk, ndsDip, iCorner,jCorner;
+
+  int quadortri=1;
+
+  int32_t iForce=0;
+  octant_t *octant;
+  ptsrc_t pntSrc;
+  vector3D_t origin, p [ 4 ],localCoords,globalCoords;
+
+  /* i/o related vars */
+  int32_t nodesPerCycle, memoryRequiredPerNode, memoryPerCycle;
+  int32_t iCycle, iInternal, iNode;
+
+  /* convinient variables */
+  double lat   = theExtendedLatDeg;
+  double lon   = theExtendedLongDeg;
+  double depth = theExtendedDepthM;
+
+
+  if( theTypeOfSource == PLANE )
+      origin=compute_cartesian_coords(lat,lon,depth );
+
+  theExtendedHypLocCart.x[0]=theExtendedHypocenterAlongStrikeM;
+  theExtendedHypLocCart.x[1]=theExtendedHypocenterDownDipM;
+  theExtendedHypLocCart.x[2]=0;
+
+  strkCells = theExtendedColumns;
+  dpCells   = theExtendedRows;
+
+  /* Variables that all poinSources will share */
+  if ( theTypeOfSource == PLANEWITHKINKS ){
+    init_planewithkinks_mapping();
+    theExtendedCellSizeAlongStrikeM=theTotalTraceLength/theExtendedColumns;
+    pntSrc.dip = 90;  /* Fixed for strikeslip */
+  } else{
+      pntSrc.dip = theExtendedDipDeg;
+      pntSrc.strike = theExtendedStrikeDeg;
+  }
+
+  pntSrc.sourceFunctionType = (source_function_t)theSourceFunctionType;
+  pntSrc.T0 = theAverageRisetimeSec;
+
+  pntSrc.displacement =
+      (double *) malloc ( sizeof( double ) * theNumberOfTimeSteps );
+  if(pntSrc.displacement == NULL){
+    fprintf(stdout, "Err alloc displacments");
+    return -1;
+  }
+
+  pntSrc.dt = theDeltaT;
+  pntSrc.numberOfTimeSteps = theNumberOfTimeSteps;
+
+  /* Compute the minimum edge*/
+  minEdge = theExtendedMinimumEdge ;
+
+  if ( theExtendedCellSizeAlongStrikeM < minEdge )
+    minEdge = theExtendedCellSizeAlongStrikeM;
+  cellPntsStrk = ( int )(theExtendedCellSizeAlongStrikeM/minEdge);
+  /*   cellPntsStrk =  1 + ( int )(theExtendedCellSizeAlongStrikeM/minEdge);   */
+  minEdgeAlongStrike=theExtendedCellSizeAlongStrikeM/(double)cellPntsStrk;
+
+  if ( theExtendedCellSizeDownDipM < minEdge )
+    minEdge = theExtendedCellSizeDownDipM;
+  cellPntsDip =  ( int )(theExtendedCellSizeDownDipM / minEdge );
+  /*  cellPntsDip = 1 + ( int )(theExtendedCellSizeDownDipM / minEdge ); */
+  minEdgeDownDip=theExtendedCellSizeDownDipM/(double)cellPntsDip;
+
+  /* Compute the grids of the fault */
+  theExtendedAlongStrikeDistanceM =
+      theExtendedColumns*theExtendedCellSizeAlongStrikeM;
+  theExtendedDownDipDistanceM =theExtendedRows*theExtendedCellSizeDownDipM;
+
+  ndsStrk= 1+(theExtendedAlongStrikeDistanceM/minEdgeAlongStrike);
+  ndsDip = 1+(theExtendedDownDipDistanceM/minEdgeDownDip);
+
+  grdStrk = dvector(0, ndsStrk);
+  grdDip  = dvector(0, ndsDip);
+
+  compute_1D_grid( theExtendedCellSizeAlongStrikeM, strkCells,
+		   cellPntsStrk, minEdgeAlongStrike, grdStrk);
+  compute_1D_grid( theExtendedCellSizeDownDipM, dpCells  ,
+		   cellPntsDip, minEdgeDownDip, grdDip);
+
+  WAIT;
+  if(myID == 0 )
+    fprintf(stdout,"\nStart force generation\n");
+
+  theForceGenerationTime = -MPI_Wtime();
+  theIOInitTime = -MPI_Wtime();
+
+  /* Initialize the io */
+  /* Array which indicates the loop a force will be written to a file */
+  myForcesCycle =  (int32_t *)malloc( sizeof(int32_t) * myMesh->nharbored );
+  for (iForce = 0 ; iForce < myMesh->nharbored; iForce++) {
+      myForcesCycle[ iForce ] = -1;
+  }
+
+  char* is_force_in_processor
+      = (char*)calloc( (2*ndsDip*ndsStrk / sizeof(char)) + 1, sizeof(char) );
+
+  if (is_force_in_processor == NULL) {
+      fprintf( stderr,"Err allocating is_force_in_processor" );
+      return -1;
+  }
+
+  iForce		= 0;
+  myNumberOfForces	= 0;
+  myNumberOfNodesLoaded = 0;
+
+  /* compute the necessary time steps to represent the source, after these,
+   * it will repeat the last value
+   */
+
+  double timeDueWindows=0, timeDueSize=0, tempTime, totalExtendedRaiseTime;
+  vector3D_t corner;
+
+  /*  Compute the time due to the windows */
+  /* Compute the max ruputure time */
+  /* Add both */
+
+  for ( iWindow=0; iWindow<theNumberOfTimeWindows; iWindow++ )
+    timeDueWindows += theWindowDelay [ iWindow ];
+
+  for ( iCorner = 0; iCorner < 2; iCorner++)
+    for ( jCorner = 0; jCorner <2; jCorner++){
+
+      corner.x[0] = grdStrk[ iCorner * (ndsStrk-1) ];
+      corner.x[1] = grdDip [ jCorner * (ndsDip-1)  ];
+      corner.x[2] = 0;
+
+      tempTime =compute_initial_time ( corner,
+				       theExtendedHypLocCart,
+				       theExtendedAverageRuptureVelocity);
+
+      if ( tempTime > 	timeDueSize  )
+	timeDueSize = tempTime;
+
+    }
+
+  totalExtendedRaiseTime = timeDueWindows + timeDueSize;
+
+  numStepsNecessary = (1.1*totalExtendedRaiseTime) / theDeltaT;
+  if( myID == 0){
+    fprintf(stdout," \n timeDueWindows = %f" , timeDueWindows );
+    fprintf(stdout," \n timeDueSize = %f" , 	timeDueSize  );
+    fprintf(stdout," \n numStepsNecessary = %d" , 	numStepsNecessary  );
+  }
+
+  WAIT;
+  /* EXITPROGRAM;*/
+
+  /* Go through the fault */
+  for ( i = 0; i < ndsDip - 1; i++){
+
+      currentDownDip = i / cellPntsDip;
+      for ( j = 0; j < ndsStrk - 1; j++){
+	currentAlongStrike = j / cellPntsStrk;
+	/*Left(0) Right(1) triangle nodes*/
+	for ( iTri = 0 ; iTri < quadortri; iTri++){
+
+	p[0]=compute_local_coords(j+i*ndsStrk+iTri,ndsStrk,grdStrk,grdDip);
+	p[1]=compute_local_coords(j+(i+iTri)*ndsStrk+1,ndsStrk,grdStrk,grdDip);
+	p[2]=compute_local_coords(j+(i+1)*ndsStrk,ndsStrk,grdStrk,grdDip);
+
+
+	if ( quadortri == 1 ) /* rectangle */{
+	    p[3]=compute_local_coords(j+(i+1)*ndsStrk+1,ndsStrk,grdStrk,grdDip);
+
+	  localCoords.x[0] = 0.5 * (p[0].x[0]+p[1].x[0]);
+	  localCoords.x[1] = 0.5 * (p[0].x[1]+p[2].x[1]);
+	  localCoords.x[2] = 0;
+
+
+	}
+	else
+	  localCoords = compute_centroid( &p[0] );
+
+
+
+	if ( theTypeOfSource == PLANE ){
+
+	  globalCoords = compute_global_coords(origin,localCoords,pntSrc.dip,
+					       0 ,pntSrc.strike);
+	  /* Transform if neccesary to domain coordinates */
+	  if ( theRegionAzimuthDeg == 0 )
+	      pntSrc.domainCoords=globalCoords;
+	  else
+	    pntSrc.domainCoords=compute_domain_coords(globalCoords ,
+						      theRegionAzimuthDeg);
+
+	}
+
+	if ( theTypeOfSource == PLANEWITHKINKS ){
+	  pntSrc.domainCoords = compute_global_coords_mapping( localCoords );
+	}
+
+	/* Check if this force is contained in this processor */
+	if ( search_point( pntSrc.domainCoords, &octant ) == 1){
+	    tag_myForcesCycle ( octant, &pntSrc );
+	    update_forceinprocessor( iForce, is_force_in_processor,1);
+	    myNumberOfForces +=1;
+	}
+	iForce+=1;
+      }
+    }
+  }
+
+  WAIT;
+  if(myID == 0)
+    fprintf(stdout, "\n Total forces = %d ", ndsDip*ndsStrk*2);
+
+
+  memoryRequiredPerNode = sizeof( vector3D_t ) * theNumberOfTimeSteps;
+
+  if(memoryRequiredPerNode > theForcesBufferSize ){
+    fprintf(stdout,"\n Err not enough memory in the theForcesBufferSize to create the source");
+    return -1;
+  }
+
+  nodesPerCycle = ( int32_t ) floor( theForcesBufferSize / memoryRequiredPerNode );
+  memoryPerCycle = nodesPerCycle * memoryRequiredPerNode;
+  myNumberOfCycles = (int32_t)floor(myNumberOfNodesLoaded / nodesPerCycle );
+  if ( myNumberOfNodesLoaded % nodesPerCycle != 0 )
+    myNumberOfCycles += 1;
+
+
+  /* go through myForceCycle and put the cycle for each node loaded */
+  iCycle = 0;
+  iInternal = 0;
+  for ( iNode = 0; iNode <  myMesh->nharbored; iNode++){
+    if( myForcesCycle[iNode] !=-1 ){
+	myForcesCycle[ iNode ] = iCycle;
+	iInternal +=1;
+	if(iInternal == nodesPerCycle) {
+	    iCycle +=1;
+	    iInternal = 0;
+	}
+    }
+  }
+
+
+  if(myID == 0){
+    fprintf(stdout,"\n Mininum Edge = %f",minEdge);
+    fprintf(stdout,"\n Minimum Memory Required to build the source = %d\n",memoryRequiredPerNode);
+
+  }
+
+  /* PE 0: open source description file */
+  FILE* fpdsrc = open_source_description_file_0();
+
+  /* write node information to the local forces file */
+  FILE* fptmpsrc = source_open_forces_file( "w" );
+  print_header_myForces( fptmpsrc, myNumberOfNodesLoaded );
+
+
+  WAIT;
+  theIOInitTime += MPI_Wtime();
+
+
+  if(myID==0) fprintf(stdout,"\n\nI/O Force Intitialization done: Time = %.2f seconds", theIOInitTime);
+
+  /* END I/O initialization*/
+
+  myNumberOfNodesLoaded =0;
+
+  for ( iCycle = 0; iCycle < myNumberOfCycles; iCycle++){
+      iForce = 0;
+      for ( i = 0; i < ndsDip - 1; i++){
+	  currentDownDip = i / cellPntsDip;
+      for ( j = 0; j < ndsStrk- 1; j++){
+	  currentAlongStrike = j / cellPntsStrk;
+	  /*Left(0) Right(1) triangle nodes*/
+	  for ( iTri = 0 ; iTri < quadortri; iTri++){
+	      if( is_forceinprocessor( iForce, is_force_in_processor ) == 1 ){
+
+		  p[0]=compute_local_coords(j+i*ndsStrk+iTri,ndsStrk,grdStrk,grdDip);
+		  p[1]=compute_local_coords(j+(i+iTri)*ndsStrk+1,ndsStrk,grdStrk,grdDip);
+		  p[2]=compute_local_coords(j+(i+1)*ndsStrk,ndsStrk,grdStrk,grdDip);
+
+	    if ( quadortri == 1 ) /* rectangle */{
+		p[3]=compute_local_coords(j+(i+1)*ndsStrk+1,ndsStrk,grdStrk,grdDip);
+
+		localCoords.x[0] = 0.5 * (p[0].x[0]+p[1].x[0]);
+		localCoords.x[1] = 0.5 * (p[0].x[1]+p[2].x[1]);
+		localCoords.x[2] = 0;
+
+		area = fabs( (p[0].x[0]-p[1].x[0])*(p[0].x[1]-p[2].x[1]) );
+	    }
+
+	    else{
+	      area=compute_area( &p[0] );
+	      localCoords = compute_centroid( &p[0] );
+	    }
+
+	    pntSrc.localCoords = localCoords;
+
+	    if ( theTypeOfSource == PLANE ){
+	      globalCoords = compute_global_coords( origin, localCoords,pntSrc.dip ,
+						    0 ,theExtendedStrikeDeg);
+	      /* Transform if neccesary to domain coordinates just for plane*/
+	      if ( theRegionAzimuthDeg == 0 )
+		  pntSrc.domainCoords = globalCoords;
+	      else{
+		  pntSrc.domainCoords =
+		  compute_domain_coords( globalCoords, theRegionAzimuthDeg );
+		pntSrc.strike = theExtendedStrikeDeg - theRegionAzimuthDeg;
+	      }
+	    }
+
+
+	    if ( theTypeOfSource == PLANEWITHKINKS ){
+		pntSrc.strike = compute_strike_planewithkinks( localCoords );
+		pntSrc.domainCoords = compute_global_coords_mapping( localCoords );
+	    }
+
+
+
+	    if ( search_point( pntSrc.domainCoords, &octant ) == 1){
+
+
+	      if( myID == 0 && iCycle == 0) /* useful just with one processor */
+		fprintf(fpdsrc,"%f %f %f %f %f %f %f %f\n",
+			pntSrc.domainCoords.x[0], pntSrc.domainCoords.x[1],
+			pntSrc.domainCoords.x[2], pntSrc.strike,
+			pntSrc.dip, pntSrc.rake, pntSrc.maxSlip,
+			pntSrc.tinit);
+
+	      /* This is the part that has to be reviewed */
+	      update_point_source( &pntSrc,currentDownDip,currentAlongStrike,area);
+	      load_myForces_with_point_source( octant, &pntSrc,
+					       is_force_in_processor, iCycle,
+					       iForce );
+	    }
+	  }
+	  iForce += 1;
+	  }
+      }
+    }
+
+    fill_myForces_cycle(iCycle);
+
+    if ( theSourceIsFiltered == 1 ) filter_myForce();
+
+    const char* local_forces_filename = source_get_local_forces_filename();
+    print_myForces_filepercycle(local_forces_filename, iCycle);
+    free_myForces();
+
+  }
+
+  if (myID == 0) {	/* PE 0: close source description file */
+      close_file( &fpdsrc );
+  }
+
+  free(pntSrc.displacement);
+
+  WAIT;
+  theForceGenerationTime += MPI_Wtime();
+
+  if (myID == 0) {
+      printf( "\nSource files generated: Time = %.2f seconds",
+	      theForceGenerationTime );
+      printf( "\nConcatenation process starts" );
+  }
+
+  theConcatTime = -MPI_Wtime();
+  /* concatenation process */
+  if (myNumberOfCycles != 0) {
+      const char* local_forces_filename = source_get_local_forces_filename();
+      concat_filespercycle_in_fptmpsrc( local_forces_filename, fptmpsrc,
+					myNumberOfCycles );
+  }
+
+  close_file( &fptmpsrc );
+  free( myForces );
+
+  WAIT;
+  theConcatTime += MPI_Wtime();
+
+  if ( myID == 0 ) {
+      printf( "\nConcatenation process done: Time = %.2f seconds",
+	      theConcatTime );
+      printf( "\n cycles = %d ", myNumberOfCycles );
+  }
+
+  return 1;
+}
+
+
+/**
+ * Use various global configuration variables to compute the coordinates
+ * of a point source.
+ */
+static void
+fill_point_source_coordinates (ptsrc_t* ps)
+{
+    /* coordinates */
+
+    // ps->globalCoords.x[0] = ((theHypocenterLatDeg - theRegionOriginLatDeg)
+    //			     *DIST1LAT);
+    // ps->globalCoords.x[1] = ((theHypocenterLongDeg - theRegionOriginLongDeg)
+    //			     *DIST1LON);
+    // ps->globalCoords.x[2] = theHypocenterDepthM - theRegionDepthShallowM;
+
+    /* transform if neccesary to the domain coordinates */
+
+    //    if (theRegionAzimuthDeg == 0) {
+    //	ps->domainCoords.x[0] = ps->globalCoords.x[0];
+    //	ps->domainCoords.x[1] = ps->globalCoords.x[1];
+    //	ps->domainCoords.x[2] = ps->globalCoords.x[2];
+    //    } else {
+    //	ps->domainCoords
+    //	    = compute_domain_coords (ps->globalCoords, theRegionAzimuthDeg);
+    //    }
+
+
+    if (theLonlatOrCartesian == 1) {
+	ps->domainCoords.x[0] = theHypocenterLatDeg;
+	ps->domainCoords.x[1] = theHypocenterLongDeg;
+	ps->domainCoords.x[2] = theHypocenterDepthM;
+    }
+
+
+    if (theLonlatOrCartesian == 0) {
+	if (myID == 0) {
+	    printf( "Point source hypocenter: longitude=%fo latitude=%fo\n",
+		    theHypocenterLongDeg,theHypocenterLatDeg );
+	}
+
+	ps->domainCoords
+	    = compute_domain_coords_linearinterp( theHypocenterLongDeg,
+						  theHypocenterLatDeg,
+						  theSurfaceCornersLong ,
+						  theSurfaceCornersLat,
+						  theRegionLengthEastM,
+						  theRegionLengthNorthM );
+
+
+    /*    printf("\n %f %f",ps->domainCoords.x[0],ps->domainCoords.x[1]);
+	  printf("\n %f %f",theSurfaceCornersLong[0],theSurfaceCornersLat[0]);
+	  printf("\n %f %f",theSurfaceCornersLong[1],theSurfaceCornersLat[1]);
+	  printf("\n %f %f",theSurfaceCornersLong[2],theSurfaceCornersLat[2]);
+	  printf("\n %f %f",theSurfaceCornersLong[3],theSurfaceCornersLat[3]);
+	  exit(1); */
+
+	ps->domainCoords.x[2] = theHypocenterDepthM;
+
+    }
+}
+
+/**
+ * Use various global configuration variables to compute the strike
+ * of a point source.
+ *
+ * \note The strike is computed asumming linear interpolation for the
+ * domain A point having the same longitude and an increment in the
+ * latitude is used to obtain a vector pointing the north. After, the rake
+ * is computed considering the vector pointing towards north.
+ */
+static void
+compute_point_source_strike( ptsrc_t* ps )
+{
+
+  vector3D_t pivot, pointInNorth, unitVec;
+
+  double norm,fi ;
+
+
+  if( theLonlatOrCartesian == 1 )return;
+
+
+  if( theLonlatOrCartesian == 0 ){
+
+    printf("\nin strike correction = %f %f", theHypocenterLongDeg,theHypocenterLatDeg);
+
+    pivot = compute_domain_coords_linearinterp(theHypocenterLongDeg,
+					       theHypocenterLatDeg,
+					       theSurfaceCornersLong ,
+		 			       theSurfaceCornersLat,
+					       theRegionLengthEastM,
+					       theRegionLengthNorthM );
+
+    pointInNorth = compute_domain_coords_linearinterp(theHypocenterLongDeg,
+						      theHypocenterLatDeg+.1,
+						      theSurfaceCornersLong ,
+						      theSurfaceCornersLat ,
+						      theRegionLengthEastM,
+						      theRegionLengthNorthM );
+
+
+    /* Compute Unit Vector */
+    unitVec.x[1]=pointInNorth.x[1]-pivot.x[1];
+    unitVec.x[0]=pointInNorth.x[0]-pivot.x[0];
+
+    norm = pow( pow( unitVec.x[0], 2)+ pow(unitVec.x[1],2), .5);
+
+    unitVec.x[1]= unitVec.x[1]/norm;
+    unitVec.x[0]= unitVec.x[0]/norm;
+
+    /* Compute the Angle North-X axis */
+    fi = atan( unitVec.x[0]/unitVec.x[1]);
+
+    if(  unitVec.x[1] < 0 ) /* in rad*/
+      fi = fi + PI;
+
+    /* Compute the strike */
+
+    ps->strike =90+ ps->strike-( 180*fi/PI);
+
+  }
+
+}
+
+/**
+ * Compute force due to a dipole.
+ *
+ * \return 1 OK, -1 on error.
+ */
+static int
+compute_myForces_point( const char* physicsin )
+{
+    int32_t   iForce;
+    octant_t* octant;
+    ptsrc_t   pntSrc;
+
+    myNumberOfNodesLoaded = 0;
+
+    fill_point_source_coordinates( &pntSrc );
+
+    /* search for source in this processor */
+    if ( search_point (pntSrc.domainCoords, &octant) != 1) {
+	return 0;	/* return OK if the source is not in this processor */
+    }
+
+    /* for other source types this is done by PE 0, in this case the
+     * PE that has the source does it
+     */
+    {
+	FILE* fpdsrc = open_source_description_file();
+
+	fprintf( fpdsrc,"%lf %lf %lf\n", pntSrc.domainCoords.x[0],
+		 pntSrc.domainCoords.x[1], pntSrc.domainCoords.x[2] );
+	close_file( &fpdsrc );
+    }
+
+    char is_force_in_processor = 0;
+    update_forceinprocessor( 0, &is_force_in_processor, 1 );
+
+    /* Array which indicates the cycle a force will written to a file in
+     * this case is one cycle
+     */
+    myForcesCycle = (int32_t *)malloc (sizeof(int32_t) * (myMesh->nharbored));
+    iForce = 0;
+
+    for (iForce = 0 ; iForce < myMesh->nharbored; iForce++) {
+	myForcesCycle[ iForce ] = -1;
+    }
+
+    tag_myForcesCycle( octant, &pntSrc );
+    myNumberOfForces += 1;
+
+    /* This variable is introduced thinking in large faults. It is approx.
+       the time it takes to reach the maximum value of slip. We compute every
+       thing in this type of source*/
+    numStepsNecessary = theNumberOfTimeSteps;
+
+    /* we have to load the force vector */
+
+    /* first we build the source */
+
+    pntSrc.strike = theSourceStrikeDeg;
+
+    compute_point_source_strike( &pntSrc );
+
+    pntSrc.dip		      = theSourceDipDeg;
+    pntSrc.rake		      = theSourceRakeDeg;
+    pntSrc.sourceFunctionType = (source_function_t)theSourceFunctionType;
+    pntSrc.T0		      = theAverageRisetimeSec;
+    pntSrc.delayTime	      = 0;
+    pntSrc.maxSlip	      = 1;
+    pntSrc.M0		      = theMomentAmplitude;
+    pntSrc.dt		      = theDeltaT;
+    pntSrc.numberOfTimeSteps  = theNumberOfTimeSteps;
+
+    pntSrc.displacement
+	= (double*)calloc (theNumberOfTimeSteps, sizeof (double));
+
+    if (pntSrc.displacement == NULL) {
+	fprintf(stderr, "Err allocating pntSrc.displacement array");
+	return -1;
+    }
+
+
+    int32_t memoryRequiredPerNode, nodesPerCycle,myNumberOfCycles, iCycle,
+	iInternal, iNode, memoryPerCycle;
+
+    memoryRequiredPerNode = 3 * sizeof (vector3D_t) * theNumberOfTimeSteps;
+    if (memoryRequiredPerNode > theForcesBufferSize) {
+	fputs ("\n ERROR: Not enough memory in the theForcesBufferSize to "
+	       "create the source", stderr);
+	return -1;
+    }
+
+    /* note: the following ops are done using integer arithmetic */
+    nodesPerCycle    = theForcesBufferSize / memoryRequiredPerNode;
+    memoryPerCycle   = nodesPerCycle * memoryRequiredPerNode;
+    myNumberOfCycles = ((myNumberOfNodesLoaded - 1) / nodesPerCycle) + 1;
+
+    /* go through myForceTag and put the cycle for each node loaded */
+    iCycle    = 0;
+    iInternal = 0;
+
+    for (iNode = 0; iNode <  myMesh->nharbored; iNode++) {
+	if (myForcesCycle[iNode] != -1) {
+	    myForcesCycle[iNode] = iCycle;
+	    iInternal++;
+
+	    if (iInternal == nodesPerCycle) {
+		iCycle++;
+		iInternal = 0;
+	    }
+	}
+    }
+
+    compute_source_function( &pntSrc );
+    myNumberOfNodesLoaded = 0;
+    load_myForces_with_point_source( octant, &pntSrc, &is_force_in_processor,
+				     0, 0 );
+
+    FILE* fptmpsrc = source_open_forces_file( "w" );
+
+    print_header_myForces( fptmpsrc, myNumberOfNodesLoaded );
+    print_myForces_transposed( fptmpsrc );
+    close_file( &fptmpsrc );
+
+    /* cleanup */
+    free( pntSrc.displacement );
+
+    return 1;
+}
+
+
+/*
+ * compute_myForces_srfh: compute the force vector for each
+ *                        node in myMesh
+ *
+ *                return -1 fail 1 ok
+ */
+static int  compute_myForces_srfh(const char *physicsin){
+
+  int32_t iSrc,iForce=0;
+  octant_t *octant;
+  ptsrc_t pntSrc;
+  int ActivePE;
+
+  /* i/o related vars */
+  int32_t nodesPerCycle, memoryRequiredPerNode, memoryPerCycle;
+  int32_t iCycle, iInternal, iNode;
+
+  numStepsNecessary = theNumberOfTimeSteps;
+
+  theForceGenerationTime = -MPI_Wtime();
+  theIOInitTime          = -MPI_Wtime();
+
+
+  pntSrc.displacement = (double*)malloc(sizeof(double)*theNumberOfTimeSteps );
+  if(pntSrc.displacement == NULL){
+    fprintf(stdout, "Err alloc displacments");
+    return -1;
+  }
+
+  pntSrc.dt = theDeltaT;
+  pntSrc.numberOfTimeSteps = theNumberOfTimeSteps;
+
+  WAIT;
+
+  if(myID == 0 ){
+    fprintf(stdout,"\n\nForce generation:starts\n");
+  }
+
+  theForceGenerationTime = -MPI_Wtime();
+  theIOInitTime = -MPI_Wtime();
+
+  /* Initialize the IO */
+  /* Array which indicates the loop a force will be written to a file */
+  myForcesCycle =  (int32_t *)malloc( sizeof(int32_t) * ( myMesh->nharbored ) );
+  for ( iForce = 0 ; iForce < myMesh->nharbored; iForce++ )
+    myForcesCycle[ iForce ] = -1;
+
+  char* is_force_in_processor
+      = (char*)calloc(theNumberOfPointSources*2/sizeof(char)+1, sizeof(char));
+  if(is_force_in_processor == NULL){
+      fprintf(stdout,"Err allocating is_force_in_processor");
+      return -1;
+  }
+
+  myNumberOfNodesLoaded =0;
+  iForce=0;
+  myNumberOfForces=0;
+
+  /* Go through the fault */
+  for ( iSrc = 0; iSrc <theNumberOfPointSources ; iSrc++){
+
+    pntSrc.domainCoords = compute_domain_coords_linearinterp(theSourceLonArray[iSrc],
+							     theSourceLatArray[iSrc],
+							     theSurfaceCornersLong ,
+							     theSurfaceCornersLat,
+							     theRegionLengthEastM,
+							     theRegionLengthNorthM );
+    pntSrc.domainCoords.x[2]= theSourceDepthArray[iSrc];
+
+    /* Check if this force is contained in this processor */
+    if ( search_point( pntSrc.domainCoords, &octant ) == 1){
+	tag_myForcesCycle ( octant, &pntSrc );
+	update_forceinprocessor( iForce, is_force_in_processor, 1);
+	myNumberOfForces +=1;
+    }
+    iForce+=1;
+  }
+
+  WAIT;
+
+  if(myID == 0) fprintf(stdout, "\nTotal forces = %d ", iForce);
+
+  memoryRequiredPerNode = sizeof( vector3D_t ) * theNumberOfTimeSteps;
+
+  if(memoryRequiredPerNode > theForcesBufferSize ){
+    fprintf(stdout,"\n Memory in the theForcesBufferSize source: compute_myForces_srfh");
+    return -1;
+  }
+
+  nodesPerCycle = (int32_t)floor( theForcesBufferSize / memoryRequiredPerNode );
+  memoryPerCycle = nodesPerCycle * memoryRequiredPerNode;
+  myNumberOfCycles = (int32_t)floor(myNumberOfNodesLoaded / nodesPerCycle );
+
+  if (myNumberOfNodesLoaded % nodesPerCycle != 0) {
+      myNumberOfCycles++;
+  }
+
+  /* go through myForceCycle and put the cycle for each node loaded */
+  iCycle = 0;
+  iInternal = 0;
+  for ( iNode = 0; iNode <  myMesh->nharbored; iNode++){
+    if( myForcesCycle[iNode] !=-1 ){
+	myForcesCycle[ iNode ] = iCycle;
+	iInternal +=1;
+	if(iInternal == nodesPerCycle) {
+	    iCycle +=1;
+	    iInternal = 0;
+	}
+    }
+  }
+
+  /* PE 0: open source description file */
+  FILE* fpdsrc = open_source_description_file_0();
+
+  /* If has active nodes, write node information to the local forces file */
+  FILE* fptmpsrc;
+  if(myNumberOfNodesLoaded==0){
+      ActivePE=0;
+  }
+  else{
+      ActivePE=1;
+      fptmpsrc = source_open_forces_file( "w" );
+      print_header_myForces( fptmpsrc, myNumberOfNodesLoaded );
+  }
+  
+  WAIT;
+  theIOInitTime += MPI_Wtime();		/* end I/O initialization */
+
+  if (myID == 0) {
+      printf( "\n I/O Force Intitialization ...%.2f s", theIOInitTime );
+      printf( "\n Source files ..........." );
+  }
+
+
+  myNumberOfNodesLoaded = 0;
+
+  for ( iCycle = 0; iCycle < myNumberOfCycles; iCycle++){
+      for ( iSrc = 0; iSrc < theNumberOfPointSources ; iSrc++){
+	  if( is_forceinprocessor( iSrc, is_force_in_processor ) == 1 ) {
+	pntSrc.domainCoords
+	    = compute_domain_coords_linearinterp(theSourceLonArray[iSrc],
+						 theSourceLatArray[iSrc],
+						 theSurfaceCornersLong ,
+						 theSurfaceCornersLat,
+						 theRegionLengthEastM,
+						 theRegionLengthNorthM );
+	pntSrc.domainCoords.x[2]= theSourceDepthArray[iSrc];
+
+	if ( search_point( pntSrc.domainCoords, &octant ) == 1){
+
+	  update_point_source_srfh( &pntSrc,iSrc);
+	  load_myForces_with_point_source(octant, &pntSrc,
+					  is_force_in_processor, iCycle, iSrc);
+
+	  if (myID == 0 && iCycle == 0) {
+	      /* useful just with one processor */
+	      fprintf(fpdsrc,"%f %f %f %f %f %f %f %f\n",
+		      pntSrc.domainCoords.x[0], pntSrc.domainCoords.x[1],
+		      pntSrc.domainCoords.x[2], pntSrc.strike,
+		      pntSrc.dip, pntSrc.rake, pntSrc.maxSlip,
+		      pntSrc.delayTime);
+	      /*  fprintf(stdout,"\n%f %f %f %f %f %f %f %f ",
+		  pntSrc.domainCoords.x[0], pntSrc.domainCoords.x[1],
+		  pntSrc.domainCoords.x[2], pntSrc.strike,
+		  pntSrc.dip, pntSrc.rake, pntSrc.maxSlip,
+		  pntSrc.delayTime); */
+	  }
+
+	}
+
+
+
+      }
+    }
+
+    fill_myForces_cycle(iCycle);
+
+    if (theSourceIsFiltered == 1) {
+	filter_myForce();
+    }
+
+    if(ActivePE){
+	const char* local_forces_filename = source_get_local_forces_filename();
+	print_myForces_filepercycle( local_forces_filename, iCycle );
+    }
+
+    free_myForces();
+  }
+
+  if (myID == 0) {	/* PE 0: close source description file */
+      close_file( &fpdsrc );
+  }
+
+  free(pntSrc.displacement);
+
+  WAIT;
+  theForceGenerationTime += MPI_Wtime();
+
+  if (myID == 0) {
+      printf( "done...%.2f s", theForceGenerationTime );
+      printf( "\n Concatenation process..." );
+  }
+
+  theConcatTime = -MPI_Wtime();
+  /* concatenation process */
+  if (myNumberOfCycles != 0) {
+      if(ActivePE){
+	  const char* local_forces_filename = source_get_local_forces_filename();
+	  concat_filespercycle_in_fptmpsrc( local_forces_filename, fptmpsrc,
+			    myNumberOfCycles );
+      }
+  }
+
+  if(ActivePE){
+      close_file( &fptmpsrc );
+  }
+
+  free( myForces );
+
+  WAIT;
+  theConcatTime += MPI_Wtime();
+
+  if (myID == 0) {
+      printf( "done...%.2f s", theConcatTime );
+  }
+
+  return 1;
+}
+
+
+/**
+ * Broadcast plane parameters.
+ *
+ * \note It initializes various global variables (too many to list here).
+ */
+static void
+broadcast_plane_parameters( void )
+{
+    /* The following #defines would not be necessary if the compiler were
+     * to support automatic (stack) array allocation by specifying their
+     * length with vars declared as constant.  We undefine these macros at
+     * the end of this function.
+     */
+#define PLANE_PARAMS_DN		13
+#define PLANE_PARAMS_IN		 2
+
+    int     i;
+    double  plane_params_d[PLANE_PARAMS_DN];
+    int32_t plane_params_i[PLANE_PARAMS_IN];
+
+    plane_params_d[ 0] = theExtendedCellSizeAlongStrikeM;
+    plane_params_d[ 1] = theExtendedCellSizeDownDipM;
+    plane_params_d[ 2] = theExtendedLatDeg;
+    plane_params_d[ 3] = theExtendedLongDeg;
+    plane_params_d[ 4] = theExtendedDepthM;
+    plane_params_d[ 5] = theExtendedAlongStrikeDistanceM;
+    plane_params_d[ 6] = theExtendedDownDipDistanceM;
+    plane_params_d[ 7] = theExtendedHypocenterAlongStrikeM;
+    plane_params_d[ 8] = theExtendedHypocenterDownDipM;
+    plane_params_d[ 9] = theExtendedAverageRuptureVelocity;
+    plane_params_d[10] = theExtendedStrikeDeg;
+    plane_params_d[11] = theExtendedDipDeg;
+    plane_params_d[12] = theExtendedMinimumEdge;
+
+    plane_params_i[0] = theExtendedColumns;
+    plane_params_i[1] = theExtendedRows;
+
+    MPI_Bcast(plane_params_d, PLANE_PARAMS_DN, MPI_DOUBLE, 0, comm_solver);
+    MPI_Bcast(plane_params_i, PLANE_PARAMS_IN, MPI_INT,    0, comm_solver);
+
+
+    if (0 != myID) {
+	theExtendedCellSizeAlongStrikeM   = plane_params_d[ 0];
+	theExtendedCellSizeDownDipM	  = plane_params_d[ 1];
+	theExtendedLatDeg		  = plane_params_d[ 2];
+	theExtendedLongDeg		  = plane_params_d[ 3];
+	theExtendedDepthM		  = plane_params_d[ 4];
+	theExtendedAlongStrikeDistanceM   = plane_params_d[ 5];
+	theExtendedDownDipDistanceM	  = plane_params_d[ 6];
+	theExtendedHypocenterAlongStrikeM = plane_params_d[ 7];
+	theExtendedHypocenterDownDipM	  = plane_params_d[ 8];
+	theExtendedAverageRuptureVelocity = plane_params_d[ 9];
+	theExtendedStrikeDeg		  = plane_params_d[10];
+	theExtendedDipDeg		  = plane_params_d[11];
+	theExtendedMinimumEdge		  = plane_params_d[12];
+
+	theExtendedColumns = plane_params_i[0];
+	theExtendedRows    = plane_params_i[1];
+    }
+
+    /* broadcast slip and rake matrices */
+    if (myID != 0) {
+	/* \note These are allocations of 3D matrices */
+	/* other processes need to allocate memory, PE 0 has already done it */
+	XMALLOC_VAR_N( theSlipMatrix, double**, theNumberOfTimeWindows );
+	XMALLOC_VAR_N( theRakeMatrix, double**, theNumberOfTimeWindows );
+
+	for (i = 0; i < theNumberOfTimeWindows; i++) {
+	    theSlipMatrix[i]
+		= dmatrix( 0, theExtendedRows - 1, 0, theExtendedColumns - 1 );
+	    theRakeMatrix[i]
+		= dmatrix( 0, theExtendedRows - 1, 0, theExtendedColumns - 1 );
+	}
+    } /* if (myID != 0) */
+
+    for (i = 0; i < theNumberOfTimeWindows; i++) {
+	/* since dmalloc allocates a contiguous chunk for the matrix,
+	 * we can get away with specifying the address of the first row
+	 * and then the size of the matrix for the broadcast.
+	 */
+	MPI_Bcast( theSlipMatrix[i][0], theExtendedRows * theExtendedColumns,
+		   MPI_DOUBLE, 0, comm_solver );
+
+	MPI_Bcast( theRakeMatrix[i][0], theExtendedRows * theExtendedColumns,
+		   MPI_DOUBLE, 0, comm_solver );
+    }
+
+#undef PLANE_PARAMS_DN
+#undef PLANE_PARAMS_IN
+}
+
+
+/**
+ * Broadcast SRFH parameters.
+ *
+ * \note It initializes various global variables (too many to list here).
+ */
+static void
+broadcast_srfh_parameters( void )
+{
+    /* this only applies to srfh sources */
+    if (theTypeOfSource != SRFH) {
+	return;
+    }
+
+    MPI_Bcast( theSurfaceCornersLat,     4, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSurfaceCornersLong,    4, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( &theNumberOfPointSources, 1, MPI_INT,    0, comm_solver );
+
+    int count = theNumberOfPointSources;
+
+    /* allocate necessary arrays */
+    if (myID != 0) {
+	XMALLOC_VAR_N( theSourceLonArray,     double,  count );
+	XMALLOC_VAR_N( theSourceLatArray,     double,  count );
+	XMALLOC_VAR_N( theSourceDepthArray,   double,  count );
+	XMALLOC_VAR_N( theSourceAreaArray,    double,  count );
+	XMALLOC_VAR_N( theSourceStrikeArray,  double,  count );
+	XMALLOC_VAR_N( theSourceDipArray,     double,  count );
+	XMALLOC_VAR_N( theSourceRakeArray,    double,  count );
+	XMALLOC_VAR_N( theSourceSlipArray,    double,  count );
+	XMALLOC_VAR_N( theSourceSlipArray,    double,  count );
+	XMALLOC_VAR_N( theSourceTinitArray,   double,  count );
+	XMALLOC_VAR_N( theSourceDtArray,      double,  count );
+	XMALLOC_VAR_N( theSourceNt1Array,     int32_t, count );
+    } /* (myID != 0) : memory allocation block */
+
+    /* broadcast parameter arrays */
+    MPI_Bcast( theSourceLonArray,    count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceLatArray,    count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceDepthArray,  count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceAreaArray,   count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceStrikeArray, count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceDipArray,    count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceRakeArray,   count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceSlipArray,   count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceTinitArray,  count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceDtArray,     count, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSourceNt1Array,    count, MPI_INT,    0, comm_solver );
+
+    /* allocate memory for the slip function arrays */
+    if (myID != 0) {
+	int i;
+
+	XMALLOC_VAR_N( theSourceSlipFunArray, double*, count );
+	for (i = 0; i < count; i++) {
+	    int length = theSourceNt1Array[i];
+	    XMALLOC_VAR_N( theSourceSlipFunArray[i], double, length );
+	}
+    }
+
+    /* broadcast slip function arrays */
+    int iSource;
+    for (iSource = 0; iSource < count; iSource++) {
+	MPI_Bcast( theSourceSlipFunArray[iSource], theSourceNt1Array[iSource],
+		   MPI_DOUBLE, 0, comm_solver );
+    }
+}
+
+
+/**
+ * broadcast information that only applies to point sources, otherwise it
+ * doesn't do anything.
+ */
+static void
+broadcast_point_source_parameters( void )
+{
+    double    d_buf[6];
+    const int d_len = DOUBLE_ARRAY_LENGTH( d_buf );
+
+    /* this only applies to point sources */
+    if (theTypeOfSource != POINT) {
+	return;
+    }
+
+    MPI_Bcast( &theLonlatOrCartesian, 1, MPI_INT, 0, comm_solver );
+
+    d_buf[0] = theHypocenterLatDeg;
+    d_buf[1] = theHypocenterLongDeg;
+    d_buf[2] = theHypocenterDepthM;
+    d_buf[3] = theSourceStrikeDeg;
+    d_buf[4] = theSourceDipDeg;
+    d_buf[5] = theSourceRakeDeg;
+
+    /* broadcast the vars above (6) */
+    MPI_Bcast( d_buf, d_len, MPI_DOUBLE, 0, comm_solver );
+
+    theHypocenterLatDeg  = d_buf[0];
+    theHypocenterLongDeg = d_buf[1];
+    theHypocenterDepthM  = d_buf[2];
+    theSourceStrikeDeg   = d_buf[3];
+    theSourceDipDeg      = d_buf[4];
+    theSourceRakeDeg     = d_buf[5];
+
+    if (theLonlatOrCartesian == 0) {
+	MPI_Bcast( theSurfaceCornersLat,  4, MPI_DOUBLE, 0, comm_solver );
+	MPI_Bcast( theSurfaceCornersLong, 4, MPI_DOUBLE, 0, comm_solver );
+    }
+}
+
+
+/**
+ * broadcast information that only applies to plane (and plane with kinks)
+ * types of sources, otherwise it doesn't do anything.
+ */
+static void
+broadcast_plane_source_parameters( void )
+{
+    /* this only applies to plane and plane with kinks sources */
+    if (theTypeOfSource != PLANE  && theTypeOfSource != PLANEWITHKINKS) {
+	return;
+    }
+
+    broadcast_plane_parameters();
+
+    if (theTypeOfSource == PLANEWITHKINKS) {
+	MPI_Bcast( &theNumberOfKinks,  1, MPI_INT , 0, comm_solver );
+
+	if (myID != 0) {
+	    XMALLOC_VAR_N( theKinkLonArray, double, theNumberOfKinks );
+	    XMALLOC_VAR_N( theKinkLatArray, double, theNumberOfKinks );
+	}
+    }
+
+    MPI_Bcast(theKinkLatArray, theNumberOfKinks, MPI_DOUBLE, 0,comm_solver);
+    MPI_Bcast(theKinkLonArray, theNumberOfKinks, MPI_DOUBLE, 0,comm_solver);
+
+    MPI_Bcast( theSurfaceCornersLat,  4, MPI_DOUBLE, 0, comm_solver );
+    MPI_Bcast( theSurfaceCornersLong, 4, MPI_DOUBLE, 0, comm_solver );
+}
+
+
+/**
+ * Broadcast source generation parameters to all PEs (from PE 0).
+ * The parameter values are read from global variables.
+ */
+static void
+source_broadcast_parameters( void )
+{
+    int32_t i_buf[5];
+    double  d_buf[15];
+
+    const int i_len = INT32_ARRAY_LENGTH( i_buf );
+    const int d_len = DOUBLE_ARRAY_LENGTH( d_buf );
+
+    /* broadcast string parameters: source output dir */
+    broadcast_string( &theSourceOutputDir, 0, comm_solver );
+
+    /* group all int parameters in an array and then broadcast the array */
+    i_buf[0] = theNumberOfTimeSteps;
+    i_buf[1] = theSourceIsFiltered;
+    i_buf[2] = theTypeOfSource;
+    i_buf[3] = theNumberOfPoles;
+    i_buf[4] = theSourceFunctionType;
+
+    /* broadcast int parameters */
+    MPI_Bcast( i_buf, i_len, MPI_INT, 0, comm_solver );
+
+    /* this is an identity assigment on PE 0 */
+    theNumberOfTimeSteps   = i_buf[0];
+    theSourceIsFiltered    = i_buf[1];
+    theTypeOfSource	   = (source_type_t)i_buf[2];
+    theNumberOfPoles	   = i_buf[3];
+    theSourceFunctionType  = i_buf[4];
+
+    /* group all double parameters in an array and broadcast the array */
+    d_buf[0]  = theRegionOriginLatDeg;
+    d_buf[1]  = theRegionOriginLongDeg;
+    d_buf[2]  = theRegionAzimuthDeg;
+    d_buf[3]  = theRegionDepthShallowM;
+    d_buf[4]  = theRegionLengthEastM;
+    d_buf[5]  = theRegionLengthNorthM;
+    d_buf[6]  = theRegionDepthDeepM;
+    d_buf[7]  = theDeltaT;
+    d_buf[8]  = theValidFreq;
+    d_buf[9]  = theAverageRisetimeSec;
+    d_buf[10] = theMomentMagnitude;
+    d_buf[11] = theMomentAmplitude;
+    d_buf[12] = theRickerTs;
+    d_buf[13] = theRickerTp;
+    d_buf[14] = theThresholdFrequency;
+
+    /* broadcast theRegion* parameters and other double parameters */
+    MPI_Bcast( d_buf, d_len, MPI_DOUBLE, 0, comm_solver );
+
+    theRegionOriginLatDeg  = d_buf[ 0];
+    theRegionOriginLongDeg = d_buf[ 1];
+    theRegionAzimuthDeg	   = d_buf[ 2];
+    theRegionDepthShallowM = d_buf[ 3];
+    theRegionLengthEastM   = d_buf[ 4];
+    theRegionLengthNorthM  = d_buf[ 5];
+    theRegionDepthDeepM    = d_buf[ 6];
+    theDeltaT		   = d_buf[ 7];
+    theValidFreq	   = d_buf[ 8];
+    theAverageRisetimeSec  = d_buf[ 9];
+    theMomentMagnitude     = d_buf[10];
+    theMomentAmplitude     = d_buf[11];
+    theRickerTs		   = d_buf[12];
+    theRickerTp		   = d_buf[13];
+    theThresholdFrequency  = d_buf[14];
+
+    /* broadcast the time windows */
+    MPI_Bcast( &theNumberOfTimeWindows, 1, MPI_INT, 0, comm_solver );
+    if (myID != 0) {
+	theWindowDelay = dvector( 0, theNumberOfTimeWindows );
+    }
+    MPI_Bcast( theWindowDelay, theNumberOfTimeWindows, MPI_DOUBLE, 0,
+	       comm_solver );
+
+    /* broadcast source-type-specific parameters */
+    broadcast_point_source_parameters();
+
+    broadcast_plane_source_parameters();
+
+    broadcast_srfh_parameters();
+
+    return;
+}
+
+
+/**
+ * Read the type of source from source.in.
+ */
+static int
+source_read_type( FILE* fpsrc )
+{
+    int source_type = -1;
+    char type_of_source[32];
+
+    /* formats */
+    read_config_string2( fpsrc, "type_of_source", type_of_source,
+			 sizeof(type_of_source) );
+
+    if (strcasecmp( type_of_source, "point" ) == 0) {
+	source_type = POINT;
+    }
+
+    else if (strcasecmp( type_of_source, "plane" ) == 0) {
+	source_type = PLANE;
+    }
+
+    else if (strcasecmp( type_of_source, "planewithkinks" ) == 0) {
+	source_type = PLANEWITHKINKS;
+    }
+
+    else if (strcasecmp( type_of_source, "srfh" ) == 0) {
+	source_type = SRFH;
+    }
+
+    else {
+	fprintf(stderr, "ERROR: Unknown type_of_source %s\n", type_of_source);
+	ABORT_PROGRAM( "ERROR: Unknown type_of_source" );
+	return -1;
+    }
+
+    return source_type;
+}
+
+
+/**
+ * Read and initialize parameters relevant to the earthquake source.
+ *
+ * \param physicsin Name of the "physics.in" file.  The file contains the
+ * domain dimensions and some other physical quantities and the path for
+ * the dir where the files that describe the fault are.
+ *
+ * \return 0 on success, -1 on error.
+ */
+static int
+source_init_parameters( const char* physicsin,
+                        double      globalDelayT,
+                        double      surfaceShift )
+{
+    FILE* fparea, *fpstrike, *fpdip, *fprake, *fpslip, *fpcoords,
+	*fpslipfun;
+
+    char source_dir[256], slipin[256], slipfunin[256];
+    char coordsin[256], areain[256], strikein[256], dipin[256], rakein[256];
+
+    size_t src_dir_len = sizeof(source_dir);
+    size_t sdo_len     = 0;
+    char* src_dir_p    = source_dir;
+
+    /* read domain and source path from physics.in */
+    FILE* fp = hu_fopen( physicsin, "r" );
+
+    if (read_domain( fp ) != 0) {
+	return -1;
+    }
+
+    hu_config_get_string_req(fp, "source_directory", &src_dir_p, &src_dir_len);
+    hu_config_get_string_req(fp, "source_directory_output",
+			     &theSourceOutputDir, &sdo_len);
+
+    close_file( &fp );
+
+    /* read source properties */
+    FILE* fpsrc = open_file_in_dir( source_dir, "source.in", "r" );
+
+    /* read filter */
+    if (read_filter( fpsrc ) == -1) {
+	return -1;
+    }
+
+    theTypeOfSource = (source_type_t)source_read_type( fpsrc );
+
+    if( read_common_all_formats( fpsrc ) == -1 ) {
+	return -1;
+    }
+
+    if ( theTypeOfSource == POINT ) {
+	if( read_point_source( fpsrc ) == -1 ) {
+	    return -1;
+	}
+    }
+
+
+    if (theTypeOfSource == PLANE || theTypeOfSource == PLANEWITHKINKS) {
+	sprintf ( slipin, "%s/slip.in" , source_dir );
+	sprintf ( rakein, "%s/rake.in" , source_dir );
+
+	if ((fpslip = fopen(slipin, "r")) == NULL) {
+	    fprintf(stderr, "Error opening %s\n", slipin);
+	    return -1;
+	}
+
+	if ((fprake = fopen(rakein, "r" ) ) == NULL) {
+	    fprintf(stderr, "Error opening %s\n", rakein);
+	    return -1;
+	}
+
+	if( read_plane_source( fpsrc, fpslip, fprake ) == -1 ) {
+	    return -1;
+	}
+
+	fclose(fpslip);
+	fclose(fprake);
+    }
+
+    if (theTypeOfSource == SRFH) {
+	sprintf( coordsin, "%s/coords.in", source_dir );
+	sprintf( areain,   "%s/area.in",   source_dir );
+	sprintf( strikein, "%s/strike.in", source_dir );
+	sprintf( dipin,    "%s/dip.in",  source_dir );
+	sprintf( rakein,   "%s/rake.in", source_dir );
+	sprintf( slipin,   "%s/slip.in", source_dir );
+	sprintf( slipfunin,"%s/slipfunction.in", source_dir );
+
+	if ( (fpcoords = fopen( coordsin, "r")) == NULL ||
+	     (fparea   = fopen( areain,   "r")) == NULL ||
+	     (fpstrike = fopen( strikein, "r")) == NULL ||
+	     (fpdip    = fopen( dipin,    "r")) == NULL ||
+	     (fprake   = fopen( rakein,   "r")) == NULL ||
+	     (fpslip   = fopen( slipin,   "r")) == NULL ||
+	     (fpslipfun   = fopen( slipfunin,   "r")) == NULL) {
+	    fprintf(stderr, "Error opening srfh files\n" );
+	    return -1;
+	}
+
+	if (read_srfh_source( fpsrc, fpcoords, fparea, fpstrike, fpdip,
+			      fprake, fpslip, fpslipfun, globalDelayT,
+			      surfaceShift ) == -1) {
+	    return -1;
+	}
+	fclose(fpcoords);
+	fclose(fparea);
+	fclose(fpstrike);
+	fclose(fpdip);
+	fclose(fprake);
+	fclose(fpslip);
+	fclose(fpslipfun);
+    }
+
+    close_file( &fpsrc );
+
+    return 0;
+}
+
+
+/*
+ *  compute_print_source: Compute and print the forces needed in
+ *                        psolve
+ *    input:
+ *          informationdirectory - where source related files are located
+ *                      myoctree - octree to be used
+ *                        mymesh - information realtive to the mesh
+ *                      myforces - the load vector
+ *           numericsinformation - see quakesource.h for description
+ *                mpiinformation - see quakesource.h for description
+ *
+ *    return:
+ *
+ */
+int
+compute_print_source( const char *physicsin, octree_t *myoctree,
+		      mesh_t *mymesh, numerics_info_t numericsinformation,
+		      mpi_info_t mpiinformation, double globalDealyT,
+		      double surfaceShift )
+{
+    /*Mesh related */
+    myOctree = myoctree;
+    myMesh   = mymesh;
+
+    /*MPI Related*/
+    myID	 = mpiinformation.myid;
+    theGroupSize = mpiinformation.groupsize;
+
+    /*Numerics related*/
+    theDeltaT		 = numericsinformation.deltat;
+    theNumberOfTimeSteps = numericsinformation.numberoftimesteps;
+    theValidFreq	 = numericsinformation.validfrequency;
+    theMinimumEdge	 = numericsinformation.minimumh;
+
+    theDomainX = numericsinformation.xlength;
+    theDomainY = numericsinformation.ylength;
+    theDomainZ = numericsinformation.zlength;
+
+    myForces = (vector3D_t **)calloc( myMesh->nharbored, sizeof(vector3D_t) );
+    if ( myForces == NULL ) {
+	fprintf(stderr, "Thread %d: quakesource: out of memory\n",myID);
+	ABORTEXIT;
+    }
+
+    if ( myID == 0 )
+	if ( source_init_parameters (
+	        physicsin,
+	        globalDealyT,
+	        surfaceShift ) == -1 ) {
+	    fprintf(stdout,"Err init_source_parameters failed");
+	    ABORTEXIT;
+	}
+
+    source_broadcast_parameters();
+
+    if ( theTypeOfSource == POINT )
+	if ( compute_myForces_point(physicsin) == -1 ){
+	    fprintf(stdout,"Err compute_myForces_point failed");
+	    ABORTEXIT;
+	}
+
+    if (  theTypeOfSource == PLANE || theTypeOfSource == PLANEWITHKINKS )
+	if ( compute_myForces_planes(physicsin) == -1 ){
+	    fprintf(stdout,"Err compute_myForces_planes failed");
+	    ABORTEXIT;
+	}
+
+    /* Standard Rupture Fault Hercules, variation of SRF by Graves */
+    if(  theTypeOfSource == SRFH )
+	if( compute_myForces_srfh(physicsin )==-1){
+	    fprintf(stdout,"Err compute_myForces_srfh failed");
+	    ABORTEXIT;
+	}
+
+    MPI_Barrier( comm_solver );
+
+    source_compute_print_stat();
+
+    MPI_Barrier( comm_solver );
+
+    return 0;
+}

--- a/quake/forward_gpu/quakesource.h
+++ b/quake/forward_gpu/quakesource.h
@@ -1,0 +1,231 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/**
+ * quakesource.h: source definition of earthquakes used in a generic finite
+ *                element code.
+ *
+
+ * Copyright (c) 2005 Leonardo Ramirez-Guzman
+ *
+ * All rights reserved.  May not be used without permission, modified, or
+ *                       copied
+ *
+ *
+ * Contact:
+ * Leonardo Ramirez Guzman
+ * Civil and Environmental Engineering
+ * Carnegie Mellon University
+ * 5000 Forbes Avenue
+ * Pittsburgh, PA 15213
+ * lramirez@andrew.cmu.edu
+ *
+ */
+
+#include "geometrics.h"
+
+
+
+/*------------------------Information data structures --------------------*/
+
+
+typedef struct numerics_info_t{
+
+  int32_t numberoftimesteps;
+
+  double deltat,validfrequency;
+
+  double minimumh;
+
+  double xlength,ylength,zlength;
+
+}numerics_info_t;
+
+
+typedef struct mpi_info_t{
+
+  int32_t myid,groupsize;
+
+}mpi_info_t;
+
+
+
+/*------------Earthquake source data structure and functions------------------*/
+
+
+/* typedef struct{ */
+
+/*   double strike, dip, rake, slip, area; */
+
+/*   vector3D_t centroid, p [ 3 ]; */
+
+/* }triangle_t; */
+
+
+
+
+typedef enum {
+
+  RAMP = 0, SINE, QUADRATIC, RICKER, EXPONENTIAL, DISCRETE
+
+} source_function_t;
+
+
+
+typedef enum {
+
+  POINT = 0, PLANE, SRFH, PLANEWITHKINKS
+
+} source_type_t;
+
+
+
+typedef struct ptsrc_t {
+
+  source_function_t sourceFunctionType;
+
+  int32_t lnid[8];
+
+  vector3D_t localCoords;  /*Local Coords in the plane to be mapped used only
+                             for terashake type earthquakes */
+
+  vector3D_t globalCoords;
+
+  vector3D_t domainCoords;
+
+  double x, y, z;                   /* Local coordinate inside an element */
+
+  double strike, dip, rake;
+
+  double delayTime, T0,Ts,Tp;
+
+  double mu, area, maxSlip, muArea;
+
+  double edgesize;                  /* Edge size of the containing element */
+
+  double nodalForce[8][3];          /* nodal forces on the containing elem */
+
+  double *displacement;              /* Displacement vector time dependant  */
+
+  double dt,numberOfTimeSteps;
+
+  double M0;
+
+  double tinit, dtfunction ;
+
+  double *slipfundiscrete;
+
+  int nt1;
+
+
+} ptsrc_t;
+
+
+
+
+extern int theForcesBufferSize;
+
+
+/*--------------------------------Functions-----------------------------------*/
+
+
+/*
+ *
+ * compute_source_function:
+ *
+ */
+void compute_source_function ( ptsrc_t *pointSource );
+
+
+
+
+/*
+ *  compute_initial_time: computes the time when the rupture is initiated in
+ *                        the given station. It assumes a homogeneous radial
+ *                        dependent rupture time.
+ *
+ *
+ */
+double compute_initial_time(vector3D_t station, vector3D_t hypocenter,
+			    double rupturevelocity );
+
+
+/* compute_local_coords: computes the coordinates of a station in the fault
+ *                       plane related to the origin of the fault
+ *
+ *  input: point
+ *         totalNodes
+ *         gridx, gridy
+ *
+ * output: vector3D_t pointInCartesian
+ *
+ */
+vector3D_t compute_local_coords(int32_t point, int32_t totalNodes,
+				double *gridx, double *gridy );
+
+
+/*
+ *  print_filter_signal:
+ *
+ */
+int PrintFilterSignal( int signalsize, double samplingfrequency,
+		       double thresholdfrequency,  int m);
+
+
+
+
+/*
+ *  Filters a signal we add zeros such that newsize is 2^n
+ *
+ */
+
+int FilterSignal ( double *signal, int signalsize,
+		   double samplingfrequency, double thresholdfrequency,
+		   int m );
+
+
+
+
+/*
+ * compute_print_source: computes the forces needed in the calculation
+ *
+ *    input:
+ *          informationdirectory - where source related files are located
+ *                      myoctree - octree to be used
+ *                        mymesh - information realtive to the mesh
+ *                      myforces - the load vector
+ *           numericsinformation - see quakesource.h for description
+ *                mpiinformation - see quakesource.h for description
+ *
+ *
+ *    It does not check if the source is in the domain. It will IGNORE A SOURCE
+ *    NOT CONTAINED.
+ *
+ */
+int compute_print_source (const char *physicsin, octree_t *myoctree,
+			  mesh_t *mymesh, numerics_info_t numericsinformation,
+			  mpi_info_t mpiinformation, double globalDelayT,
+			  double surfaceShift );
+
+
+void update_forceinprocessor(int32_t iForce, char *inoutprocessor, int onoff);
+
+FILE* source_open_forces_file( const char* flags );
+
+int source_get_local_loaded_nodes_count();

--- a/quake/forward_gpu/run_example
+++ b/quake/forward_gpu/run_example
@@ -1,0 +1,2 @@
+ prun -N 2 -n 8  ./psolve labase.e  /usr/users/0/ramirezg/herculesv1.0CVS/examples/test1/physics.in /usr/users/0/ramirezg/herculesv1.0CVS/examples/test1/numerical.in  $SCRATCH/tests/sourceterashake/meshtera $SCRATCH/tests/sourceterashake/veltera /usr/users/0/ramirezg/herculesv1.0CVS/examples/test1/vis.cfg
+

--- a/quake/forward_gpu/stiffness.cu
+++ b/quake/forward_gpu/stiffness.cu
@@ -1,0 +1,446 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "psolve.h"
+#include "nonlinear.h" //NEEDS TO BE HERE FOR NONLINEAR TO RUN
+#include "stiffness.h"
+#include "quake_util.h"
+#include "kernel.h"
+#include "util.h"
+#include "timers.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+
+/* -------------------------------------------------------------------------- */
+/*                             Global Variables                               */
+/* -------------------------------------------------------------------------- */
+
+static int32_t    myLinearElementsCount;
+static int32_t   *myLinearElementsMapper;
+static int32_t   *myLinearElementsMapperDevice;
+static rev_entry_t   *reverseLookup;
+static rev_entry_t   *reverseLookupDevice;
+static fvector_t *localForceDevice;
+
+
+/* -------------------------------------------------------------------------- */
+/*          Initialization of parameters for nonlinear compatibility          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Counts the number of nonlinear elements in my local mesh
+ */
+void linear_elements_count(int32_t myID, mesh_t *myMesh) {
+
+    int32_t eindex;
+    int32_t count = 0;
+
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+        if ( isThisElementNonLinear(myMesh, eindex) == NO ) {
+            count++;
+        }
+    }
+
+    if ( count > myMesh-> lenum ) {
+        fprintf(stderr,"Thread %d: linear_elements_count: "
+                "more elements than expected\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    myLinearElementsCount = count;
+
+    return;
+}
+
+
+/**
+ * Re-counts and stores the nonlinear element indices to a static local array
+ * that will serve as mapping tool to the local mesh elements table.
+ */
+void linear_elements_mapping(int32_t myID, mesh_t *myMesh) {
+
+    int32_t eindex;
+    int32_t count = 0;
+
+    XMALLOC_VAR_N(myLinearElementsMapper, int32_t, myLinearElementsCount);
+
+    for (eindex = 0; eindex < myMesh->lenum; eindex++) {
+
+        if ( isThisElementNonLinear(myMesh, eindex) == NO ) {
+            myLinearElementsMapper[count] = eindex;
+            count++;
+        }
+    }
+
+    if ( count != myLinearElementsCount ) {
+        fprintf(stderr,"Thread %d: linear_elements_mapping: "
+                "more elements than the count\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    return;
+}
+
+
+void stiffness_init(int32_t myID, mesh_t *myMesh)
+{
+
+    int       i;
+    int32_t   eindex;
+    int32_t   lin_eindex;
+    elem_t*   elemp;
+
+    linear_elements_count(myID, myMesh);
+    linear_elements_mapping(myID, myMesh);
+    
+    /* Create reverse node->element lookup table */
+    reverseLookup = (rev_entry_t *)calloc(myMesh->nharbored, 
+					  sizeof(rev_entry_t));
+    memset(reverseLookup, 0, myMesh->nharbored * sizeof(rev_entry_t));
+
+    /* loop on the number of elements */
+    for (lin_eindex = 0; lin_eindex < myLinearElementsCount; lin_eindex++) {
+
+        eindex = myLinearElementsMapper[lin_eindex];
+        elemp  = &myMesh->elemTable[eindex];
+
+        for (i = 0; i < 8; i++) {
+	  rev_entry_t *tableEntry = &(reverseLookup[elemp->lnid[i]]);
+
+	  if (tableEntry->count >= 8) {
+	    fprintf(stderr, "Thread %d: reverseLookup entry too large\n", myID);
+	    MPI_Abort(MPI_COMM_WORLD, ERROR);
+	    exit(1);
+	  }
+
+	  tableEntry->elements[tableEntry->count].elemid = lin_eindex;
+	  tableEntry->elements[(tableEntry->count)++].offset = i;
+	}
+    }
+
+    /* Allocate device memory */
+    if (cudaMalloc((void**)&myLinearElementsMapperDevice, 
+		   myLinearElementsCount * sizeof(int32_t)) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to allocate mapper memory\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    if (cudaMalloc((void**)&(localForceDevice), 
+		   myLinearElementsCount * 8 * sizeof(fvector_t)) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to allocate localForce memory\n", 
+		myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    if (cudaMalloc((void**)&(reverseLookupDevice), 
+		   myMesh->nharbored * sizeof(rev_entry_t)) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to allocate reverseLookup memory\n", 
+		myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    /* Copy static element mapper to device */
+    if (cudaMemcpy(myLinearElementsMapperDevice, myLinearElementsMapper, 
+		   myLinearElementsCount * sizeof(int32_t),  
+		   cudaMemcpyHostToDevice) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to copy mapper to device\n", myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    /* Copy reverse table lookup to device */
+    if (cudaMemcpy(reverseLookupDevice, reverseLookup, 
+		   myMesh->nharbored * sizeof(rev_entry_t),  
+		   cudaMemcpyHostToDevice) != cudaSuccess) {
+        fprintf(stderr, "Thread %d: Failed to copy reverseLookup to device\n", 
+		myID);
+        MPI_Abort(MPI_COMM_WORLD, ERROR);
+        exit(1);
+    }
+
+    return;
+}
+
+
+void stiffness_delete(int32_t myID) {
+    /* Free stiffness module memory */
+    free(myLinearElementsMapper);
+    free(reverseLookup);
+
+    /* Free device memory */
+    cudaFree(myLinearElementsMapperDevice);
+    cudaFree(localForceDevice);
+    cudaFree(reverseLookupDevice);
+
+    return;
+}
+
+
+/* -------------------------------------------------------------------------- */
+/*                       Stiffness Contribution Methods                       */
+/* -------------------------------------------------------------------------- */
+
+
+/**
+ * Compute and add the force due to the element stiffness matrices.
+ *
+ * \param myMesh   Pointer to the solver mesh structure.
+ * \param mySolver Pointer to the solver main data structures.
+ * \param theK1    First stiffness matrix (K1).
+ * \param theK2    Second stiffness matrix (K2).
+ */
+void compute_addforce_conventional( mesh_t* myMesh, mysolver_t* mySolver, 
+				    fmatrix_t (*theK1)[8], fmatrix_t (*theK2)[8] )
+{
+    fvector_t localForce[8];
+    int       i, j;
+    int32_t   eindex;
+    int32_t   lin_eindex;
+
+    /* loop on the number of elements */
+    for (lin_eindex = 0; lin_eindex < myLinearElementsCount; lin_eindex++) {
+
+        elem_t* elemp;
+        e_t*    ep;
+
+        eindex = myLinearElementsMapper[lin_eindex];
+        elemp  = &myMesh->elemTable[eindex];
+        ep     = &mySolver->eTable[eindex];
+
+        /* step 1: calculate the force due to the element stiffness */
+        memset( localForce, 0, 8 * sizeof(fvector_t) );
+
+        /* contribution by node j to node i */
+        for (i = 0; i < 8; i++)
+        {
+            fvector_t* toForce = &localForce[i];
+
+            for (j = 0; j < 8; j++)
+            {
+                int32_t    nodeJ  = elemp->lnid[j];
+                fvector_t* myDisp = mySolver->tm1 + nodeJ;
+
+                /*
+		 * contributions by the stiffnes/damping matrix
+		 * contribution by ( - deltaT_square * Ke * Ut )
+		 * But if myDisp is zero avoids multiplications
+		 */
+                if ( vector_is_all_zero( myDisp ) != 0 ) {
+                    MultAddMatVec( &theK1[i][j], myDisp, -ep->c1, toForce );
+                    MultAddMatVec( &theK2[i][j], myDisp, -ep->c2, toForce );
+                }
+            }
+        }
+
+        /* step 2: sum up my contribution to my vertex nodes */
+        for (i = 0; i < 8; i++) {
+            int32_t    lnid       = elemp->lnid[i];
+            fvector_t* nodalForce = mySolver->force + lnid;
+
+            nodalForce->f[0] += localForce[i].f[0];
+            nodalForce->f[1] += localForce[i].f[1];
+            nodalForce->f[2] += localForce[i].f[2];
+        }
+    } /* for all the elements */
+}
+
+
+/**
+ * Compute and add the force due to the element stiffness matrices with the effective method.
+ */
+void compute_addforce_effective_cpu( mesh_t* myMesh, mysolver_t* mySolver )
+{
+    /* \TODO use mu_and_lamda to compute first,second and third coefficients */
+
+    fvector_t localForce[8];
+    fvector_t curDisp[8];
+    int       i;
+    int32_t   eindex;
+    int32_t   lin_eindex;
+
+    /* loop on the number of elements */
+    for (lin_eindex = 0; lin_eindex < myLinearElementsCount; lin_eindex++) {
+
+        elem_t* elemp;
+        e_t*    ep;
+
+        eindex = myLinearElementsMapper[lin_eindex];
+        elemp  = &myMesh->elemTable[eindex];
+        ep     = &mySolver->eTable[eindex];
+
+        memset( localForce, 0, 8 * sizeof(fvector_t) );
+
+        for (i = 0; i < 8; i++) {
+            int32_t    lnid = elemp->lnid[i];
+            fvector_t* tm1Disp = mySolver->tm1 + lnid;
+//	    fvector_t* tm2Disp = mySolver->tm2 + lnid;
+
+            curDisp[i].f[0] = tm1Disp->f[0];
+            curDisp[i].f[1] = tm1Disp->f[1];
+            curDisp[i].f[2] = tm1Disp->f[2];
+
+        }
+
+        /* Coefficients for new stiffness matrix calculation */
+        if (vector_is_zero( curDisp ) != 0) {
+
+            double first_coeff  = -0.5625 * (ep->c2 + 2 * ep->c1);
+            double second_coeff = -0.5625 * (ep->c2);
+            double third_coeff  = -0.5625 * (ep->c1);
+
+            double atu[24];
+            double firstVec[24];
+
+            aTransposeU( curDisp, atu );
+            firstVector( atu, firstVec, first_coeff, second_coeff, third_coeff );
+            au( localForce, firstVec );
+        }
+
+        for (i = 0; i < 8; i++) {
+            int32_t lnid          = elemp->lnid[i];;
+            fvector_t* nodalForce = mySolver->force + lnid;
+
+            nodalForce->f[0] += localForce[i].f[0];
+            nodalForce->f[1] += localForce[i].f[1];
+            nodalForce->f[2] += localForce[i].f[2];
+        }
+    } /* for all the elements */
+}
+
+
+/**
+ * Compute and add the force due to the element stiffness matrices with 
+   the effective method.
+ */
+void compute_addforce_effective_gpu( mesh_t* myMesh, mysolver_t* mySolver )
+{
+    /* Copy working data to device */
+    cudaMemcpy(mySolver->tm1Device, mySolver->tm1, 
+	       myMesh->nharbored * sizeof(fvector_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(mySolver->forceDevice, mySolver->force, 
+	       myMesh->nharbored * sizeof(fvector_t), cudaMemcpyHostToDevice);
+
+    int blocksize = mySolver->gpu_spec->max_threads/2;
+    int gridsize = (myLinearElementsCount / blocksize) + 1;
+
+    kernelStiffnessCalcLocal<<<gridsize, blocksize>>>(myLinearElementsCount, 
+						      myLinearElementsMapperDevice, 
+						      mySolver->elemTableDevice, 
+						      mySolver->eTableDevice, 
+						      mySolver->tm1Device, 
+						      localForceDevice);
+
+
+    cudaDeviceSynchronize();
+
+    blocksize = mySolver->gpu_spec->max_threads/2;
+    gridsize = ((myMesh->nharbored) / blocksize) + 1;
+    kernelStiffnessAddLocal<<<gridsize, blocksize>>>(myMesh->nharbored,
+    						     reverseLookupDevice,
+    						     localForceDevice,
+    						     mySolver->forceDevice);
+
+    cudaDeviceSynchronize();
+
+    /* Copy working data back to host */
+    cudaMemcpy(mySolver->force, mySolver->forceDevice,
+	       myMesh->nharbored * sizeof(fvector_t), cudaMemcpyDeviceToHost);
+
+    return;
+}
+
+
+/* -------------------------------------------------------------------------- */
+/*                         Efficient Method Utilities                         */
+/* -------------------------------------------------------------------------- */
+
+
+void firstVector_kappa( const double* atu, double* finalVector, double kappa)
+{
+    finalVector[0] += 0.;
+    finalVector[1] += 0.;
+    finalVector[2] += 0.;
+    finalVector[3] += kappa * (atu[3] + atu[10] + atu[17]);
+    finalVector[4] += 0.;
+    finalVector[5] += kappa * ( atu[5] + atu[12] ) /3.;
+    finalVector[6] += kappa * ( atu[6] + atu[20] ) /3.;
+    finalVector[7] += kappa * atu[7] / 9.;
+
+    finalVector[8] += 0.;
+    finalVector[9] += 0.;
+    finalVector[10] += kappa * ( atu[10] + atu[3] + atu[17]);
+    finalVector[11] += 0.;
+    finalVector[12] += kappa * ( atu[12] + atu[5] ) / 3.;
+    finalVector[13] += 0.;
+    finalVector[14] += kappa * ( atu[14] + atu[21] ) /3.;
+    finalVector[15] += kappa * atu[15] / 9.;
+
+    finalVector[16] += 0.;
+    finalVector[17] += kappa * ( atu[17] + atu[3] + atu[10] );
+    finalVector[18] += 0.;
+    finalVector[19] += 0.;
+    finalVector[20] += kappa * ( atu[20] + atu[6] ) / 3.;
+    finalVector[21] += kappa * ( atu[21] + atu[14] ) / 3.;
+    finalVector[22] += 0.;
+    finalVector[23] += kappa * atu[23] / 9.;
+}
+
+void firstVector_mu( const double* atu, double* finalVector, double b )
+{
+    finalVector[0] += 0;
+    finalVector[1] += b * (atu[19] + atu[1]);
+    finalVector[2] += b * (atu[11] + atu[2]);
+    finalVector[3] += b * ( 4. * atu[3] - 2. * (atu[10] + atu[17]) ) / 3.;
+    finalVector[4] += b * (atu[13] + atu[22] + 2. * atu[4]) / 3.;
+    finalVector[5] += b * ( 7. * atu[5] - 2. * atu[12] ) / 9.;
+    finalVector[6] += b * ( 7. * atu[6] - 2. * atu[20] ) / 9.;
+    finalVector[7] += ( 10. * b * atu[7] ) / 27.;
+
+    finalVector[8]  += 0;
+    finalVector[9]  += b * (atu[18] + atu[9]);
+    finalVector[10] += b * ( 4. * atu[10] - 2. * (atu[3] + atu[17]) ) / 3.;
+    finalVector[11] += b * (atu[11] + atu[2]);
+    finalVector[12] += b * ( 7. * atu[12] - 2. * atu[5] ) / 9.;
+    finalVector[13] += b * (atu[4] + atu[22] + 2. * atu[13]) / 3.;
+    finalVector[14] += b * ( 7. * atu[14] - 2. * atu[21] ) / 9.;
+    finalVector[15] += (10. * b * atu[15] ) / 27.;
+
+    finalVector[16] += 0;
+    finalVector[17] += b * ( 4. * atu[17] - 2. * (atu[3] + atu[10]) ) / 3.;
+    finalVector[18] += b * (atu[18] + atu[9]);
+    finalVector[19] += b * (atu[19] + atu[1]);
+    finalVector[20] += b * ( 7. * atu[20] - 2. * atu[6] ) / 9.;
+    finalVector[21] += b * ( 7. * atu[21] - 2. * atu[14] ) / 9.;
+    finalVector[22] += b * ( atu[4] + atu[13] + 2. * atu[22]) / 3.;
+    finalVector[23] += (10. * b * atu[23] ) / 27.;
+}
+

--- a/quake/forward_gpu/stiffness.h
+++ b/quake/forward_gpu/stiffness.h
@@ -1,0 +1,40 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+#ifndef STIFFNESS_H_
+#define STIFFNESS_H_
+
+typedef enum {
+    CONVENTIONAL = 0, EFFECTIVE
+} stiffness_type_t;
+
+void linear_elements_count   (int32_t myID, mesh_t *myMesh);
+void linear_elements_mapping (int32_t myID, mesh_t *myMesh);
+void stiffness_init          (int32_t myID, mesh_t *myMesh);
+void stiffness_delete        (int32_t myID);
+
+void compute_addforce_conventional( mesh_t* myMesh, mysolver_t* mySolver, fmatrix_t (*theK1)[8],
+				    fmatrix_t (*theK2)[8] );
+void compute_addforce_effective_cpu( mesh_t* myMesh, mysolver_t* mySolver );
+void compute_addforce_effective_gpu( mesh_t* myMesh, mysolver_t* mySolver );
+
+void firstVector_kappa( const double* atu, double* finalVector, double kappa);
+void firstVector_mu( const double* atu, double* finalVector, double b);
+
+#endif /* STIFFNESS_H_ */

--- a/quake/forward_gpu/timers.cu
+++ b/quake/forward_gpu/timers.cu
@@ -1,0 +1,238 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mpi.h>
+#include "timers.h"
+
+
+#define MAXTIMERS 100 /*Maximim number of usable timers*/
+
+struct timer {
+
+    char             name[128];
+    double           starttime;
+    double           elapsed;
+    double           max;
+    double           min;
+    double           average;
+    int              running;
+    enum TimerKind   flags;
+};
+
+
+static int FindTimer(char* TimerName);
+
+struct timer Timers[MAXTIMERS];
+static int   NumberOfTimersUsed = 0;
+
+
+void  Timer_Start(char* TimerName){
+
+    int timernum;
+
+    timernum = FindTimer(TimerName);
+    if (timernum== -1){
+	if (NumberOfTimersUsed == MAXTIMERS){
+	    fprintf(stderr, "Too many timers (%d) allocated!\n", MAXTIMERS);
+	    MPI_Abort(MPI_COMM_WORLD, -1);
+	    exit(1);
+	}
+	strcpy(Timers[NumberOfTimersUsed].name, TimerName);
+	Timers[NumberOfTimersUsed].elapsed = 0;
+	Timers[NumberOfTimersUsed].max     = 0;
+	Timers[NumberOfTimersUsed].min     = 0;
+	Timers[NumberOfTimersUsed].average = 0;
+	Timers[NumberOfTimersUsed].flags   = (TimerKind)0;
+	Timers[NumberOfTimersUsed].running = 1;
+	Timers[NumberOfTimersUsed].starttime = MPI_Wtime();
+	NumberOfTimersUsed++;
+    }
+    else{
+	Timers[timernum].starttime= MPI_Wtime();
+    }
+
+}
+
+
+
+void     Timer_Stop(char* TimerName){
+
+    int timernum;
+
+    timernum = FindTimer(TimerName);
+    if (timernum== -1){
+	fprintf(stderr, "Timer_Stop called for nonexistant timer %s!\n", TimerName);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+    Timers[timernum].running = 0;
+    if (Timers[timernum].flags & NON_CUMULATIVE)
+	Timers[timernum].elapsed =   MPI_Wtime() - Timers[timernum].starttime;
+    else
+	Timers[timernum].elapsed +=  MPI_Wtime() - Timers[timernum].starttime;
+}
+
+
+
+void     Timer_Reset(char* TimerName){
+
+    int timernum;
+
+    timernum = FindTimer(TimerName);
+    if (timernum== -1){
+	fprintf(stderr, "Timer_Reset called for nonexistant timer %s!\n", TimerName);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+    Timers[timernum].elapsed = 0;
+    Timers[timernum].max     = 0;
+    Timers[timernum].min     = 0;
+    Timers[timernum].average = 0;
+    Timers[timernum].flags   = (TimerKind)0;
+    Timers[timernum].running = 0;
+    Timers[timernum].starttime=0;
+}
+
+
+/*Only current use is to set non-cumlative timers */
+void     Timer_Config(char* TimerName, enum TimerKind kind){
+
+    int timernum;
+
+    timernum = FindTimer(TimerName);
+    if (timernum== -1){
+	fprintf(stderr, "Timer_Config called for nonexistant timer %s!\n", TimerName);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+
+    Timers[timernum].flags = kind;
+
+}
+
+
+
+double   Timer_Value(char* TimerName, enum TimerKind kind){
+
+    int timernum;
+
+    timernum = FindTimer(TimerName);
+    if (timernum== -1){
+	fprintf(stderr, "Timer_Value called for nonexistant timer %s!\n", TimerName);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+    if (Timers[timernum].running){
+	if (Timers[timernum].flags & NON_CUMULATIVE)
+	    return (MPI_Wtime() - Timers[timernum].starttime);
+	else
+	    return (Timers[timernum].elapsed + MPI_Wtime() - Timers[timernum].starttime);
+    }
+
+    if (kind & MAX)
+	return Timers[timernum].max;
+    if (kind & MIN)
+	return Timers[timernum].min;
+    if (kind & AVERAGE)
+	return Timers[timernum].average;
+
+    return Timers[timernum].elapsed;
+}
+
+
+
+/*Used to see if a timer has been instantiated */
+int      Timer_Exists(char* TimerName){
+
+    int timernum;
+ 
+    timernum = FindTimer(TimerName);
+ 
+    if (timernum== -1)
+	return 0;
+    else
+	return 1;
+}
+
+
+
+
+void     Timer_PrintAll(MPI_Comm communicator){
+
+    int PENum;
+    MPI_Comm_rank(communicator, &PENum);
+    if (PENum != 0){
+	fprintf(stderr, "PrintAll() called on non-zero PE# %d!\n", PENum);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+
+    int index;
+    for( index=0; index<NumberOfTimersUsed; index++){
+	printf("Timer: %s: ",Timers[index].name);
+	if (Timers[index].running) printf("This timer was never stopped!");
+	if (Timers[index].flags & NON_CUMULATIVE)
+	    printf("(Non-Cumulative) ");
+	printf("%f  ", Timers[index].elapsed);
+	if (Timers[index].flags & MIN)
+	    printf("(Min %f)   ", Timers[index].min);
+	if (Timers[index].flags & MAX)
+	    printf("(Max %f)   ", Timers[index].max);
+	if (Timers[index].flags & AVERAGE)
+	    printf("(Avg %f)   ", Timers[index].average);
+	printf("\n");
+    }
+}
+
+
+
+void     Timer_Reduce(char* TimerName, enum TimerKind kind, MPI_Comm Communicator){
+
+    int timernum;
+
+    timernum = FindTimer(TimerName);
+    if (timernum== -1){
+	fprintf(stderr, "Timer_Reduce called for nonexistant timer %s!\n", TimerName);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+
+    if (Timers[timernum].running){
+	fprintf(stderr, "Timer_Reduce called on unstopped timer %s!\n", TimerName);
+	MPI_Abort(MPI_COMM_WORLD, -1);
+	exit(1);
+    }
+
+    if (kind & MIN){
+	MPI_Reduce (&Timers[timernum].elapsed, &Timers[timernum].min, 1, MPI_DOUBLE, MPI_MIN, 0, Communicator);
+	Timers[timernum].flags = (TimerKind)((int)Timers[timernum].flags | MIN);
+    }
+
+    if (kind & MAX){
+	MPI_Reduce (&Timers[timernum].elapsed, &Timers[timernum].max, 1, MPI_DOUBLE, MPI_MAX, 0, Communicator);
+	Timers[timernum].flags = (TimerKind)((int)Timers[timernum].flags | MAX);
+    }
+
+    if (kind & AVERAGE){
+	int size;
+	MPI_Comm_size(Communicator, &size);
+	MPI_Reduce (&Timers[timernum].elapsed, &Timers[timernum].average, 1, MPI_DOUBLE, MPI_SUM, 0, Communicator);
+	Timers[timernum].average = Timers[timernum].average / size;
+	Timers[timernum].flags = (TimerKind)((int)Timers[timernum].flags | AVERAGE);
+    }
+
+}
+
+
+
+static int FindTimer(char* TimerName){
+
+    int index;
+    for( index=0; index<NumberOfTimersUsed; index++)
+	if ( !strcmp(TimerName, Timers[index].name) )
+	    return index;
+
+    return -1;
+}
+
+

--- a/quake/forward_gpu/timers.h
+++ b/quake/forward_gpu/timers.h
@@ -1,0 +1,13 @@
+#include <mpi.h>
+
+enum TimerKind {NO_TIMER=0, NON_CUMULATIVE=1, MAX=2, MIN=4, AVERAGE=8};
+
+extern void     Timer_Start(char* TimerName);
+extern void     Timer_Stop(char* TimerName);
+extern void     Timer_Reset(char* TimerName);
+extern int      Timer_Exists(char* TimerName);
+extern void     Timer_Config(char* TimerName, enum TimerKind kind);
+extern double   Timer_Value(char* TimerName, enum TimerKind kind);
+extern void     Timer_PrintAll(MPI_Comm Communicator);
+extern void     Timer_Reduce(char* TimerName, enum TimerKind kind, MPI_Comm Communicator);
+

--- a/quake/forward_gpu/util.cu
+++ b/quake/forward_gpu/util.cu
@@ -1,0 +1,947 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ * Description: Miscellaneous support functions.
+ */
+#ifndef _GNU_SOURCE
+#define  _GNU_SOURCE
+#endif
+#include <mpi.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <math.h>
+
+#include "util.h"
+#include "htimer.h"
+
+/* Undo redefinitions in util.h */
+#ifdef hu_fread
+#undef hu_fread
+#endif
+
+
+struct hu_str_t {
+    char*   str;
+    ssize_t len;
+};
+
+typedef struct hu_str_t hu_str_t;
+
+
+/**
+ * Check for garlic NAN values in a floating point array (float version)
+ *
+ * \param v Float array of the given length.
+ * \param len Array length.
+ * \param[out] idx Index of the first element that was found to be a NAN.
+ *
+ * return 0 if no NAN is found, != 0 otherwise (i.e., there's a NAN).
+ */
+int
+hu_farray_has_nan( const float* v, const size_t len, size_t* idx )
+{
+    const float* end = v + len;
+
+    /* \todo add a conditional assertion for v != NULL && idx != NULL */
+
+    while (v < end && !isnan(*v)) {
+	v++;
+    }
+
+    *idx = len - (end - v);
+
+    /* if we got to (past) the end then there were no NAN values so (!(v
+     * == end)) is 0, otherwise if there was a nan then v != end, thus the
+     * expression is 1  */
+    return !(v == end);
+}
+
+
+/**
+ * Check for garlic NAN values in a floating point array (float version)
+ *
+ * \param v Float array of the given length.
+ * \param len Array length.
+ * \param[out] idx Index of the first element that was found to be a NAN.
+ *
+ * return 0 if no NAN is found, != 0 otherwise (i.e., there's a NAN).
+ */
+int
+hu_darray_has_nan( const double* v, const size_t len, size_t* idx )
+{
+    const double* end = v + len;
+
+    /* \todo add a conditional assertion for v != NULL && idx != NULL */
+
+    while (v < end && !isnan(*v)) {
+	v++;
+    }
+
+    *idx = len - (end - v);
+
+    /* if we got to (past) the end then there were no NAN values so (!(v
+     * == end)) is 0, otherwise if there was a nan then v != end, thus the
+     * expression is 1  */
+    return !(v == end);
+}
+
+
+/**
+ * Compute the product of the elements of an array v.  The type of the array
+ * entries is size_t
+ */
+size_t
+hu_st_product( const size_t v[], int len )
+{
+    const size_t* v_end = v + len;
+    size_t p = 1;
+
+    /* iterate over elements of the array and multiply the running product */
+    while (v < v_end) {
+	p *= *v;
+	v++;
+    }
+
+    return p;
+}
+
+
+void
+hu_offset_indices( const size_t len[], int dim, size_t index, size_t idx[] )
+{
+    dim--;
+
+    for (; dim >= 0; dim--) {
+	idx[dim] = index % len[dim];
+	index /= len[dim];
+    }
+}
+
+
+/**
+ * Check for garlic NAN values in a floating point array (float version)
+ *
+ * \param v Float array / matrix of the given lengths.
+ * \param dim Dimensionality of the array / matrix.
+ * \param len Length along each dimension for the array / matrix.  This
+ *	is an array containing 'dim' lengths.
+ * \param[out] idx Indices of the first element that was found to be a NAN.
+ *	This is an array of length 'dim'.  On return in contains the
+ *	indices.
+ *
+ * return 0 if no NAN is found, != 0 otherwise (i.e., there's a NAN).
+ */
+int
+hu_farray_has_nan_nd( const float* v, int dim, const size_t len[],
+		      size_t idx[] )
+{
+    /* \todo add assertions for v, len and idx not null */
+    size_t total_len = hu_st_product( len, dim );
+    size_t index     = total_len;
+    int    ret       = hu_farray_has_nan( v, total_len, &index );
+
+    if (ret != 0) {
+	/* get indices */
+	hu_offset_indices( len, dim, index, idx );
+    }
+
+    return ret;
+}
+
+
+/**
+ * Check for garlic NAN values in a floating point array (float version)
+ *
+ * \param v Float array / matrix of the given lengths.
+ * \param dim Dimensionality of the array / matrix.
+ * \param len Length along each dimension for the array / matrix.  This
+ *	is an array containing 'dim' lengths.
+ * \param[out] idx Indices of the first element that was found to be a NAN.
+ *	This is an array of length 'dim'.  On return in contains the
+ *	indices.
+ *
+ * return 0 if no NAN is found, != 0 otherwise (i.e., there's a NAN).
+ */
+int
+hu_darray_has_nan_nd( const double* v, int dim, const size_t len[],
+		      size_t idx[] )
+{
+    size_t total_len = hu_st_product( len, dim );
+    size_t index     = total_len;
+    int    ret       = hu_darray_has_nan( v, total_len, &index );
+
+    /* \todo add assertions for v, len and idx not null */
+    if (ret != 0) {
+	/* get indices */
+	hu_offset_indices( len, dim, index, idx );
+    }
+
+    return ret;
+}
+
+
+/**
+ * Error handling routine.  It prints on \c stderr a hopefully
+ * informational message about the error condition, and then aborts the
+ * execution of the parallel program by calling \c MPI_Abort() and \c exit().
+ * The first line of the status message contains the processor id for the
+ * process calling hu_solver_abort.
+ *
+ * \pre myID should be initialized.
+ *
+ * \param fname function name of the caller, it can be NULL, in that case
+ *	is not printed.
+ * \param perror_msg Message for the perror() call.
+ * \param fmt format string for additional message, followed by the
+ *	 optional arguments.
+ *
+ * \return This function should not return, instead it aborts execution.
+ *
+ * \author jclopez
+ */
+int
+hu_solver_abort(
+	const char* fname,
+	const char* perror_msg,
+	const char* fmt,
+	...
+	)
+{
+    int	mpi_rank;
+    int my_errno = errno;
+
+    MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
+
+    fprintf( stderr, "\nPE %d called solver_abort() ", mpi_rank );
+
+    if (NULL != fname) {
+	fputs( "from ", stderr );
+	fputs( fname, stderr );
+	fputs( ": ", stderr );
+    }
+
+    if (NULL != fmt) {
+	va_list ap;
+
+	va_start( ap, fmt );
+	vfprintf( stderr, fmt, ap );
+	va_end( ap );
+	fputc( '\n', stderr );
+    }
+
+    if (NULL != perror_msg) {
+	fprintf( stderr, "%s: %s\n", perror_msg, strerror( my_errno ) );
+    }
+
+    fputc( '\n', stderr );
+
+    MPI_Abort( MPI_COMM_WORLD, HERC_ERROR );
+    exit( 1 );
+
+    return -1;
+}
+
+
+void
+hu_assert_abort(
+	const char*     file,
+	const char*     function_name,
+	int             line,
+	const char*     assertion_text
+	)
+{
+    hu_solver_abort( function_name, NULL,
+		     "In %s:%d assertion failed \"(%s)\"\n",
+		     file, line, assertion_text );
+}
+
+
+void*
+hu_xmalloc( size_t size, const char* varname )
+{
+    void* ptr = malloc( size );
+
+    if (NULL == ptr) {
+	const char* my_var_name = (varname == NULL) ? "Unknow" : varname;
+
+	solver_abort( __FUNCTION_NAME, "malloc",
+		      "Memory allocation failed for variable \'%s\'",
+		      my_var_name );
+    }
+
+    return ptr;
+}
+
+
+/**
+ * fopen equivalent routine with error checking.
+ * On error it calls hu_solver_abort()
+ */
+FILE*
+hu_fopen( const char* filename, const char* mode )
+{
+    FILE* fp;
+
+    HU_ASSERT_PTR_ALWAYS( filename );
+    HU_ASSERT_PTR_ALWAYS( mode );
+
+    fp = fopen( filename, mode );
+
+    if (NULL == fp) {
+	hu_solver_abort( __FUNCTION_NAME, filename,
+			 "fopen( filename = \'%s\', mode = %s ) failed!",
+			 filename, mode );
+    }
+
+    return fp;
+}
+
+
+/**
+ * fclose equivalent routine with error checking.
+ * On error it calls hu_solver_abort()
+ *
+ */
+int
+hu_fclose( FILE* fp )
+{
+    int ret;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+
+    ret = fclose( fp );
+
+    if (0 != ret) {
+	// TODO replace with a warning instead of an abort
+	hu_solver_abort(__FUNCTION_NAME, "fclose() failed", "fp = 0x%p\n", fp);
+    }
+
+    return ret;
+}
+
+
+/**
+ * Close a file descriptor (FILE*) and set it to NULL.
+ *
+ * \return the return value from calling fclose(fp)
+ */
+int
+hu_fclosep( FILE** fp )
+{
+    int ret;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+    ret = hu_fclose( *fp );
+    *fp = NULL; /* nullify this handle so we don't use it again */
+
+    return ret;
+}
+
+
+/**
+ * fseeko equivalent routine with error checking.
+ * On error it calls hu_solver_abort()
+ */
+int
+hu_fseeko( FILE* fp, off_t offset, int whence )
+{
+    int ret;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+
+    ret = fseeko( fp, offset, whence );
+
+    if (0 != ret) {
+	hu_solver_abort( __FUNCTION_NAME, "fseek() failed", "fp = 0x%p"
+			 "offset="OFFT_FMT", whence=%d\n", fp, offset, whence );
+    }
+
+    return ret;
+}
+
+
+/**
+ * ftello equivalent routine with error checking.
+ * On error it calls hu_solver_abort()
+ */
+off_t
+hu_ftello( FILE* fp )
+{
+    off_t ret;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+
+    ret = ftello( fp );
+
+    if (-1 == ret) {
+	hu_solver_abort(__FUNCTION_NAME, "ftello() failed", "fp = 0x%p\n", fp);
+    }
+
+    return ret;
+}
+
+
+
+/**
+ * fwrite equivalent routine with error checking.
+ * On error it calls hu_solver_abort()
+ */
+size_t
+hu_fwrite( void* ptr, size_t size, size_t n, FILE* fp )
+{
+    size_t ret;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+    /* make sure ptr != NULL unless size or n are 0 */
+    HU_ASSERT( ( (ptr != NULL) || (size == 0 || n == 0) ) );
+
+    ret = fwrite( ptr, size, n, fp );
+
+    if (n != ret) {
+	hu_solver_abort( __FUNCTION_NAME, "fwrite() failed",
+			 "fp=0x%p ptr=0x%p size=%zd n=%zd\n", fp, ptr, size, n );
+    }
+
+    return ret;
+}
+
+/**
+ * fread equivalent routine with error checking.
+ * On error it calls hu_solver_abort()
+ */
+size_t
+hu_fread_trace( void* ptr, size_t size, size_t n, FILE* fp, const char* fname )
+{
+    fputs( "hu_read(...) called from ", stderr );
+    fputs( fname, stderr );
+    fputc( '\n', stderr );
+
+    return hu_fread( ptr, size, n, fp );
+}
+
+
+/**
+ * fread equivalent routine with error checking.
+ * On error it calls hu_solver_abort()
+ */
+size_t
+hu_fread( void* ptr, size_t size, size_t n, FILE* fp )
+{
+    size_t ret;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+    /* make sure ptr != NULL unless size or n are 0 */
+    HU_ASSERT( ( (ptr != NULL) || (size == 0 || n == 0) ) );
+
+    ret = fread( ptr, size, n, fp );
+
+    if (n != ret) {
+	hu_solver_abort( __FUNCTION_NAME, "fread() failed",
+			 "fp=0x%p ptr=0x%p size=%d n=%d ret=%d\n", fp, ptr,
+			 size, n, ret );
+    }
+
+    return ret;
+}
+
+
+/**
+ * print / split output to two files (stderr and the provided file pointer).
+ *
+ * \param fp     Pointer to the output file stream.
+ * \param format Format string as in fprintf.
+ * \param args   List of arguments in a properly initialized va_list.
+ */
+int
+hu_print_tee_va( FILE *fp, const char* format, va_list args )
+{
+    int ret = 0;
+
+    if (format != NULL) {
+	va_list my_args1, my_args2;
+
+	va_copy( my_args1, args );
+	ret = vfprintf( fp, format, my_args1 );
+	va_end( my_args1 );
+
+	/* restart printing and send it to standard error */
+	va_copy( my_args2, args );
+	vfprintf( stderr, format, my_args2 );
+	va_end( my_args2 );
+    }
+
+    return ret;
+}
+
+
+/**
+ * print / split output to two files (stderr and the provided file pointer).
+ *
+ * \param fp     Pointer to the output file stream.
+ * \param format Format string as in fprintf.
+ */
+int
+print_tee( FILE* fp, const char* format, ... )
+{
+    int ret = 0;
+
+    if (format != NULL) {
+	va_list args;
+
+	va_start( args, format );
+	hu_print_tee_va( fp, format, args );
+	va_end( args );
+    }
+
+    return ret;
+}
+
+
+int
+hu_parse_int( const char* str, int base, int* value )
+{
+    int   my_value;
+    char* endptr;
+
+    HU_ASSERT_PTR_ALWAYS( str );
+    HU_ASSERT_PTR_ALWAYS( value );
+
+    my_value = strtol( str, &endptr, base );
+
+    if (*endptr == 0 || isspace(*endptr)) {
+	*value = my_value;
+	return 0;
+    }
+
+    return -1;
+}
+
+
+/**
+ * Parse a float from a string (char*).  This function returns an
+ * error if the string cannot be parsed.
+ *
+ * \param arg string containing the float to parse
+ * \param value float ptr. where the (output) result is stored.
+ *
+ * \return 0 on success, -1 on error.
+ */
+int
+hu_parse_float( const char* str, float* value )
+{
+    float my_value;
+    char* endptr;
+
+    HU_ASSERT_PTR_ALWAYS( str );
+    HU_ASSERT_PTR_ALWAYS( value );
+
+    my_value = strtof( str, &endptr );
+
+    if (*endptr != '\0' && !isspace(*endptr)) {
+	return -1;
+    }
+
+    *value = my_value;
+
+    return 0;
+}
+
+
+/**
+ * Parse a float from a string (char*).  This function returns an
+ * error if the string cannot be parsed.
+ *
+ * \param arg string containing the float to parse
+ * \param value float ptr. where the (output) result is stored.
+ *
+ * \return 0 on success, -1 on error.
+ */
+int
+hu_parse_double( const char* str, double* value )
+{
+    double my_value;
+    char* endptr;
+
+    HU_ASSERT_PTR_ALWAYS( str );
+    HU_ASSERT_PTR_ALWAYS( value );
+
+    my_value = strtod( str, &endptr );
+
+    if (*endptr != '\0' && !isspace(*endptr)) {
+	return -1;
+    }
+
+    *value = my_value;
+
+    return 0;
+}
+
+
+static int
+hu_config_parse_double( const char* str, void* value )
+{
+    return hu_parse_double( str, (double*)value );
+}
+
+
+static int
+hu_config_parse_float( const char* str, void* value )
+{
+    return hu_parse_float( str, (float*)value );
+}
+
+
+static int
+hu_config_parse_int( const char* str, void* value )
+{
+    return hu_parse_int( str, 0, (int*) value );
+}
+
+
+static int
+hu_config_parse_uint( const char* str, void* value )
+{
+    unsigned int my_val;
+
+    if (sscanf( str, "%u", &my_val ) == 1) {
+	*((unsigned int*)value) = my_val;
+	return 0;
+    }
+
+    return -1;
+}
+
+
+static int
+hu_config_parse_str( const char* str, void* value )
+{
+    hu_str_t* valstr = (hu_str_t*)value;
+
+    HU_ASSERT_PTR_ALWAYS( str );
+    HU_ASSERT_PTR_ALWAYS( valstr );
+
+    if (valstr->str == NULL) {  /* allocate new string */
+	valstr->str = strdup( str );
+	HU_ASSERT_PTR_ALWAYS( valstr->str );
+	valstr->len = strlen( valstr->str ) + 1;
+	return 0;
+    }
+
+    /* else: copy the string to the given buffer if there's enough space */
+    if (strlen( str ) < valstr->len) {
+	strcpy( valstr->str, str );
+	return 0;
+    }
+
+    return -1;
+}
+
+
+static int
+hu_config_parse_str_unsafe( const char* str, void* value )
+{
+    hu_str_t* valstr = (hu_str_t*)value;
+
+    HU_ASSERT_PTR_ALWAYS( str );
+    HU_ASSERT_PTR_ALWAYS( valstr );
+    HU_ASSERT_PTR_ALWAYS( valstr->str );
+
+    strcpy( valstr->str, str );
+
+    return 0;
+}
+
+
+#ifndef HAVE_GETLINE
+/*
+ * Quick workaround for systems without getline().  This implementation
+ * uses fgets() and does not have exactly the same semantics as getline.
+ * I.e., the output string parameter is not automatically resized
+ */
+ssize_t
+getline( char** lineptr, size_t* n, FILE* stream)
+{
+    ssize_t len;
+    char* str;
+
+    if (NULL == *lineptr) {
+	return -1;
+    }
+
+    if (0 == *n) {
+	return -1;
+    }
+
+    str = fgets( *lineptr, *n, stream );
+
+    if (NULL == str) { /* check for errors */
+	return -1;
+    }
+
+    len = strlen( str );
+
+    /* check whether or not a full line was read */
+    if ( (len + 1 == *n) && ((*lineptr)[len - 1] != '\n') ) {
+	return -1;
+    }
+
+    return len;
+}
+#endif /* HAVE_GETLINE */
+
+/**
+ * Parse a text file and return the value of a match string.
+ *
+ * \return 1 if found, 0 if not found, -1 on error.
+ */
+int
+hu_config_read(
+	FILE*              fp,
+	const char*        key,
+	hu_config_parse_fn parse_val,
+	hu_config_option_t flag,
+	void*		   val
+	)
+{
+    static size_t CONFIG_LINE_SIZE_DEFAULT = 256;
+    static const char* config_err_msg_fmt
+	= "Did not find variable in configuration file\n"
+	  "variable name: %s\n";
+
+    const static char delimiters[] = " =\n\t";
+
+    char*   line;
+    size_t  keylen;
+    ssize_t ln  = 0;
+    size_t  n   = CONFIG_LINE_SIZE_DEFAULT;
+    int     ret = 0, found = 0;
+
+    HU_ASSERT_PTR_ALWAYS( fp );
+    HU_ASSERT_PTR_ALWAYS( key );
+    HU_ASSERT_PTR_ALWAYS( parse_val );
+    HU_ASSERT_PTR_ALWAYS( val );
+
+    rewind( fp );               /* start from the beginning of the file */
+    line = (char*)malloc( n * sizeof(char) );
+
+    keylen = strlen( key );
+
+    /* sequentially look for variable name */
+    while (!found && !feof( fp ) && ln >= 0 ) {
+	ssize_t ln = getline( &line, &n, fp );  /* read in one line */
+
+	if (ln < 0 && !feof( fp )) { /* error and not EOF, then I/O error */
+	    ret = -1;
+	    break;
+	}
+
+	if (ln > 0 && strncmp( line, key, keylen ) == 0) {
+	    found =1;
+	    break;
+	}
+    } /* while */
+
+    if (found) {		/* process entry if found */
+	char* strtok_state;
+	char* name = strtok_r( line, delimiters, &strtok_state );
+
+	ret = -1;
+	if ((name != NULL) && (strcmp( name, key ) == 0)) {
+	    char* value = strtok_r( NULL, delimiters, &strtok_state );
+
+	    if (value != NULL && parse_val( value, val ) == 0 ) {
+		ret = 1;
+	    }
+	}
+    }
+
+    free( line );
+
+    /* error handling */
+    if (ret == -1) {		/* an error occurred, abort */
+	hu_solver_abort( __FUNCTION_NAME, NULL,
+			 "Error while reading configuration variable from"
+			 "configuration file\n"
+			 "variable name: %s\n",
+			 key );
+    }
+
+    else if (ret == 0) {	/* not found, then take action accordingly */
+	switch (flag) {
+	case HU_REQUIRED:
+	    hu_solver_abort( __FUNCTION_NAME, NULL, config_err_msg_fmt, key );
+	    break;
+	case HU_OPTIONAL_WARN:
+	case HU_REQ_WARN:
+	    fprintf( stderr, config_err_msg_fmt, key );
+	    break;
+	case HU_OPTIONAL:
+	    break;
+	}
+    }
+
+    return ret;
+}
+
+
+
+
+int
+hu_config_get_string( FILE* fp, const char* key, hu_config_option_t flag,
+		      char** val, size_t* len )
+{
+    int ret;
+    hu_str_t valstr;
+
+    HU_ASSERT_PTR_ALWAYS( val );
+    HU_ASSERT_PTR_ALWAYS( len );
+
+    valstr.str = *val;
+    valstr.len = *len;
+
+    ret = hu_config_read( fp, key, hu_config_parse_str, flag, &valstr );
+
+    if (ret == 1) {
+	*val = valstr.str;
+	*len = valstr.len;
+    }
+
+    return ret;
+}
+
+
+int
+hu_config_get_string_unsafe(
+	FILE* fp,
+	const char* key,
+	hu_config_option_t flag,
+	char* val
+	)
+{
+    int	     ret;
+    hu_str_t valstr;
+
+    HU_ASSERT_PTR_ALWAYS( val );
+
+    valstr.str = val;
+    valstr.len = -1;
+
+    ret = hu_config_read( fp, key, hu_config_parse_str_unsafe, flag, &valstr );
+
+    return ret;
+}
+
+
+int
+hu_config_get_string_def( FILE* fp, const char* key, char** val, size_t* len,
+			  const char* default_value )
+{
+    int ret = hu_config_get_string_opt( fp, key, val, len );
+
+    if (ret == 0) { /* not found */
+	*len = strlen( default_value );
+	*val = strdup( default_value );
+    }
+
+    return ret;
+}
+
+
+
+int
+hu_config_get_int(FILE* fp, const char* key, int* val, hu_config_option_t flag)
+{
+    return hu_config_read( fp, key, hu_config_parse_int, flag, val );
+}
+
+
+int
+hu_config_get_uint(
+	FILE*	           fp,
+	const char*	   key,
+	unsigned int*	   val,
+	hu_config_option_t flag
+	)
+{
+    return hu_config_read( fp, key, hu_config_parse_uint, flag, val );
+}
+
+
+int
+hu_config_get_double(
+	FILE*	           fp,
+	const char*	   key,
+	double*		   val,
+	hu_config_option_t flag
+	)
+{
+    return hu_config_read( fp, key, hu_config_parse_double, flag, val );
+}
+
+
+int
+hu_config_get_float(
+	FILE*	           fp,
+	const char*	   key,
+	float*		   val,
+	hu_config_option_t flag
+	)
+{
+    return hu_config_read( fp, key, hu_config_parse_float, flag, val );
+}
+
+
+int
+hu_parse_text( FILE* fp, const char* key, const char type, void* result )
+{
+    switch (type) {
+    case 'i': return hu_config_get_int_req( fp, key, (int *)result );
+    case 'u': return hu_config_get_uint_req( fp, key, (unsigned int *)result );
+    case 'f': return hu_config_get_float_req( fp, key, (float *)result );
+    case 'd': return hu_config_get_double_req( fp, key, (double *)result );
+    case 's': return hu_config_get_string_unsafe(fp, key, HU_REQUIRED, (char *)result);
+    default:
+	fputs( "parsetext: unknown type ", stderr );
+	fputc( type, stderr );
+	fputc( '\n', stderr );
+	return -1;
+    }
+}
+
+int
+hu_parsetext_v(
+	FILE* fp,
+	const char* key,
+	const char type, 
+	void* result
+	)
+{
+    int ret = hu_parse_text( fp, key, type, result );
+
+    fputs( "parsetext: ", stderr );
+    fputs( key, stderr );
+    fprintf( stderr, " %c %d\n", type, ret );
+
+    return ret;
+}

--- a/quake/forward_gpu/util.h
+++ b/quake/forward_gpu/util.h
@@ -1,0 +1,414 @@
+/* -*- C -*- */
+
+/* @copyright_notice_start
+ *
+ * This file is part of the CMU Hercules ground motion simulator developed
+ * by the CMU Quake project.
+ *
+ * Copyright (C) Carnegie Mellon University. All rights reserved.
+ *
+ * This program is covered by the terms described in the 'LICENSE.txt' file
+ * included with this software package.
+ *
+ * This program comes WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 'LICENSE.txt' file for more details.
+ *
+ *  @copyright_notice_end
+ */
+
+/*
+ * Description: Miscellaneous support functions.
+ */
+#ifndef HERC_UTIL_H
+#define HERC_UTIL_H
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+#include "funcname.h"
+
+/** Replace fseeko with fseek */
+#ifdef BIGBEN
+#define fseeko	fseek
+#endif
+
+
+/**
+ * Macros with the format string for int64_t and uint64_t types.
+ */
+#if (defined __WORDSIZE) && (__WORDSIZE == 64)
+#  define UINT64_FMT		"lu"
+#  define INT64_FMT		"ld"
+#  define MPI_INT64		MPI_LONG
+#else /*  __WORDSIZE && __WORDSIZE == 64 */
+#  define UINT64_FMT		"llu"
+#  define INT64_FMT		"lld"
+#  define MPI_INT64		MPI_LONG_LONG_INT
+#endif
+
+#if (defined _FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+#  define OFFT_FMT		UINT64_FMT
+#else
+#  define OFFT_FMT		"d"
+#endif
+
+
+
+#ifndef STRINGIZE
+#  ifdef HAVE_STRINGIZE
+#    define STRINGIZE(s)          #s
+#  else
+#    define STRINGIZE(s)          "s"
+#  endif
+#endif /* STRINGIZE */
+
+
+
+#ifndef STRINGX
+#  define STRINGX(s)		STRINGIZE(s)
+#endif /* ! STRINGX */
+
+
+#define HU_VOID_CAST_EXP	(void)
+
+/**
+ * Execute a given statement only if the condition is true.
+ * The goal of this macro is to simplify certain code constructions such as:
+ *
+ * if (foo) {
+ *	bar();
+ * }
+ *
+ * and replace them with
+ *   SUL_COND_EXEC (foo, bar());
+ *
+ * It is mainly intended to be used inside other macros.
+ */
+#define HU_COND_EXEC(flag,statement)  \
+    (HU_VOID_CAST_EXP ((flag) ? (statement) : 0 ))
+
+
+
+#define HU_ASSERT_COND(p,c)						\
+    do {                                                                \
+	if ((c) && ! (p)) {                                             \
+	    hu_assert_abort( __FILE__,	__FUNCTION_NAME, __LINE__,	\
+			     STRINGX(p) );				\
+	}                                                               \
+    } while (0)
+
+
+
+#ifdef HERCULES_DISABLE_ASSERT
+# define HU_ENABLE_ASSERT	0
+#else
+# define HU_ENABLE_ASSERT	1
+#endif /* HERCULES_DISABLE_ASSERT */
+
+#define HU_ASSERT(p)		HU_ASSERT_COND((p),HU_ENABLE_ASSERT)
+#define HU_ASSERT_PTR(p)	HU_ASSERT(NULL != (p))
+
+/**
+ * Unconditional assertions, these are not disabled at compile time.
+ */
+#define HU_ASSERT_ALWAYS(p)     HU_ASSERT_COND((p),1)
+#define HU_ASSERT_PTR_ALWAYS(p) HU_ASSERT_ALWAYS(NULL != (p))
+
+
+/**
+ * Conditional global barrier.
+ * Execute a \c MPI_Barrier( \c comm_solver ) when flag is set.
+ */
+#define HU_COND_GLOBAL_BARRIER(flag)		\
+    HU_COND_EXEC( flag, MPI_Barrier( comm_solver ) )
+
+#define HERC_ERROR		-100
+
+
+#define XMALLOC_N(type,n)			\
+    ((type*)hu_xmalloc( ((n) * sizeof(type)), NULL ))
+
+#define XMALLOC(type)			XMALLOC(type,1)
+
+
+/**
+ * Allocate memory for an named array.  An array of the given length and type
+ * is allocated and assigned to the specified pointer.  
+ * If the allocation fails the error is reported with a message that includes
+ * the variable name and the amount of memory to be allocated.
+ *
+ * \param var name of the variable in the program, i.e., pass the variable.
+ * \param type the basic type of each element in the array.
+ * \param n array length.
+ */
+#define XMALLOC_VAR_N(var,type,n)					\
+    do {								\
+	(var) = ((type*)hu_xmalloc(((n) * sizeof(type)), STRINGX(var))); \
+    } while (0)
+
+
+/**
+ * Allocate memory for a string of a given length.  The amount of
+ * allocated memory is 1 byte larger than the specified string length.
+ */
+#define XMALLOC_STRING(var,n)   XMALLOC_VAR_N((var),char,((n)+1))
+
+#define XMALLOC_VAR(var,type)	XMALLOC_VAR((var),(type),1)
+
+#ifndef HAVE_FDATASYNC
+/* replace with fsync */
+#define fdatasync(fd)	fsync(fd)
+#endif /* HAVE_FDATASYNC */
+
+enum hu_config_option_t {
+    HU_REQUIRED,
+    HU_REQ_WARN,
+    HU_OPTIONAL,
+    HU_OPTIONAL_WARN
+};
+
+typedef enum hu_config_option_t hu_config_option_t;
+
+
+/* ------------------------------------------------------------------------- *
+ * Function declaration. 
+ * Documentation along with function definition in .c file.
+ * ------------------------------------------------------------------------- */
+
+/** Compatibility function renaming macro */
+#define solver_abort	hu_solver_abort
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Type of the parsing function for configuration variables in the
+ * config file.
+ */
+typedef int (*hu_config_parse_fn)( const char* str, void* value );
+
+
+extern void* hu_xmalloc( size_t size, const char* varname );
+
+extern void
+hu_assert_abort(
+	const char*     file,
+	const char*     function_name,
+	int             line,
+	const char*     assertion_text
+	);
+
+
+extern FILE*  hu_fopen( const char* filename, const char* mode );
+extern int    hu_fclose( FILE* fp );
+extern int    hu_fclosep( FILE** fp );
+extern int    hu_fseeko( FILE* fp, off_t offset, int whence );
+extern off_t  hu_ftello( FILE* fp );
+extern size_t hu_fwrite( void* ptr, size_t size, size_t n, FILE* fp );
+
+extern size_t hu_fread( void* ptr, size_t size, size_t n, FILE* fp );
+extern size_t hu_fread_trace( void* ptr, size_t size, size_t n, FILE* fp,
+			      const char* fname );
+
+#ifdef HU_FVERBOSE
+#define hu_fread(ptr,size,n,fp)					\
+    hu_fread_trace( ptr, size, n, fp, __FUNCTION_NAME )
+#endif
+
+extern int    hu_print_tee_va( FILE *fp, const char* format, va_list args );
+
+extern int
+hu_parsetext_v(	FILE* fp, const char* string, const char type, void* result );
+
+extern int hu_solver_abort( const char* function_name, const char* error_msg,
+			    const char* format, ... );
+
+
+extern int hu_parse_double( const char* str, double* value );
+extern int hu_parse_float( const char* str, float* value );
+extern int hu_parse_int( const char* str, int base, int* value );
+
+extern int
+hu_config_read(
+	FILE*              fp,
+	const char*        key,
+	hu_config_parse_fn parse_val,
+	hu_config_option_t flag,
+	void*		   val
+	);
+
+
+extern int
+hu_config_get_string( FILE* fp, const char* key, hu_config_option_t flag,
+		      char** val, size_t* len );
+
+extern int
+hu_config_get_string_unsafe( FILE* fp, const char* key, hu_config_option_t flag,
+			     char* val );
+
+extern int
+hu_config_get_int(
+	FILE*		   fp,
+	const char*	   key,
+	int*		   val,
+	hu_config_option_t flag
+	);
+
+extern int
+hu_config_get_uint(
+	FILE*	           fp,
+	const char*	   key,
+	unsigned int*	   val,
+	hu_config_option_t flag
+	);
+
+
+extern int
+hu_config_get_double(
+	FILE*	           fp,
+	const char*	   key,
+	double*		   val,
+	hu_config_option_t flag
+	);
+
+
+extern int
+hu_config_get_float(
+	FILE*	           fp,
+	const char*	   key,
+	float*		   val,
+	hu_config_option_t flag
+	);
+
+
+static inline int
+hu_config_get_int_req( FILE* fp, const char* key, int* value )
+{
+    return hu_config_get_int( fp, key, value, HU_REQUIRED );
+}
+
+
+static inline int
+hu_config_get_uint_req( FILE* fp, const char* key, unsigned int* value )
+{
+    return hu_config_get_uint( fp, key, value, HU_REQUIRED );
+}
+
+
+static inline int
+hu_config_get_double_req( FILE* fp, const char* key, double* value )
+{
+    return hu_config_get_double( fp, key, value, HU_REQUIRED );
+}
+
+
+static inline int
+hu_config_get_float_req( FILE* fp, const char* key, float* value )
+{
+    return hu_config_get_float( fp, key, value, HU_REQUIRED );
+}
+
+
+static inline int
+hu_config_get_string_req( FILE* fp, const char* key, char** val, size_t* len )
+{
+    return hu_config_get_string( fp, key, HU_REQUIRED, val, len );
+}
+
+static inline int
+hu_config_get_int_opt( FILE* fp, const char* key, int* value )
+{
+    return hu_config_get_int( fp, key, value, HU_OPTIONAL );
+}
+
+
+static inline int
+hu_config_get_uint_opt( FILE* fp, const char* key, unsigned int* value )
+{
+    return hu_config_get_uint( fp, key, value, HU_OPTIONAL );
+}
+
+
+static inline int
+hu_config_get_double_opt( FILE* fp, const char* key, double* value )
+{
+    return hu_config_get_double( fp, key, value, HU_OPTIONAL );
+}
+
+
+static inline int
+hu_config_get_float_opt( FILE* fp, const char* key, float* value )
+{
+    return hu_config_get_float( fp, key, value, HU_OPTIONAL );
+}
+
+
+static inline int
+hu_config_get_string_opt( FILE* fp, const char* key, char** val, size_t* len )
+{
+    return hu_config_get_string( fp, key, HU_OPTIONAL, val, len );
+}
+
+static inline int
+read_config_string2( FILE* fp, const char* key, char* val, size_t len )
+{
+    return hu_config_get_string_req( fp, key, &val, &len );
+}
+
+int
+hu_config_get_string_def( FILE* fp, const char* key, char** val, size_t* len,
+			  const char* default_val );
+
+/**
+ * Free the memory pointed by *ptr and then set *ptr to NULL.
+ */
+static inline void
+xfree( void** ptr )
+{
+    if (ptr != NULL) {
+	if (NULL != *ptr) {
+	    free( *ptr );
+	}
+	*ptr = NULL;
+    }
+}
+
+/*
+//static inline void
+//xfree_char( char** ptr )
+//{
+//    xfree( (void**)ptr );
+//}
+*/
+
+#define DEF_XFREE_TYPE(type)						\
+    static inline void xfree_##type(type ** p) { xfree( (void**)p ); } 
+
+DEF_XFREE_TYPE(char);
+DEF_XFREE_TYPE(int32_t);
+
+#undef DEF_XFREE_TYPE
+
+extern int
+hu_darray_has_nan_nd( const double* v, int dim, const size_t len[],
+		      size_t idx[] );
+
+extern int
+hu_farray_has_nan_nd( const float* v, int dim, const size_t len[],
+		      size_t idx[] );
+
+extern int
+hu_darray_has_nan( const double* v, const size_t len, size_t* idx );
+
+extern int
+hu_farray_has_nan( const float* v, const size_t len, size_t* idx );
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
+
+#endif /* HERC_UTIL_H */

--- a/systemdef.mk
+++ b/systemdef.mk
@@ -112,11 +112,25 @@ endif
 
 
 ifeq ($(SYSTEM), USCHPC)
-	MPI_DIR	 ?= /usr/usc/mpich/1.2.6..13b/gm-gnu32
-	CC	  = $(MPI_DIR)/bin/mpicxx
-	LD	  = $(MPI_DIR)/bin/mpicxx
+	MPI_DIR	 ?= /usr/usc/mpich/default/mx-gnu43
+	CC	  = $(MPI_DIR)/bin/mpicc
+	CXX	  = $(MPI_DIR)/bin/mpicc
+	LD	  = $(MPI_DIR)/bin/mpicc
 	CFLAGS   += -Wall
-	CPPFLAGS += -DPROCPERNODE=2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+#	CPPFLAGS += -DPROCPERNODE=2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+        CPPFLAGS    += -D_USE_FILE_OFFSET64 -D_FILE_OFFSET_BITS=64 -D_USE_LARGEFILE64       
+endif
+
+ifeq ($(SYSTEM), USCHPCGPU)
+	CUDA_DIR	 ?= /usr/usc/cuda/5.0
+	MPI_DIR	 ?= /usr/usc/openmpi/1.6.4
+	CC	  = nvcc
+	CXX	  = nvcc
+	LD	  = mpicxx
+	NVCC	  = /usr/usc/cuda/5.0/bin/nvcc
+#	CFLAGS   += -Wall
+	NVFLAGS += -arch sm_35 -D_USE_FILE_OFFSET64 -D_FILE_OFFSET_BITS=64 -D_USE_LARGEFILE64
+        CPPFLAGS    += -D_USE_FILE_OFFSET64 -D_FILE_OFFSET_BITS=64 -D_USE_LARGEFILE64
 endif
 
 


### PR DESCRIPTION
This was coded at USC HPCC (hpc-login2) so the systemdef.mk and Makefiles are currently customized for that system. The GPU source is located in ./quake/forward_gpu. The source files needed to be renamed to .cu so that the NVCC compiler would recognize them as CUDA (otherwise, it just passes *.c files to another underlying compiler such as gcc). This code is still being tested but I wanted to share what currently exists.

The build method I adopted is to compile all psolve source files with nvcc (CUDA-enabled C++ compiler), then use the mpicxx wrapper (C++ MPI) to do the final linking. This seemed the simplest option since CUDA code ended being placed in the main program psolve.c, and this minimized the need for "extern C" guards in all the non CUDA headers. The downside of this was that I encountered numerous C++ compiler errors which needed to be corrected. Most of these were int->enum_type conversions without explicit cast and use of C++ reserved words in the C code.

This GPU version of psolve runs in the following manner. At startup, it queries CUDA for the number of connected (local) GPUs. Then it uses a simple load balancing method for each rank of the MPI process to select one of the available local GPUs. Each rank queries its selected GPU for its hardware specifications and saves this information. Several device buffers (buffers that exist on the GPU) are allocated and these pointers are saved as well. Right now these specs and pointers are piggybacked in the mysolver_t structure to minimize changes to the code but they should really be broken out into a new data structure.

The stiffness module (stiffness.cu) has been updated to perform its calculations entirely on the GPU. It uses the device specs and previously allocated buffers to compute the forces at each element, and their impact on each node. The original compute_addforce_effective() routine was split into two kernels. The first kernel computes the local force for each element similarly to the CPU version. The second kernel sums up the force contributions for each node. This kernel requires use of a new data structure which is essentially a reverse lookup table mapping node -> element reference. I'd like to find a way to eliminate this extra data structure but right now it's needed. The second kernel runs a thread for each node.
